### PR TITLE
ci: add action to enforce semantic PR titles

### DIFF
--- a/.github/workflows/semantic-prs.yaml
+++ b/.github/workflows/semantic-prs.yaml
@@ -1,0 +1,40 @@
+name: Semantic PRs
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate_title:
+    name: Validate Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            improve
+            refactor
+            revert
+            test
+            ci
+            docs
+            chore
+
+          scopes: |
+            nb
+            pvc
+            tb
+            ws
+          requireScope: false


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow to enforce semantic pull request titles for better clarity and consistency in the development process.
NOTE: this is the same as https://github.com/kubeflow/notebooks/pull/14, but for the `main` branch.