### PR TITLE
test(ws): add tests for workspace and workspaceKind controller loops

### DIFF
--- a/workspaces/controller/internal/controller/suite_test.go
+++ b/workspaces/controller/internal/controller/suite_test.go
@@ -169,6 +169,11 @@ func NewExampleWorkspace1(name string, namespace string, workspaceKind string) *
 	}
 }
 
+func NewExampleWorkspace2(name string, namespace string, workspaceKind string) *kubefloworgv1beta1.Workspace {
+	workspace := NewExampleWorkspace1(name, namespace, workspaceKind)
+	return workspace
+}
+
 // NewExampleWorkspaceKind1 returns the common "WorkspaceKind 1" object used in tests.
 func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 	return &kubefloworgv1beta1.WorkspaceKind{
@@ -416,4 +421,15 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 			},
 		},
 	}
+}
+
+func NewExampleWorkspaceKind2(name, portId string) *kubefloworgv1beta1.WorkspaceKind {
+	workspaceKind := NewExampleWorkspaceKind1(name)
+	workspaceKind.Spec.PodTemplate.Options.ImageConfig.Values[0].Spec.Ports[0].Id = portId
+	return workspaceKind
+}
+func NewExampleWorkspaceKind3(name, prefixEnvValue string) *kubefloworgv1beta1.WorkspaceKind {
+	workspaceKind := NewExampleWorkspaceKind1(name)
+	workspaceKind.Spec.PodTemplate.ExtraEnv[0].Value = prefixEnvValue
+	return workspaceKind
 }


### PR DESCRIPTION
This PR is still a work in progress, but I’d appreciate a review before completing all tests.

The tests covered in this PR include:

- Verifying that resources like Service and StatefulSet are created when a Workspace is created.
- Ensuring that reconciled resources are deleted and properly recreated.
- Checking that updated reconciled resources are reverted as expected.
- Validating that Go templates in WorkspaceKind's spec.podTemplate.extraEnv[].value function correctly:
   -  Succeed with a valid portID.
   -  Return an empty string for an invalid portID.
   -  Set the Workspace to an error state for invalid template formats (e.g., using single quotes for the portID string).