### PR TITLE
feat(ws): update list workspacekinds JSON payloads

### DIFF
--- a/workspaces/backend/internal/models/pod_models.go
+++ b/workspaces/backend/internal/models/pod_models.go
@@ -1,0 +1,52 @@
+package models
+
+type WorkspaceKindPodMetadata struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+type ImageConfig struct {
+	Default string             `json:"default"`
+	Values  []ImageConfigValue `json:"values"`
+}
+
+type ImageConfigValue struct {
+	Id          string            `json:"id"`
+	DisplayName string            `json:"displayName"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Hidden      *bool             `json:"hidden,omitempty"`
+	Redirect    *OptionRedirect   `json:"redirect,omitempty"`
+}
+
+type PodConfig struct {
+	Default string           `json:"default"`
+	Values  []PodConfigValue `json:"values"`
+}
+
+type PodConfigValue struct {
+	Id          string            `json:"id"`
+	DisplayName string            `json:"displayName"`
+	Description string            `json:"description"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+type OptionRedirect struct {
+	To      string   `json:"to"`
+	Message *Message `json:"message,omitempty"`
+}
+
+type Message struct {
+	Text  string `json:"text"`
+	Level string `json:"level"`
+}
+
+type WorkspaceKindPodOptions struct {
+	ImageConfig ImageConfig `json:"image_config"`
+	PodConfig   PodConfig   `json:"pod_config"`
+}
+
+type PodTemplateModel struct {
+	PodMetadata WorkspaceKindPodMetadata `json:"pod_metadata"`
+	VolumeMount map[string]string        `json:"volume_mounts"`
+	Options     WorkspaceKindPodOptions  `json:"options"`
+}

--- a/workspaces/backend/internal/models/workspacekinds.go
+++ b/workspaces/backend/internal/models/workspacekinds.go
@@ -124,7 +124,7 @@ func NewWorkspaceKindModelFromWorkspaceKind(item *kubefloworgv1beta1.WorkspaceKi
 	}
 
 	volumeMounts := map[string]string{"home": ""}
-	if &item.Spec.PodTemplate.VolumeMounts.Home != nil {
+	if item.Spec.PodTemplate.VolumeMounts.Home != "" {
 		volumeMounts["home"] = item.Spec.PodTemplate.VolumeMounts.Home
 	}
 


### PR DESCRIPTION
Resolution details for #128.
We investigate this issue with referring to payload example provided in #127 .
Seems the example is not relevant with all it's fields to workspacekind resource. 
Currently the output for the sample yaml as resource input (jupyterlab_v1beta1_workspacekind.yaml) - 

```bash
curl -i localhost:4000/api/v1/workspacekinds
```

```json
{
   "data":[
      {
         "name":"jupyterlab",
         "spawner":{
            "display_name":"JupyterLab Notebook",
            "description":"A Workspace which runs JupyterLab in a Pod",
            "deprecated":false,
            "deprecation_message":"This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind.",
            "hidden":false
         },
         "pod_template":{
            "pod_metadata":{
               "labels":{
                  "my-workspace-kind-label":"my-value"
               },
               "annotations":{
                  "my-workspace-kind-annotation":"my-value"
               }
            },
            "image_config":{
               "current":"jupyterlab_scipy_190",
               "desired":"jupyterlab_scipy_190",
               "redirect_chain":[
                  {
                     "source":"jupyterlab_scipy_180",
                     "target":"jupyterlab_scipy_190"
                  }
               ]
            },
            "pod_config":{
               "current":"tiny_cpu",
               "desired":"tiny_cpu",
               "redirect_chain":[
                  {
                     "source":"tiny_cpu",
                     "target":"tiny_cpu"
                  },
                  {
                     "source":"tiny_cpu",
                     "target":"small_cpu"
                  },
                  {
                     "source":"tiny_cpu",
                     "target":"big_gpu"
                  }
               ]
            }
         }
      }
   ]
}
```
