### PR TITLE
ci(ws): run `make test-e2e` on GitHub Actions

### DIFF
--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -1,4 +1,4 @@
-name: "workspaces/controller: unit-tests"
+name: Controller - Tests
 
 permissions: {}
 
@@ -10,11 +10,9 @@ on:
     branches: [ "main", "notebooks-v2", "v*-branch" ]
 
 jobs:
-
-  "unit-tests":
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
 
       - name: Set up Go
@@ -24,17 +22,17 @@ jobs:
           check-latest: true
           cache-dependency-path: workspaces/controller/go.sum
 
-      - name: Test
-        run: make test
+      - name: Run unit tests
         working-directory: workspaces/controller
+        run: make test
 
-  "e2e-tests":
+  e2e-tests:
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
 
-      - uses: helm/kind-action@v1
+      - name: Set up Kind
+        uses: helm/kind-action@v1
         with:
           version: v0.23.0
           node_image: kindest/node:v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b
@@ -47,8 +45,8 @@ jobs:
           check-latest: true
           cache-dependency-path: workspaces/controller/go.sum
 
-      - name: Test E2E
+      - name: Run e2e tests
         env:
           KUBEFLOW_TEST_PROMPT: "false"
-        run: make test-e2e
         working-directory: workspaces/controller
+        run: make test-e2e

--- a/.github/workflows/workspaces-controller_unit-tests.yaml
+++ b/.github/workflows/workspaces-controller_unit-tests.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - uses: helm/kind-action@v1
         with:
+          version: v0.23.0
+          node_image: kindest/node:v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b
           cluster_name: kind
 
       - name: Set up Go

--- a/.github/workflows/workspaces-controller_unit-tests.yaml
+++ b/.github/workflows/workspaces-controller_unit-tests.yaml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: helm/kind-action@v1
+        with:
+          cluster_name: kind
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/workspaces-controller_unit-tests.yaml
+++ b/.github/workflows/workspaces-controller_unit-tests.yaml
@@ -27,3 +27,21 @@ jobs:
       - name: Test
         run: make test
         working-directory: workspaces/controller
+
+  "e2e-tests":
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - uses: helm/kind-action@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: workspaces/controller/go.mod
+          check-latest: true
+          cache-dependency-path: workspaces/controller/go.sum
+
+      - run: make test-e2e
+        working-directory: workspaces/controller

--- a/.github/workflows/workspaces-controller_unit-tests.yaml
+++ b/.github/workflows/workspaces-controller_unit-tests.yaml
@@ -47,5 +47,8 @@ jobs:
           check-latest: true
           cache-dependency-path: workspaces/controller/go.sum
 
-      - run: make test-e2e
+      - name: Test E2E
+        env:
+          KUBEFLOW_TEST_PROMPT: "false"
+        run: make test-e2e
         working-directory: workspaces/controller


### PR DESCRIPTION
This is something that works differently in new Kubebuilder, compared to what's in kubeflow/kubeflow notebook controller.

Previously, what they called e2e tests was running in envtest, but currently they expect to run in externally-provided kind. So, let's run this on CI as well, so we don't have dead code.