### PR TITLE
chore: clean up OWNERS file (avoid non-maintainers)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,3 @@
 approvers:
   - kimwnasptd
   - thesuperzapper
-  - andreyvelich
-  - james-jwu
-  - jbottum
-  - johnugeorge
-  - terrytangyuan
-  - zijianjoy


### PR DESCRIPTION
Currently the owners file lists many people who are not maintainers.

This is a problem because all PRs are being assigned to people who are not related to the Notebooks development and slowing down the time to get a review.

NOTE: this is the same as https://github.com/kubeflow/notebooks/pull/17, but for the `main` branch.