### PR TITLE
feat(ws): set `status.pauseTime` on workspace

### DIFF
--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -935,7 +935,6 @@ func (r *WorkspaceReconciler) generateWorkspaceStatus(ctx context.Context, log l
 		}
 	}
 
-
 	// cases where the Pod does not exist
 	if pod == nil {
 		// STATUS: Paused

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -371,10 +371,6 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	//
-	// TODO: figure out how to set `status.pauseTime`, it will probably have to be done in a webhook
-	//
-
 	// update Workspace status
 	workspaceStatus, err := r.generateWorkspaceStatus(ctx, log, workspace, pod, statefulSet)
 	if err != nil {
@@ -926,6 +922,17 @@ func generateService(workspace *kubefloworgv1beta1.Workspace, imageConfigSpec ku
 // generateWorkspaceStatus generates a WorkspaceStatus for a Workspace
 func (r *WorkspaceReconciler) generateWorkspaceStatus(ctx context.Context, log logr.Logger, workspace *kubefloworgv1beta1.Workspace, pod *corev1.Pod, statefulSet *appsv1.StatefulSet) (kubefloworgv1beta1.WorkspaceStatus, error) {
 	status := workspace.Status
+
+	// set pauseTime
+	if *workspace.Spec.Paused {
+		if status.PauseTime == 0 {
+			status.PauseTime = metav1.Now().Unix()
+		}
+	} else {
+		if status.PauseTime != 0 {
+			status.PauseTime = 0
+		}
+	}
 
 	// cases where the Pod does not exist
 	if pod == nil {

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -923,7 +923,8 @@ func generateService(workspace *kubefloworgv1beta1.Workspace, imageConfigSpec ku
 func (r *WorkspaceReconciler) generateWorkspaceStatus(ctx context.Context, log logr.Logger, workspace *kubefloworgv1beta1.Workspace, pod *corev1.Pod, statefulSet *appsv1.StatefulSet) (kubefloworgv1beta1.WorkspaceStatus, error) {
 	status := workspace.Status
 
-	// set pauseTime
+	// if workspace is paused, update the `status.pauseTime`
+	// NOTE: when the workspace is not paused, the pauseTime should be 0
 	if *workspace.Spec.Paused {
 		if status.PauseTime == 0 {
 			status.PauseTime = metav1.Now().Unix()
@@ -933,6 +934,7 @@ func (r *WorkspaceReconciler) generateWorkspaceStatus(ctx context.Context, log l
 			status.PauseTime = 0
 		}
 	}
+
 
 	// cases where the Pod does not exist
 	if pod == nil {


### PR DESCRIPTION
This PR populates the `status.pauseTime` on the Workspace:

- Set `status.pauseTime` to current Unix epoch when paused.
- Reset `status.pauseTime` to 0 when unpaused.



