### PR TITLE
feat(ws): introduce limits on HTTP body/header size

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -94,5 +94,5 @@ func (a *App) Routes() http.Handler {
 	router.GET(AllWorkspaceKindsPath, a.GetWorkspaceKindsHandler)
 	router.GET(WorkspaceKindsByNamePath, a.GetWorkspaceKindHandler)
 
-	return a.RecoverPanic(a.enableCORS(router))
+	return a.recoverPanic(a.enableCORS(router))
 }

--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -18,11 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
 )
 
 type Envelope[D any] struct {
@@ -47,59 +43,6 @@ func (a *App) WriteJSON(w http.ResponseWriter, status int, data any, headers htt
 	_, err = w.Write(js)
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (a *App) ReadJSON(w http.ResponseWriter, r *http.Request, dst any) error {
-
-	maxBytes := 1_048_576
-	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
-
-	dec := json.NewDecoder(r.Body)
-	dec.DisallowUnknownFields()
-
-	err := dec.Decode(dst)
-	if err != nil {
-		var syntaxError *json.SyntaxError
-		var unmarshalTypeError *json.UnmarshalTypeError
-		var invalidUnmarshalError *json.InvalidUnmarshalError
-		var maxBytesError *http.MaxBytesError
-
-		switch {
-		case errors.As(err, &syntaxError):
-			return fmt.Errorf("body contains badly-formed JSON (at character %d)", syntaxError.Offset)
-
-		case errors.Is(err, io.ErrUnexpectedEOF):
-			return errors.New("body contains badly-formed JSON")
-
-		case errors.As(err, &unmarshalTypeError):
-			if unmarshalTypeError.Field != "" {
-				return fmt.Errorf("body contains incorrect JSON type for field %q", unmarshalTypeError.Field)
-			}
-			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshalTypeError.Offset)
-
-		case errors.Is(err, io.EOF):
-			return errors.New("body must not be empty")
-
-		case errors.As(err, &maxBytesError):
-			return fmt.Errorf("body must not be larger than %d bytes", maxBytesError.Limit)
-
-		case strings.HasPrefix(err.Error(), "json: unknown field "):
-			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
-			return fmt.Errorf("body contains unknown key %s", fieldName)
-
-		case errors.As(err, &invalidUnmarshalError):
-			panic(err)
-		default:
-			return err
-		}
-	}
-
-	err = dec.Decode(&struct{}{})
-	if !errors.Is(err, io.EOF) {
-		return errors.New("body must only contain a single JSON value")
 	}
 
 	return nil

--- a/workspaces/backend/api/middleware.go
+++ b/workspaces/backend/api/middleware.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 )
 
-func (a *App) RecoverPanic(next http.Handler) http.Handler {
+func (a *App) recoverPanic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {


### PR DESCRIPTION
This PR rejects clearly malformed/malicious HTTP requests by hard dropping the connection if:

1. The header size exceeds 128 Kib
2. The body size exceeds 4 Mib

Also, we were not using the `ReadJSON` method, so I have removed it to avoid confusion.