### PR TITLE
test(ws): add safety prompt for E2E test execution

### DIFF
--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -202,19 +202,19 @@ define prompt_for_e2e_test_execution
         echo "Skipping E2E test confirmation prompt (KUBEFLOW_TEST_PROMPT is set to true)"; \
     else \
         current_k8s_context=$$(kubectl config current-context); \
-        echo "===== WARNING: E2E Test Execution on Active Kubernetes Cluster ====="; \
-        echo "Current Kubernetes context: $$current_k8s_context"; \
-        echo "Running E2E tests will utilize your current Kubernetes cluster."; \
-        echo "This may result in the deletion of certain resources such as cert-manager ...:"; \
-        echo "Are you sure you want to proceed with the E2E tests? (yes/no)"; \
+        echo "================================ WARNING ================================"; \
+		echo "E2E tests use your current Kubernetes context!"; \
+		echo "This will DELETE EXISTING RESOURCES such as cert-manager!"; \
+        echo "Current context: '$$current_k8s_context'"; \
+		echo "========================================================================="; \
+        echo "Proceed with E2E tests? (yes/NO)"; \
         read user_confirmation; \
         case $$user_confirmation in \
             [yY] | [yY][eE][sS] ) \
-                echo "Proceeding with E2E tests...";; \
-            [nN] | [nN][oO] ) \
-                echo "E2E test execution aborted."; exit 1;; \
-            * ) \
-                echo "Invalid response. E2E test execution aborted for safety."; exit 1;; \
+                echo "Running E2E tests...";; \
+            [nN] | [nN][oO] | * ) \
+                echo "Aborting E2E tests..."; \
+                exit 1; \
         esac \
     fi
 endef

--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -66,8 +66,8 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
+	@$(prompt_for_e2e_test_execution)
 	go test ./test/e2e/ -v -ginkgo.v
-
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint
 	$(GOLANGCI_LINT) run
@@ -195,4 +195,26 @@ echo "Downloading $${package}" ;\
 GOBIN=$(LOCALBIN) go install $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
+endef
+
+define prompt_for_e2e_test_execution
+    if [ "$$(echo "$(KUBEFLOW_TEST_PROMPT)" | tr '[:upper:]' '[:lower:]')" = "false" ]; then \
+        echo "Skipping E2E test confirmation prompt (KUBEFLOW_TEST_PROMPT is set to true)"; \
+    else \
+        current_k8s_context=$$(kubectl config current-context); \
+        echo "===== WARNING: E2E Test Execution on Active Kubernetes Cluster ====="; \
+        echo "Current Kubernetes context: $$current_k8s_context"; \
+        echo "Running E2E tests will utilize your current Kubernetes cluster."; \
+        echo "This may result in the deletion of certain resources such as cert-manager ...:"; \
+        echo "Are you sure you want to proceed with the E2E tests? (yes/no)"; \
+        read user_confirmation; \
+        case $$user_confirmation in \
+            [yY] | [yY][eE][sS] ) \
+                echo "Proceeding with E2E tests...";; \
+            [nN] | [nN][oO] ) \
+                echo "E2E test execution aborted."; exit 1;; \
+            * ) \
+                echo "Invalid response. E2E test execution aborted for safety."; exit 1;; \
+        esac \
+    fi
 endef


### PR DESCRIPTION
This PR enhances the safety of running `make test-e2e` by implementing a confirmation prompt.

## Why is this important?

The `make test-e2e` command executes tests on the current Kubernetes cluster. This can potentially disrupt a production environment, as the tests include cleanup operations such as deleting cert-manager after completion.

## What changes were made?

1. Added a confirmation prompt before test execution:
   - Displays the current Kubernetes cluster context
   - Asks for user confirmation to proceed

2. Implemented a bypass option for CI/CD pipelines:
   - Set environment variable `KUBEFLOW_TEST_PROMPT=FALSE` to skip the prompt
   - The variable is case-insensitive (e.g., "FALSE", "false", or "False" are all valid)

3. User confirmation:
   - Accepts "yes" or "y" (case-insensitive) to proceed with the tests
   - Any other input will abort the operation
