### PR TITLE
feat(ws): Implement Start restart and stop workspace actions

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
@@ -1,0 +1,188 @@
+import { ExpandableSection, Icon, Tab, Tabs, TabTitleText, Content } from '@patternfly/react-core';
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+} from '@patternfly/react-icons';
+import * as React from 'react';
+
+// remove when changing to fetch data from BE
+const mockedWorkspaceKind = {
+  name: 'jupyter-lab',
+  displayName: 'JupyterLab Notebook',
+  description: 'A Workspace which runs JupyterLab in a Pod',
+  deprecated: false,
+  deprecationMessage: '',
+  hidden: false,
+  icon: {
+    url: 'https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png',
+  },
+  logo: {
+    url: 'https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg',
+  },
+  podTemplate: {
+    podMetadata: {
+      labels: { myWorkspaceKindLabel: 'my-value' },
+      annotations: { myWorkspaceKindAnnotation: 'my-value' },
+    },
+    volumeMounts: { home: '/home/jovyan' },
+    options: {
+      imageConfig: {
+        default: 'jupyterlab_scipy_190',
+        values: [
+          {
+            id: 'jupyterlab_scipy_180',
+            displayName: 'jupyter-scipy:v1.8.0',
+            labels: { pythonVersion: '3.11' },
+            hidden: true,
+            redirect: {
+              to: 'jupyterlab_scipy_190',
+              message: {
+                text: 'This update will change...',
+                level: 'Info',
+              },
+            },
+          },
+          {
+            id: 'jupyterlab_scipy_190',
+            displayName: 'jupyter-scipy:v1.9.0',
+            labels: { pythonVersion: '3.11' },
+            hidden: true,
+            redirect: {
+              to: 'jupyterlab_scipy_200',
+              message: {
+                text: 'This update will change...',
+                level: 'Warning',
+              },
+            },
+          },
+        ],
+      },
+      podConfig: {
+        default: 'tiny_cpu',
+        values: [
+          {
+            id: 'tiny_cpu',
+            displayName: 'Tiny CPU',
+            description: 'Pod with 0.1 CPU, 128 Mb RAM',
+            labels: { cpu: '100m', memory: '128Mi' },
+            redirect: {
+              to: 'small_cpu',
+              message: {
+                text: 'This update will change...',
+                level: 'Danger',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+const getLevelIcon = (level: string) => {
+  switch (level) {
+    case 'Info':
+      return (
+        <Icon status="info">
+          <InfoCircleIcon />
+        </Icon>
+      );
+    case 'Warning':
+      return (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+      );
+    case 'Danger':
+      return (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      );
+    default:
+      return (
+        <Icon status="info">
+          <InfoCircleIcon />
+        </Icon>
+      );
+  }
+};
+
+export const WorkspaceRedirectInformationView: React.FC = () => {
+  const [activeKey, setActiveKey] = React.useState<string | number>(0);
+  // change this to get from BE, and use the workspaceKinds API
+  const workspaceKind = mockedWorkspaceKind;
+
+  const { imageConfig } = workspaceKind.podTemplate.options;
+  const { podConfig } = workspaceKind.podTemplate.options;
+
+  const imageConfigRedirects = imageConfig.values.map((value) => ({
+    src: value.id,
+    dest: value.redirect.to,
+    message: value.redirect.message.text,
+    level: value.redirect.message.level,
+  }));
+  const podConfigRedirects = podConfig.values.map((value) => ({
+    src: value.id,
+    dest: value.redirect.to,
+    message: value.redirect.message.text,
+    level: value.redirect.message.level,
+  }));
+
+  const getMaxLevel = (
+    redirects: { dest: string; level: string; message: string; src: string }[],
+  ) => {
+    let maxLevel = redirects[0].level;
+    redirects.forEach((redirect) => {
+      if (
+        (maxLevel === 'Info' && (redirect.level === 'Warning' || redirect.level === 'Danger')) ||
+        (maxLevel === 'Warning' && redirect.level === 'Danger')
+      ) {
+        maxLevel = redirect.level;
+      }
+    });
+    return maxLevel;
+  };
+
+  return (
+    <Tabs activeKey={activeKey} onSelect={(event, eventKey) => setActiveKey(eventKey)}>
+      {imageConfigRedirects.length > 0 && (
+        <Tab
+          eventKey={0}
+          title={
+            <TabTitleText>
+              Image Config {getLevelIcon(getMaxLevel(imageConfigRedirects))}
+            </TabTitleText>
+          }
+        >
+          {imageConfigRedirects.map((redirect, index) => (
+            <Content style={{ display: 'flex', alignItems: 'baseline' }} key={index}>
+              {getLevelIcon(redirect.level)}
+              <ExpandableSection toggleText={` ${redirect.src} -> ${redirect.dest}`}>
+                <Content>{redirect.message}</Content>
+              </ExpandableSection>
+            </Content>
+          ))}
+        </Tab>
+      )}
+      {podConfigRedirects.length > 0 && (
+        <Tab
+          eventKey={1}
+          title={
+            <TabTitleText>Pod Config {getLevelIcon(getMaxLevel(podConfigRedirects))}</TabTitleText>
+          }
+        >
+          {podConfigRedirects.map((redirect, index) => (
+            <Content style={{ display: 'flex', alignItems: 'baseline' }} key={index}>
+              {getLevelIcon(redirect.level)}
+              <ExpandableSection toggleText={` ${redirect.src} -> ${redirect.dest}`}>
+                <Content>{redirect.message}</Content>
+              </ExpandableSection>
+            </Content>
+          ))}
+        </Tab>
+      )}
+    </Tabs>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRestartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRestartActionModal.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import {
+  Button,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TabTitleText,
+} from '@patternfly/react-core';
+import { Workspace } from '~/shared/types';
+import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
+
+interface RestartActionAlertProps {
+  onClose: () => void;
+  isOpen: boolean;
+  workspace: Workspace | null;
+}
+
+export const WorkspaceRestartActionModal: React.FC<RestartActionAlertProps> = ({
+  onClose,
+  isOpen,
+  workspace,
+}) => {
+  const workspacePendingUpdate = workspace?.status.pendingRestart;
+  const handleClick = (isUpdate = false) => {
+    if (isUpdate) {
+      console.log(`Update ${workspace?.name}`);
+    }
+    console.log(`Restart ${workspace?.name}`);
+    onClose();
+  };
+  return (
+    <Modal
+      variant="medium"
+      isOpen={isOpen}
+      aria-describedby="modal-title-icon-description"
+      aria-labelledby="title-icon-modal-title"
+      onClose={onClose}
+    >
+      <ModalHeader title="Restart Workspace" />
+      <ModalBody>
+        {workspacePendingUpdate ? (
+          <>
+            <TabTitleText>
+              There are pending redirect updates for that workspace. Are you sure you want to
+              proceed?
+            </TabTitleText>
+            <WorkspaceRedirectInformationView />
+          </>
+        ) : (
+          <Content>Are you sure you want to restart the workspace?</Content>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        {workspacePendingUpdate && (
+          <Button onClick={() => handleClick(true)}>Update and Restart</Button>
+        )}
+        <Button
+          onClick={() => handleClick(false)}
+          variant={workspacePendingUpdate ? 'secondary' : 'primary'}
+        >
+          Restart
+        </Button>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TabTitleText,
+} from '@patternfly/react-core';
+import { Workspace } from '~/shared/types';
+import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
+
+interface StartActionAlertProps {
+  onClose: () => void;
+  isOpen: boolean;
+  workspace: Workspace | null;
+}
+
+export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
+  onClose,
+  isOpen,
+  workspace,
+}) => {
+  const handleClick = (isUpdate = false) => {
+    if (isUpdate) {
+      console.log(`Update ${workspace?.name}`);
+    }
+    console.log(`Start ${workspace?.name}`);
+    onClose();
+  };
+  return (
+    <Modal
+      variant="medium"
+      isOpen={isOpen}
+      aria-describedby="modal-title-icon-description"
+      aria-labelledby="title-icon-modal-title"
+      onClose={onClose}
+    >
+      <ModalHeader title="Start Workspace" />
+      <ModalBody>
+        <TabTitleText>
+          There are pending redirect updates for that workspace. Are you sure you want to proceed?
+        </TabTitleText>
+        <WorkspaceRedirectInformationView />
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={() => handleClick(true)}>Update and Start</Button>
+        <Button onClick={() => handleClick(false)} variant="secondary">
+          Start
+        </Button>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TabTitleText,
+  Content,
+} from '@patternfly/react-core';
+import { Workspace } from '~/shared/types';
+import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
+
+interface StopActionAlertProps {
+  onClose: () => void;
+  isOpen: boolean;
+  workspace: Workspace | null;
+}
+
+export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
+  onClose,
+  isOpen,
+  workspace,
+}) => {
+  const workspacePendingUpdate = workspace?.status.pendingRestart;
+  const handleClick = (isUpdate = false) => {
+    if (isUpdate) {
+      console.log(`Update ${workspace?.name}`);
+    }
+    console.log(`Stop ${workspace?.name}`);
+    onClose();
+  };
+  return (
+    <Modal
+      variant="medium"
+      isOpen={isOpen}
+      aria-describedby="modal-title-icon-description"
+      aria-labelledby="title-icon-modal-title"
+      onClose={onClose}
+    >
+      <ModalHeader title="Stop Workspace" />
+      <ModalBody>
+        {workspacePendingUpdate ? (
+          <>
+            <TabTitleText>
+              There are pending redirect updates for that workspace. Are you sure you want to
+              proceed?
+            </TabTitleText>
+            <WorkspaceRedirectInformationView />
+          </>
+        ) : (
+          <Content>Are you sure you want to stop the workspace?</Content>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        {workspacePendingUpdate && (
+          <Button onClick={() => handleClick(true)}>Update and Stop</Button>
+        )}
+        <Button
+          onClick={() => handleClick(false)}
+          variant={workspacePendingUpdate ? 'secondary' : 'primary'}
+        >
+          {workspacePendingUpdate ? 'Stop and defer updates' : 'Stop'}
+        </Button>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};


### PR DESCRIPTION
Fixes: #146

Implemented Start, restart and stop workspace actions present in the workspace table actions kebab dropdown.
with the requested buttons and warning, from the issue description.
snapshots:
1. start with pending updates: 
![image](https://github.com/user-attachments/assets/2a33d2bd-5d59-4b9a-93b7-5dadf31b074a)

2. restart without pending updates: 
![image](https://github.com/user-attachments/assets/d0a5b0ed-d5dc-46a4-ab68-663f119f2a0e)

3. stop without pending updates: 
![image](https://github.com/user-attachments/assets/a1c08f49-79df-4577-8433-0cd15895e1cb)

4. stop with pending updates: 
![image](https://github.com/user-attachments/assets/8cba5e30-fdbe-4a5b-afe6-3ed5291bb138)

5. restart with pending updates: 
![image](https://github.com/user-attachments/assets/4467030f-8923-4dac-a188-de6328e28a4e)
