### PR TITLE
ci: trigger workflows for PRs with `ok-to-test` label

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,0 +1,48 @@
+name: Approve Workflow Runs
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Approve Pending Workflow Runs
+        uses: actions/github-script@v7
+        with:
+          retries: 3
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+            }
+            
+            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
+            
+            core.info(`Found ${runs.length} workflow runs that need approval`)
+            for (const run of runs) {
+              core.info(`Approving workflow run ${run.id}`)
+              const request = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }
+              await github.rest.actions.approveWorkflowRun(request)
+            }

--- a/.github/workflows/ws-backend-test.yml
+++ b/.github/workflows/ws-backend-test.yml
@@ -1,13 +1,23 @@
-name: UI - BFF - Build and Test
+name: Backend - Build and Test
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   push:
-    branches: [ "main", "notebooks-v2", "v*-branch" ]
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
   pull_request:
-    paths: [ "workspaces/backend/**" ]
-    branches: [ "main", "notebooks-v2", "v*-branch" ]
+    paths:
+      - workspaces/backend/**
+      ## NOTE: we also test on changes to the controller as the backend depends on the controller
+      - workspaces/controller/**
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/ws-controller-test.yaml
+++ b/.github/workflows/ws-controller-test.yaml
@@ -1,13 +1,23 @@
 name: Controller - Build and Test
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   push:
-    branches: [ "main", "notebooks-v2", "v*-branch" ]
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
   pull_request:
-    paths: [ "workspaces/controller/**" ]
-    branches: [ "main", "notebooks-v2", "v*-branch" ]
+    paths:
+      - workspaces/controller/**
+      ## NOTE: we also test on changes to the backend as the backend depends on the controller
+      - workspaces/backend/**
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/ws-frontend-test.yml
+++ b/.github/workflows/ws-frontend-test.yml
@@ -1,12 +1,24 @@
-name: UI - Frontend - Test and Build
+name: Frontend - Build and Test
+
+permissions:
+  contents: read
+
 on:
   push:
-    branches: [ "main", "notebooks-v2", "v*-branch" ]
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
   pull_request:
-    paths: [ "workspaces/frontend/**" ]
-    branches: [ "main", "notebooks-v2", "v*-branch" ]
+    paths:
+      - workspaces/frontend/**
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
+
 jobs:
-  test-and-build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install dependencies
         working-directory: workspaces/frontend


### PR DESCRIPTION
This PR:

1. Adds a new workflow that will trigger workflows for PRs that have the `ok-to-test` label
2. Cleans up some of the existing workflow names/permissions/formatting
3. Makes it so we run backend/controller tests if changes are made to either (as they depend on each other)