### PR TITLE
feat(ws): Add popup to Workspace data vol column in workspaces table

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/DataVolumesList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/DataVolumesList.tsx
@@ -1,0 +1,74 @@
+import {
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  Content,
+  Flex,
+  FlexItem,
+  List,
+  ListItem,
+  Stack,
+  StackItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import { DatabaseIcon, LockedIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { Workspace } from '~/shared/types';
+
+interface DataVolumesListProps {
+  workspace: Workspace;
+}
+
+export const DataVolumesList: React.FC<DataVolumesListProps> = ({ workspace }) => {
+  const workspaceDataVol = workspace.podTemplate.volumes.data;
+
+  const singleDataVolRenderer = (data: {
+    pvcName: string;
+    mountPath: string;
+    readOnly: boolean;
+  }) => (
+    <Flex
+      gap={{ default: 'gapSm' }}
+      alignItems={{ default: 'alignItemsFlexStart' }}
+      flexWrap={{ default: 'nowrap' }}
+    >
+      <FlexItem>
+        <DatabaseIcon />
+      </FlexItem>
+      <FlexItem>
+        <Content>
+          {data.pvcName}
+          {data.readOnly && (
+            <Tooltip content="Data is readonly">
+              <LockedIcon style={{ marginLeft: '5px' }} />
+            </Tooltip>
+          )}
+        </Content>
+        <Stack>
+          <StackItem>
+            <Content component="small">
+              Mount path:{' '}
+              <ClipboardCopy variant={ClipboardCopyVariant.inlineCompact}>
+                {data.mountPath}
+              </ClipboardCopy>
+            </Content>
+          </StackItem>
+        </Stack>
+      </FlexItem>
+    </Flex>
+  );
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <strong data-testid="notebook-storage-bar-title">Cluster storage</strong>
+      </StackItem>
+      <StackItem>
+        <List isPlain>
+          {workspaceDataVol.map((data, index) => (
+            <ListItem key={`data-vol-${index}`}>{singleDataVolRenderer(data)}</ListItem>
+          ))}
+        </List>
+      </StackItem>
+    </Stack>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/ExpandedWorkspaceRow.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/ExpandedWorkspaceRow.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { ExpandableRowContent, Td, Tr } from '@patternfly/react-table';
+import { Workspace, WorkspacesColumnNames } from '~/shared/types';
+import { DataVolumesList } from '~/app/pages/Workspaces/DataVolumesList';
+
+interface ExpandedWorkspaceRowProps {
+  workspace: Workspace;
+  columnNames: WorkspacesColumnNames;
+}
+
+export const ExpandedWorkspaceRow: React.FC<ExpandedWorkspaceRowProps> = ({
+  workspace,
+  columnNames,
+}) => {
+  const renderExpandedData = () =>
+    Object.keys(columnNames).map((colName) => {
+      switch (colName) {
+        case 'name':
+          return (
+            <Td noPadding colSpan={1}>
+              <ExpandableRowContent>
+                <DataVolumesList workspace={workspace} />
+              </ExpandableRowContent>
+            </Td>
+          );
+        default:
+          return <Td />;
+      }
+    });
+
+  return (
+    <Tr>
+      <Td />
+      {renderExpandedData()}
+    </Tr>
+  );
+};

--- a/workspaces/frontend/src/shared/types.ts
+++ b/workspaces/frontend/src/shared/types.ts
@@ -70,3 +70,15 @@ export interface Workspace {
   };
   status: WorkspaceStatus;
 }
+
+export type WorkspacesColumnNames = {
+  name: string;
+  kind: string;
+  image: string;
+  podConfig: string;
+  state: string;
+  homeVol: string;
+  cpu: string;
+  ram: string;
+  lastActivity: string;
+};


### PR DESCRIPTION
Fixes: #149

added popup with the worspace data vol info, that will show when hovering on the data vol column field.

please inform me if anything needs to be changes in matter of functionality or styling.

added a picture of the change:

![image](https://github.com/user-attachments/assets/a347b2e9-67cf-4c08-982e-a8ea67485c53)
