### PR TITLE
chore: issue templates + readme updates + common gha

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,75 @@
+name: 🐜 Bug Report
+description: Tell us about something not working properly
+labels: [ "kind/bug", "priority/needs-triage" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Bug Report
+        
+        Thanks for helping make the Kubeflow project better!
+
+  - type: checkboxes
+    attributes:
+      label: Checks
+      options:
+        - label: I have searched the [existing issues](https://github.com/kubeflow/notebooks/issues).
+          required: true
+        - label: My issue is related to one of the components in the [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks) repository.
+          required: true
+
+  - type: input
+    id: kubeflow-notebooks-version
+    attributes:
+      label: Kubeflow Notebooks Version
+      placeholder: X.X.X
+    validations:
+      required: true
+
+  - type: input
+    id: kubeflow-platform
+    attributes:
+      label: Kubeflow Platform
+      description: Which method did you use to [install](https://www.kubeflow.org/docs/started/installing-kubeflow/#kubeflow-platform) your Kubeflow Platform?
+      placeholder: ...
+    validations:
+      required: true
+
+  - type: input
+    id: kubernetes-distribution
+    attributes:
+      label: Kubernetes Distribution
+      description: How are you running Kubernetes?
+      placeholder: EKS / GKE / AKS / k3d / custom / etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: kubernetes-version
+    attributes:
+      label: Kubernetes Version
+      description: Output of `kubectl version` command.
+      placeholder: |
+        Client Version: version.Info{Major:"X", Minor:"XX", GitVersion:"vX.X.X", ...}
+        Server Version: version.Info{Major:"X", Minor:"XX", GitVersion:"vX.X.X", ...}
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: The __context__ the problem occurred in, and an __overview__ of what went wrong.
+      placeholder: I was trying to... but then...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: Outputs of commands like `kubectl logs my-pod` or `kubectl describe pods my-pod`.
+      placeholder: |
+        * include any relevant log outputs here *
+      render: shell

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,46 @@
+name: 💡 Feature Request
+description: Suggest an idea for the project
+labels: [ "kind/enhancement", "priority/needs-triage" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Feature Request
+        
+        Thanks for helping make the Kubeflow project better!
+
+  - type: checkboxes
+    attributes:
+      label: Checks
+      options:
+        - label: I have searched the [existing issues](https://github.com/kubeflow/notebooks/issues).
+          required: true
+        - label: My request is related to one of the components in the [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks) repository.
+          required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What has motivated your request?
+      placeholder: |
+        * This is the most important part of the request *
+        
+        * Help us understand what you are trying to achieve, try to separate it from any implementation you may have in mind *
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation
+      description: What is your proposed implementation?
+      placeholder: |
+        * It's fine to leave this blank if you don't have an implementation already in mind *
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing & able to help?
+      options:
+        - label: I am able to submit a PR!
+        - label: I can help test the feature!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Kubeflow Documentation
+    url: https://www.kubeflow.org/
+    about: Kubeflow Documentation
+
+  - name: Kubeflow Documentation - Notebooks
+    url: https://www.kubeflow.org/docs/components/notebooks/
+    about: Kubeflow Notebooks Documentation
+
+  - name: "Kubeflow Slack (join `#kubeflow-notebooks` channel)"
+    url: https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels
+    about: Join the Kubeflow Slack

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- 
+⚠️ please review https://www.kubeflow.org/docs/about/contributing/
+
+Thank you for contributing to Kubeflow!
+
+If there are related issues, please reference them using one of the following:
+
+ closes: #ISSUE
+ related: #ISSUE
+
+Please remember:
+ - provide enough information so that others can review your pull request
+ - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
+ - the title of your pull request will be used to generate the changelog entry, so make it count!
+-->

--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,0 +1,49 @@
+name: Approve Workflow Runs
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Approve Pending Workflow Runs
+        uses: actions/github-script@v7
+        with:
+          retries: 3
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+            }
+            
+            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
+            
+            core.info(`Found ${runs.length} workflow runs that need approval`)
+            for (const run of runs) {
+              core.info(`Approving workflow run ${run.id}`)
+              const request = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }
+              await github.rest.actions.approveWorkflowRun(request)
+            }

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,61 @@
+name: Stale Issues and Pull Requests
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run every day at midnight
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 21
+
+          stale-issue-label: lifecycle/stale
+          exempt-issue-labels: lifecycle/frozen,kind/enhancement
+
+          stale-pr-label: lifecycle/stale
+          exempt-pr-labels: lifecycle/frozen,kind/enhancement
+
+          # The message that will be added as a comment to the issues
+          # when the stale workflow marks it automatically as stale with a label.
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs.
+            Thank you for your contributions.
+            
+            Members may comment `/lifecycle frozen` to prevent this issue from being marked as stale.
+
+          # The message that will be added as a comment to the issues
+          # when the stale workflow closes it automatically after being stale for too long.
+          close-issue-message: |
+            This issue has been automatically closed because it has not had recent activity.
+            
+            Members may comment `/reopen` to reopen it.
+
+          # The message that will be added as a comment to the pull requests
+          # when the stale workflow marks it automatically as stale with a label.
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs.
+            Thank you for your contributions.
+            
+            Members may comment `/lifecycle frozen` to prevent this pull request from being marked as stale.
+
+          # The message that will be added as a comment to the pull requests
+          # when the stale workflow closes it automatically after being stale for too long.
+          close-pr-message: |
+            This pull request has been automatically closed because it has not had recent activity.
+            You can reopen the PR if you want.
+
+          # The issues or the pull requests with a milestone will not be marked as stale automatically
+          exempt-all-milestones: true
+
+          # Learn more about operations: https://github.com/actions/stale#operations-per-run.
+          operations-per-run: 250

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,10 @@ To indicate a breaking change, add `!` after the prefix, e.g. `feat!: my commit 
 
 You may optionally include a __scope__ after the prefix, for example:
 
-- `nb` (notebooks - web-app, controller, images)
-- `pvc` (volumes - web-app, controller)
-- `tb` (tensorboards - web-app, controller)
-- `ws` (workspaces - frontend, backend, controller, images)
+- `nb` (changes to notebooks - web-app, controller, images)
+- `pvc` (changes to volumes - web-app, controller)
+- `tb` (changes to tensorboards - web-app, controller)
+- `ws` (changes to workspaces - frontend, backend, controller, images)
 
 ### Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Kubeflow Notebooks
+
+Welcome to the Kubeflow Notebooks project! 
+Contributions are welcome via GitHub pull requests.
+
+Please see the [Contributing to Kubeflow](https://www.kubeflow.org/docs/about/contributing/) page for more information.
+
+## Sign Your Work
+
+To certify you agree to the [Developer Certificate of Origin](https://developercertificate.org/) you must sign-off each commit message using `git commit --signoff`, or manually write the following:
+
+```text
+feat(ws): my commit message`
+
+Signed-off-by: John Smith <john-smith@users.noreply.github.com>
+```
+
+## Use Semantic Commits
+
+We use [semantic commits](https://www.conventionalcommits.org/en/v1.0.0/) to help us automatically generate changelogs and release notes.
+
+__The name of your PR must be a semantic commit message__, with one of the following _prefixes_ and one of the following _scopes_:
+
+### Prefixes
+
+- `fix:` (bug fixes)
+- `feat:` (new features)
+- `improve:` (improvements to existing features)
+- `refactor:` (code changes that neither fixes a bug nor adds a feature)
+- `revert:` (reverts a previous commit)
+- `test:` (adding missing tests, refactoring tests; no production code change)
+- `ci:` (changes to CI configuration or build scripts)
+- `docs:` (documentation only changes)
+- `chore:` (ignored in changelog)
+
+To indicate a breaking change, add `!` after the prefix, e.g. `feat!: my commit message`.
+
+### Scopes
+
+- `nb` (notebooks - web-app, controller, images)
+- `pvc` (volumes - web-app, controller)
+- `tb` (tensorboards - web-app, controller)
+- `ws` (workspaces - frontend, backend, controller, images)
+
+### Examples
+
+- `fix(nb): something that was broken`
+- `feat(ws): a new feature`
+- `chore: update readme`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ Signed-off-by: John Smith <john-smith@users.noreply.github.com>
 
 We use [semantic commits](https://www.conventionalcommits.org/en/v1.0.0/) to help us automatically generate changelogs and release notes.
 
-__The name of your PR must be a semantic commit message__, with one of the following _prefixes_ and one of the following _scopes_:
-
 ### Prefixes
+
+A semantic commit message must start with one of the following __prefixes__:
 
 - `fix:` (bug fixes)
 - `feat:` (new features)
@@ -37,6 +37,8 @@ To indicate a breaking change, add `!` after the prefix, e.g. `feat!: my commit 
 
 ### Scopes
 
+You may optionally include a __scope__ after the prefix, for example:
+
 - `nb` (notebooks - web-app, controller, images)
 - `pvc` (volumes - web-app, controller)
 - `tb` (tensorboards - web-app, controller)
@@ -44,6 +46,9 @@ To indicate a breaking change, add `!` after the prefix, e.g. `feat!: my commit 
 
 ### Examples
 
+Here are some examples of semantic commit messages:
+
 - `fix(nb): something that was broken`
 - `feat(ws): a new feature`
+- `improve: a general improvement`
 - `chore: update readme`

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ Connect with _other users_ and the [Notebooks Working Group](https://github.com/
 
 ## Contributing
 
-Please see the [Contributing to Kubeflow](https://www.kubeflow.org/docs/about/contributing/) page for more information.
+Please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file for more information.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [Kubeflow Notebooks](https://www.kubeflow.org/docs/components/notebooks/overview/) lets you run web-based development environments on your Kubernetes cluster by running them inside Pods.
 
+> ⚠️ __Note__ ⚠️
+> 
+> We are currently moving the _Kubeflow Notebooks 1.0_ codebase from [`kubeflow/kubeflow`](https://github.com/kubeflow/kubeflow) to this repository ([`kubeflow/notebooks`](https://github.com/kubeflow/notebooks)).
+> Please see [`kubeflow/kubeflow#7549`](https://github.com/kubeflow/kubeflow/issues/7549) for more information.
+> 
+> We are currently developing _Kubeflow Notebooks 2.0_ in this repository under the [`notebooks-v2`](https://github.com/kubeflow/notebooks/tree/notebooks-v2) branch.
+> Please see [`kubeflow/notebooks#85`](https://github.com/kubeflow/notebooks/issues/85) for more information.
+
 ## What is Kubeflow Notebooks?
 
 Key features of Kubeflow Notebooks:
@@ -13,7 +21,7 @@ Key features of Kubeflow Notebooks:
 
 ## Installation
 
-Currently, Kubeflow Notebooks must be deployed as part of a full Kubeflow platform (not as a standalone component).
+Kubeflow Notebooks is designed to be deployed as part of a [Kubeflow Platform](https://www.kubeflow.org/docs/started/introduction/#what-is-kubeflow-platform) (not as a standalone component).
 
 Please refer to the [Installing Kubeflow](https://www.kubeflow.org/docs/started/installing-kubeflow/) page for more information.
 
@@ -25,16 +33,11 @@ The official documentation for Kubeflow Notebooks can be found [here](https://ww
 
 Kubeflow Notebooks is part of the Kubeflow project, refer to the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) page for more information.
 
-Connect with _other users_ and the [Notebooks Working Group](https://github.com/kubeflow/community/tree/master/wg-notebooks) in the following places:
+Connect with _other users_ and the [Notebooks Working Group](https://github.com/kubeflow/community/tree/master/wg-notebooks) (maintainers of Kubeflow Notebooks) in the following places:
 
-- [Kubeflow Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack) - Join the [`#kubeflow-notebooks`](https://kubeflow.slack.com/archives/CESP7FCQ7) channel.
+- [Kubeflow Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) - Join the [`#kubeflow-notebooks`](https://cloud-native.slack.com/archives/C073W562HFY) channel.
 - [Kubeflow Mailing List](https://groups.google.com/g/kubeflow-discuss)
 
 ## Contributing
-
-> ⚠️ __Note__ ⚠️
-> 
-> We are currently moving the Kubeflow Notebooks codebase from [`kubeflow/kubeflow`](https://github.com/kubeflow/kubeflow) to this repository ([`kubeflow/notebooks`](https://github.com/kubeflow/notebooks)).
-> For now, please continue to make contributions by raising PRs on `kubeflow/kubeflow`.
 
 Please see the [Contributing to Kubeflow](https://www.kubeflow.org/docs/about/contributing/) page for more information.


### PR DESCRIPTION
closes https://github.com/kubeflow/notebooks/pull/4

This PR does the following:

1. Adds github issue templates for bug reports/feature requests
2. Adds a notice to the readme in `main` about notebooks 2.0
3. Adds the "approve GHA workflows" workflow for PRs with the `ok-to-test` label
4. Adds a "stale Issue/PR workflow" (note, this will cause all the old issues to be marked as stale, but we can then go through them and mark the important ones as frozen).
5. Adds a `CONTRIBUTING.md` guide with basic info about commit signing