### PR TITLE
fix(ws): use correct `nodeSelector` type and add CRD validation tests

### DIFF
--- a/workspaces/controller/api/v1beta1/workspace_types.go
+++ b/workspaces/controller/api/v1beta1/workspace_types.go
@@ -41,7 +41,7 @@ type WorkspaceSpec struct {
 	//+kubebuilder:validation:MaxLength:=63
 	//+kubebuilder:validation:Pattern:=^[a-z0-9][-a-z0-9]*[a-z0-9]$
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Workspace 'kind' is immutable"
-	//+kubebuilder:example="jupyter-lab"
+	//+kubebuilder:example="jupyterlab"
 	Kind string `json:"kind"`
 
 	// options for "podTemplate"-type WorkspaceKinds
@@ -86,6 +86,8 @@ type WorkspacePodVolumes struct {
 	//  - these PVCs must already exist in the Namespace
 	//  - these PVCs must be RWX (ReadWriteMany, ReadWriteOnce)
 	//+kubebuilder:validation:Optional
+	//+listType:="map"
+	//+listMapKey:="name"
 	Data []PodVolumeMount `json:"data,omitempty"`
 }
 

--- a/workspaces/controller/api/v1beta1/workspacekind_types.go
+++ b/workspaces/controller/api/v1beta1/workspacekind_types.go
@@ -126,6 +126,8 @@ type WorkspaceKindPodTemplate struct {
 	//  - the following string templates are available:
 	//     - `.PathPrefix`: the path prefix of the Workspace (e.g. '/workspace/{profile_name}/{workspace_name}/')
 	//+kubebuilder:validation:Optional
+	//+listType:="map"
+	//+listMapKey:="name"
 	ExtraEnv []v1.EnvVar `json:"extraEnv,omitempty"`
 
 	// container SecurityContext for Workspace Pods (MUTABLE)
@@ -297,6 +299,7 @@ type ImageConfigValue struct {
 	Redirect *OptionRedirect `json:"redirect,omitempty"`
 
 	// the spec of the image config
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageConfig 'spec' is immutable"
 	Spec ImageConfigSpec `json:"spec"`
 }
 
@@ -369,6 +372,7 @@ type PodConfigValue struct {
 	Redirect *OptionRedirect `json:"redirect,omitempty"`
 
 	// the spec of the pod config
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="PodConfig 'spec' is immutable"
 	Spec PodConfigSpec `json:"spec"`
 }
 
@@ -379,7 +383,7 @@ type PodConfigSpec struct {
 
 	// node selector configs for the pod
 	//+kubebuilder:validation:Optional
-	NodeSelector *v1.NodeSelector `json:"nodeSelector,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// toleration configs for the pod
 	//+kubebuilder:validation:Optional

--- a/workspaces/controller/api/v1beta1/zz_generated.deepcopy.go
+++ b/workspaces/controller/api/v1beta1/zz_generated.deepcopy.go
@@ -340,8 +340,10 @@ func (in *PodConfigSpec) DeepCopyInto(out *PodConfigSpec) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = new(v1.NodeSelector)
-		(*in).DeepCopyInto(*out)
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations

--- a/workspaces/controller/config/crd/bases/kubeflow.org_workspacekinds.yaml
+++ b/workspaces/controller/config/crd/bases/kubeflow.org_workspacekinds.yaml
@@ -405,6 +405,9 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   httpProxy:
                     description: http proxy configs (MUTABLE)
                     properties:
@@ -607,6 +610,9 @@ spec:
                                   - image
                                   - ports
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: ImageConfig 'spec' is immutable
+                                    rule: self == oldSelf
                               required:
                               - id
                               - spawner
@@ -1659,88 +1665,10 @@ spec:
                                           type: object
                                       type: object
                                     nodeSelector:
+                                      additionalProperties:
+                                        type: string
                                       description: node selector configs for the pod
-                                      properties:
-                                        nodeSelectorTerms:
-                                          description: Required. A list of node selector
-                                            terms. The terms are ORed.
-                                          items:
-                                            description: |-
-                                              A null or empty node selector term matches no objects. The requirements of
-                                              them are ANDed.
-                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                            properties:
-                                              matchExpressions:
-                                                description: A list of node selector
-                                                  requirements by node's labels.
-                                                items:
-                                                  description: |-
-                                                    A node selector requirement is a selector that contains values, a key, and an operator
-                                                    that relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: The label key that
-                                                        the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        Represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        An array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. If the operator is Gt or Lt, the values
-                                                        array must have a single element, which will be interpreted as an integer.
-                                                        This array is replaced during a strategic merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchFields:
-                                                description: A list of node selector
-                                                  requirements by node's fields.
-                                                items:
-                                                  description: |-
-                                                    A node selector requirement is a selector that contains values, a key, and an operator
-                                                    that relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: The label key that
-                                                        the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        Represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        An array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. If the operator is Gt or Lt, the values
-                                                        array must have a single element, which will be interpreted as an integer.
-                                                        This array is replaced during a strategic merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          type: array
-                                      required:
-                                      - nodeSelectorTerms
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: resource configs for the "main"
                                         container in the pod
@@ -1838,6 +1766,9 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: PodConfig 'spec' is immutable
+                                    rule: self == oldSelf
                               required:
                               - id
                               - spawner

--- a/workspaces/controller/config/crd/bases/kubeflow.org_workspaces.yaml
+++ b/workspaces/controller/config/crd/bases/kubeflow.org_workspaces.yaml
@@ -46,7 +46,7 @@ spec:
             properties:
               kind:
                 description: the WorkspaceKind to use
-                example: jupyter-lab
+                example: jupyterlab
                 maxLength: 63
                 minLength: 2
                 pattern: ^[a-z0-9][-a-z0-9]*[a-z0-9]$
@@ -125,6 +125,9 @@ spec:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       home:
                         description: |-
                           the name of the PVC to mount as the home volume

--- a/workspaces/controller/internal/controller/workspacekind_controller_test.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,153 +35,251 @@ import (
 )
 
 var _ = Describe("WorkspaceKind Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
 
+	// Define variables to store common objects for tests.
+	var (
+		testResource1 *kubefloworgv1beta1.WorkspaceKind
+	)
+
+	// Define utility constants and variables for object names and testing.
+	const (
+		testResourceName1 = "jupyterlab"
+	)
+
+	BeforeEach(func() {
+		testResource1 = &kubefloworgv1beta1.WorkspaceKind{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testResourceName1,
+			},
+			Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+				Spawner: kubefloworgv1beta1.WorkspaceKindSpawner{
+					DisplayName:        "JupyterLab Notebook",
+					Description:        "A Workspace which runs JupyterLab in a Pod",
+					Hidden:             ptr.To(false),
+					Deprecated:         ptr.To(false),
+					DeprecationMessage: ptr.To("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
+					Icon: kubefloworgv1beta1.WorkspaceKindIcon{
+						Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
+					},
+					Logo: kubefloworgv1beta1.WorkspaceKindIcon{
+						ConfigMap: &kubefloworgv1beta1.WorkspaceKindConfigMap{
+							Name: "my-logos",
+							Key:  "apple-touch-icon-152x152.png",
+						},
+					},
+				},
+				PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
+					PodMetadata: &kubefloworgv1beta1.WorkspaceKindPodMetadata{},
+					ServiceAccount: kubefloworgv1beta1.WorkspaceKindServiceAccount{
+						Name: "default-editor",
+					},
+					Culling: &kubefloworgv1beta1.WorkspaceKindCullingConfig{
+						Enabled:            ptr.To(true),
+						MaxInactiveSeconds: ptr.To(int64(86400)),
+						ActivityProbe: kubefloworgv1beta1.ActivityProbe{
+							Exec: &kubefloworgv1beta1.ActivityProbeExec{
+								Command: []string{"bash", "-c", "exit 0"},
+							},
+						},
+					},
+					Probes: &kubefloworgv1beta1.WorkspaceKindProbes{},
+					VolumeMounts: kubefloworgv1beta1.WorkspaceKindVolumeMounts{
+						Home: "/home/jovyan",
+					},
+					HTTPProxy: &kubefloworgv1beta1.HTTPProxy{
+						RemovePathPrefix: ptr.To(false),
+						RequestHeaders: &kubefloworgv1beta1.IstioHeaderOperations{
+							Set:    map[string]string{"X-RStudio-Root-Path": "{{ .PathPrefix }}"},
+							Add:    map[string]string{},
+							Remove: []string{},
+						},
+					},
+					ExtraEnv: []v1.EnvVar{
+						{
+							Name:  "NB_PREFIX",
+							Value: "{{ .PathPrefix }}",
+						},
+					},
+					ContainerSecurityContext: &v1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
+						RunAsNonRoot: ptr.To(true),
+					},
+					Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
+						ImageConfig: kubefloworgv1beta1.ImageConfig{
+							Default: "jupyter_scipy_171",
+							Values: []kubefloworgv1beta1.ImageConfigValue{
+								{
+									Id: "jupyter_scipy_170",
+									Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+										DisplayName: "jupyter-scipy:v1.7.0",
+										Description: ptr.To("JupyterLab 1.7.0, with SciPy Packages"),
+										Hidden:      ptr.To(true),
+									},
+									Redirect: &kubefloworgv1beta1.OptionRedirect{
+										To:             "jupyter_scipy_171",
+										WaitForRestart: true,
+										Message: &kubefloworgv1beta1.RedirectMessage{
+											Level: "Info",
+											Text:  "This update will increase the version of JupyterLab to v1.7.1",
+										},
+									},
+									Spec: kubefloworgv1beta1.ImageConfigSpec{
+										Image: "docker.io/kubeflownotebookswg/jupyter-scipy:v1.7.0",
+										Ports: []kubefloworgv1beta1.ImagePort{
+											{
+												DisplayName: "JupyterLab",
+												Port:        8888,
+												Protocol:    "HTTP",
+											},
+										},
+									},
+								},
+							},
+						},
+						PodConfig: kubefloworgv1beta1.PodConfig{
+							Default: "small_cpu",
+							Values: []kubefloworgv1beta1.PodConfigValue{
+								{
+									Id: "small_cpu",
+									Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+										DisplayName: "Small CPU",
+										Description: ptr.To("Pod with 1 CPU, 2 GB RAM, and 1 GPU"),
+										Hidden:      ptr.To(false),
+									},
+									Redirect: nil,
+									Spec: kubefloworgv1beta1.PodConfigSpec{
+										Resources: &v1.ResourceRequirements{
+											Requests: map[v1.ResourceName]resource.Quantity{
+												v1.ResourceCPU:    resource.MustParse("1"),
+												v1.ResourceMemory: resource.MustParse("2Gi"),
+											},
+										},
+									},
+								},
+								{
+									Id: "big_gpu",
+									Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+										DisplayName: "Big GPU",
+										Description: ptr.To("Pod with 4 CPUs, 16 GB RAM, and 1 GPU"),
+										Hidden:      ptr.To(false),
+									},
+									Redirect: nil,
+									Spec: kubefloworgv1beta1.PodConfigSpec{
+										Affinity:     nil,
+										NodeSelector: nil,
+										Tolerations: []v1.Toleration{
+											{
+												Key:      "nvidia.com/gpu",
+												Operator: v1.TolerationOpExists,
+												Effect:   v1.TaintEffectNoSchedule,
+											},
+										},
+										Resources: &v1.ResourceRequirements{
+											Requests: map[v1.ResourceName]resource.Quantity{
+												v1.ResourceCPU:    resource.MustParse("4"),
+												v1.ResourceMemory: resource.MustParse("16Gi"),
+											},
+											Limits: map[v1.ResourceName]resource.Quantity{
+												"nvidia.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	Context("When reconciling a WorkspaceKind", func() {
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Name: testResourceName1,
 		}
+
 		workspacekind := &kubefloworgv1beta1.WorkspaceKind{}
 
 		BeforeEach(func() {
-			By("creating the custom resource for the Kind WorkspaceKind")
+			By("creating a new WorkspaceKind")
 			err := k8sClient.Get(ctx, typeNamespacedName, workspacekind)
 			if err != nil && errors.IsNotFound(err) {
-				resource := &kubefloworgv1beta1.WorkspaceKind{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: resourceName,
-					},
-					Spec: kubefloworgv1beta1.WorkspaceKindSpec{
-						Spawner: kubefloworgv1beta1.WorkspaceKindSpawner{
-							DisplayName:        "JupyterLab Notebook",
-							Description:        "A Workspace which runs JupyterLab in a Pod",
-							Hidden:             ptr.To(false),
-							Deprecated:         ptr.To(false),
-							DeprecationMessage: ptr.To("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
-							Icon: kubefloworgv1beta1.WorkspaceKindIcon{
-								Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
-							},
-							Logo: kubefloworgv1beta1.WorkspaceKindIcon{
-								ConfigMap: &kubefloworgv1beta1.WorkspaceKindConfigMap{
-									Name: "my-logos",
-									Key:  "apple-touch-icon-152x152.png",
-								},
-							},
-						},
-
-						PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
-							PodMetadata: &kubefloworgv1beta1.WorkspaceKindPodMetadata{},
-							ServiceAccount: kubefloworgv1beta1.WorkspaceKindServiceAccount{
-								Name: "default-editor",
-							},
-							Culling: &kubefloworgv1beta1.WorkspaceKindCullingConfig{
-								Enabled:            ptr.To(true),
-								MaxInactiveSeconds: ptr.To(int64(86400)),
-								ActivityProbe: kubefloworgv1beta1.ActivityProbe{
-									Exec: &kubefloworgv1beta1.ActivityProbeExec{
-										Command: []string{"bash", "-c", "exit 0"},
-									},
-								},
-							},
-							Probes: &kubefloworgv1beta1.WorkspaceKindProbes{},
-							VolumeMounts: kubefloworgv1beta1.WorkspaceKindVolumeMounts{
-								Home: "/home/jovyan",
-							},
-							HTTPProxy: &kubefloworgv1beta1.HTTPProxy{
-								RemovePathPrefix: ptr.To(false),
-								RequestHeaders: &kubefloworgv1beta1.IstioHeaderOperations{
-									Set:    map[string]string{"X-RStudio-Root-Path": "{{ .PathPrefix }}"},
-									Add:    map[string]string{},
-									Remove: []string{},
-								},
-							},
-							ExtraEnv: []v1.EnvVar{
-								{
-									Name:  "NB_PREFIX",
-									Value: "{{ .PathPrefix }}",
-								},
-							},
-							ContainerSecurityContext: &v1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								Capabilities: &v1.Capabilities{
-									Drop: []v1.Capability{"ALL"},
-								},
-								RunAsNonRoot: ptr.To(true),
-							},
-							Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
-								ImageConfig: kubefloworgv1beta1.ImageConfig{
-									Default: "jupyter_scipy_171",
-									Values: []kubefloworgv1beta1.ImageConfigValue{
-										{
-											Id: "jupyter_scipy_170",
-											Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
-												DisplayName: "jupyter-scipy:v1.7.0",
-												Description: ptr.To("JupyterLab 1.7.0, with SciPy Packages"),
-												Hidden:      ptr.To(true),
-											},
-											Redirect: &kubefloworgv1beta1.OptionRedirect{
-												To:             "jupyter_scipy_171",
-												WaitForRestart: true,
-												Message: &kubefloworgv1beta1.RedirectMessage{
-													Level: "Info",
-													Text:  "This update will increase the version of JupyterLab to v1.7.1",
-												},
-											},
-											Spec: kubefloworgv1beta1.ImageConfigSpec{
-												Image: "docker.io/kubeflownotebookswg/jupyter-scipy:v1.7.0",
-												Ports: []kubefloworgv1beta1.ImagePort{
-													{
-														DisplayName: "JupyterLab",
-														Port:        8888,
-														Protocol:    "HTTP",
-													},
-												},
-											},
-										},
-									},
-								},
-								PodConfig: kubefloworgv1beta1.PodConfig{
-									Default: "small_cpu",
-									Values: []kubefloworgv1beta1.PodConfigValue{
-										{
-											Id: "small_cpu",
-											Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
-												DisplayName: "Small CPU",
-												Description: ptr.To("Pod with 1 CPU, 2 GB RAM, and 1 GPU"),
-												Hidden:      ptr.To(false),
-											},
-											Redirect: nil,
-											Spec: kubefloworgv1beta1.PodConfigSpec{
-												Resources: &v1.ResourceRequirements{
-													Requests: map[v1.ResourceName]resource.Quantity{
-														"cpu":    resource.MustParse("1"),
-														"memory": resource.MustParse("2Gi"),
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}
+				resource := testResource1.DeepCopy()
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
+
+			By("checking if the WorkspaceKind exists")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, workspacekind)).To(Succeed())
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			By("checking if the WorkspaceKind still exists")
 			resource := &kubefloworgv1beta1.WorkspaceKind{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Cleanup the specific resource instance WorkspaceKind")
+			By("deleting the WorkspaceKind")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
+
+		It("should not allow updating immutable fields", func() {
+			patch := client.MergeFrom(workspacekind.DeepCopy())
+
+			By("failing to update the `spec.podTemplate.serviceAccount.name` field")
+			newWorkspaceKind := workspacekind.DeepCopy()
+			newWorkspaceKind.Spec.PodTemplate.ServiceAccount.Name = "new-editor"
+			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
+
+			By("failing to update the `spec.podTemplate.volumeMounts.home` field")
+			newWorkspaceKind = workspacekind.DeepCopy()
+			newWorkspaceKind.Spec.PodTemplate.VolumeMounts.Home = "/home/jovyan/new"
+			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
+
+			By("failing to update the `spec.podTemplate.options.imageConfig.values[0].spec` field")
+			newWorkspaceKind = workspacekind.DeepCopy()
+			newWorkspaceKind.Spec.PodTemplate.Options.ImageConfig.Values[0].Spec.Image = "new-image:latest"
+			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
+
+			By("failing to update the `spec.podTemplate.options.podConfig.values[0].spec` field")
+			newWorkspaceKind = workspacekind.DeepCopy()
+			newWorkspaceKind.Spec.PodTemplate.Options.PodConfig.Values[0].Spec.Resources.Requests[v1.ResourceCPU] = resource.MustParse("99")
+			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
+		})
+
+		It("should not allow mutually exclusive fields to be set", func() {
+			patch := client.MergeFrom(workspacekind.DeepCopy())
+
+			By("only allowing one of `spec.spawner.icon.{url,configMap}` to be set")
+			newWorkspaceKind := workspacekind.DeepCopy()
+			newWorkspaceKind.Spec.Spawner.Icon = kubefloworgv1beta1.WorkspaceKindIcon{
+				Url: ptr.To("https://example.com/icon.png"),
+				ConfigMap: &kubefloworgv1beta1.WorkspaceKindConfigMap{
+					Name: "my-logos",
+					Key:  "icon.png",
+				},
+			}
+			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
+
+			By("only allowing one of `spec.podTemplate.culling.activityProbe.{exec,jupyter}` to be set")
+			newWorkspaceKind = workspacekind.DeepCopy()
+			newWorkspaceKind.Spec.PodTemplate.Culling.ActivityProbe = kubefloworgv1beta1.ActivityProbe{
+				Exec: &kubefloworgv1beta1.ActivityProbeExec{
+					Command: []string{"bash", "-c", "exit 0"},
+				},
+				Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
+					LastActivity: true,
+				},
+			}
+			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
+		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &WorkspaceKindReconciler{


### PR DESCRIPTION
This PR makes the following changes to the workspace controller: 

- Uses the correct type for `spec.podTemplate.options.podConfig.values[].spec.nodeSelector`
- Ensures that the `spec` of `podConfig` and `imageConfig` values does not change
- Updates a few types to use the `+listType:="map"` because they should not support multiple elements with the same key:
     - `spec.podTemplate.volumes.data[]` (keyed on `name`)
     - `spec.podTemplate.extraEnv[]` (keyed on `name`)

I have also added tests for some of the more complicated `+kubebuilder:validation:XValidation` / `x-kubernetes-validations` we are doing, so we dont have to worry about regressions in the future.