### PR TITLE
feat(ws): Notebooks 2.0 // Frontend // Workspace details // Applies MUI Theming 

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
@@ -9,6 +9,8 @@ import {
   Tab,
   TabTitleText,
   Title,
+  TabContentBody,
+  TabContent,
 } from '@patternfly/react-core';
 import { Workspace } from '~/shared/types';
 import { WorkspaceDetailsOverview } from '~/app/pages/Workspaces/Details/WorkspaceDetailsOverview';
@@ -37,7 +39,7 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
   };
 
   return (
-    <DrawerPanelContent isResizable defaultSize="50%">
+    <DrawerPanelContent>
       <DrawerHead>
         <Title headingLevel="h6">{workspace.name}</Title>
         <WorkspaceDetailsActions onEditClick={onEditClick} onDeleteClick={onDeleteClick} />
@@ -48,20 +50,30 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
       <DrawerPanelBody>
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
           <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>} aria-label="Overview">
-            <WorkspaceDetailsOverview workspace={workspace} />
+            <TabContent id="overviewSectionBodyPadding">
+              <TabContentBody hasPadding>
+                <WorkspaceDetailsOverview workspace={workspace} />
+              </TabContentBody>
+            </TabContent>
           </Tab>
           <Tab eventKey={1} title={<TabTitleText>Activity</TabTitleText>} aria-label="Activity">
-            Activity
+            <TabContent id="activitySectionBodyPadding">
+              <TabContentBody hasPadding>Activity</TabContentBody>
+            </TabContent>
           </Tab>
           <Tab eventKey={2} title={<TabTitleText>Logs</TabTitleText>} aria-label="Logs">
-            Logs
+            <TabContent id="logsSectionBodyPadding">
+              <TabContentBody hasPadding>Logs</TabContentBody>
+            </TabContent>
           </Tab>
           <Tab
             eventKey={3}
             title={<TabTitleText>Pod template</TabTitleText>}
             aria-label="Pod template"
           >
-            Pod template
+            <TabContent id="podTemplateBodyPadding">
+              <TabContentBody hasPadding>Pod template</TabContentBody>
+            </TabContent>
           </Tab>
         </Tabs>
       </DrawerPanelBody>

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
@@ -4,6 +4,7 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
+  Divider,
 } from '@patternfly/react-core';
 import { Workspace } from '~/shared/types';
 
@@ -14,24 +15,28 @@ type WorkspaceDetailsOverviewProps = {
 export const WorkspaceDetailsOverview: React.FunctionComponent<WorkspaceDetailsOverviewProps> = ({
   workspace,
 }) => (
-  <DescriptionList>
+  <DescriptionList isHorizontal>
     <DescriptionListGroup>
       <DescriptionListTerm>Name</DescriptionListTerm>
       <DescriptionListDescription>{workspace.name}</DescriptionListDescription>
     </DescriptionListGroup>
+    <Divider />
     <DescriptionListGroup>
       <DescriptionListTerm>Kind</DescriptionListTerm>
       <DescriptionListDescription>{workspace.kind}</DescriptionListDescription>
     </DescriptionListGroup>
+    <Divider />
     <DescriptionListGroup>
       <DescriptionListTerm>Labels</DescriptionListTerm>
       <DescriptionListDescription>
         {workspace.podTemplate.podMetadata.labels.join(', ')}
       </DescriptionListDescription>
     </DescriptionListGroup>
+    <Divider />
     <DescriptionListGroup>
       <DescriptionListTerm>Pod config</DescriptionListTerm>
       <DescriptionListDescription>{workspace.options.podConfig}</DescriptionListDescription>
     </DescriptionListGroup>
+    <Divider />
   </DescriptionList>
 );

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -367,7 +367,7 @@ export const Workspaces: React.FunctionComponent = () => {
   );
 
   return (
-    <Drawer isExpanded={selectedWorkspace != null}>
+    <Drawer isInline isExpanded={selectedWorkspace != null}>
       <DrawerContent panelContent={workspaceDetailsContent}>
         <DrawerContentBody>
           <PageSection isFilled>

--- a/workspaces/frontend/src/shared/style/MUI-theme.scss
+++ b/workspaces/frontend/src/shared/style/MUI-theme.scss
@@ -23,6 +23,9 @@
   --mui-button--LineHeight: 1.75;
   --mui-link-underlineColor: rgba(33, 150, 243, 0.4);
 
+  // Drawer
+  --mui-drawer-BorderLeft: var(--mui-palette-grey-300);
+
   // Menu item
   --mui-menu__item--PaddingBlockStart: 6px;
   --mui-menu__item--PaddingBlockEnd: 6px;
@@ -175,8 +178,22 @@
   --pf-v6-c-button--BackgroundColor: rgba(33, 150, 243, 0.04);
 }
 
+.mui-theme .pf-v6-c-description-list {
+  --pf-v6-c-description-list--RowGap: var(--pf-t--global--spacer--gap--group-to-group--horizontal--compact);
+}
+
+.mui-theme .pf-v6-c-description-list__term {
+  font: var(--mui-font-subtitle2);
+}
+
 .mui-theme .pf-v6-c-description-list__text .pf-v6-l-split__item.pf-m-fill {
   align-content: center;
+}
+
+
+
+.mui-theme .pf-v6-c-drawer {
+  --pf-v6-c-drawer--m-inline--m-expanded__panel--after--BackgroundColor: var(--mui-drawer-BorderLeft);
 }
 
 .mui-theme .pf-v6-c-form__group {
@@ -669,6 +686,13 @@
   --pf-v6-c-tab-content__body--m-padding--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 }
 
+.pf-v6-c-tab-content__body.pf-m-padding {
+  --pf-v6-c-tab-content__body--PaddingInlineStart: 0px;
+  --pf-v6-c-tab-content__body--PaddingInlineEnd: 0px;
+  --pf-v6-c-tab-content__body--PaddingBlockStart: var(--mui-spacing-8px);
+  --pf-v6-c-tab-content__body--PaddingBlockEnd: var(--mui-spacing-8px);
+}
+
 .mui-theme .pf-v6-c-tabs {
   --pf-v6-c-tabs__link--hover--BackgroundColor: var(--mui-tabs__link--hover--BackgroundColor);
   --pf-v6-c-tabs__item--PaddingBlockStart: var(--mui-tabs__item--PaddingBlockStart);
@@ -760,6 +784,7 @@
 }
 
 .mui-theme .pf-v6-c-page__main-container {
+  --pf-v6-c-page__main-container--BorderWidth: 0px;
   --pf-v6-c-page__main-container--BorderRadius: var(--mui-shape-borderRadius);
   box-shadow: var(--mui-shadows-1);
 }


### PR DESCRIPTION
Adds MUI support to Notebooks 2.0 UI. Applies theming to Workspace details drawer to align with MUI theming and KF Central UI.

Before:
<img width="1917" alt="Screenshot 2025-01-23 at 4 05 18 PM" src="https://github.com/user-attachments/assets/ecad8e81-920d-457d-b707-08eea2044756" />

After:
<img width="1920" alt="Screenshot 2025-01-24 at 12 11 21 PM" src="https://github.com/user-attachments/assets/533b22d4-1a28-4490-a76e-fdf61d55ecad" />

MUI [Responsive Drawer](https://mui.com/material-ui/react-drawer/#responsive-drawer):
<img width="500" alt="Screenshot 2025-01-23 at 4 38 04 PM" src="https://github.com/user-attachments/assets/14a428ef-4578-4359-9288-ea1d5df67f7e" />

KF Central UI (Aligns with list styling in "Overview" tab):
<img width="963" alt="Screenshot 2025-01-23 at 4 20 42 PM" src="https://github.com/user-attachments/assets/c7b95bf1-362a-432b-a5cb-7ee80aabfabf" />
