### PR TITLE
feat(ws): add `pendingRestart` field to workspace model

### DIFF
--- a/workspaces/backend/internal/models/workspaces/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/funcs.go
@@ -101,11 +101,12 @@ func NewWorkspaceModelFromWorkspace(ws *kubefloworgv1beta1.Workspace, wsk *kubef
 			Icon:    iconRef,
 			Logo:    logoRef,
 		},
-		DeferUpdates: ptr.Deref(ws.Spec.DeferUpdates, false),
-		Paused:       ptr.Deref(ws.Spec.Paused, false),
-		PausedTime:   ws.Status.PauseTime,
-		State:        wsState,
-		StateMessage: ws.Status.StateMessage,
+		DeferUpdates:   ptr.Deref(ws.Spec.DeferUpdates, false),
+		Paused:         ptr.Deref(ws.Spec.Paused, false),
+		PausedTime:     ws.Status.PauseTime,
+		PendingRestart: ws.Status.PendingRestart,
+		State:          wsState,
+		StateMessage:   ws.Status.StateMessage,
 		PodTemplate: PodTemplate{
 			PodMetadata: PodMetadata{
 				Labels:      podLabels,

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -19,17 +19,18 @@ package workspaces
 // Workspace represents a workspace in the system, and is returned by GET and LIST operations.
 // NOTE: this type is not used for CREATE or UPDATE operations, see WorkspaceCreate
 type Workspace struct {
-	Name          string            `json:"name"`
-	Namespace     string            `json:"namespace"`
-	WorkspaceKind WorkspaceKindInfo `json:"workspaceKind"`
-	DeferUpdates  bool              `json:"deferUpdates"`
-	Paused        bool              `json:"paused"`
-	PausedTime    int64             `json:"pausedTime"`
-	State         WorkspaceState    `json:"state"`
-	StateMessage  string            `json:"stateMessage"`
-	PodTemplate   PodTemplate       `json:"podTemplate"`
-	Activity      Activity          `json:"activity"`
-	Services      []Service         `json:"services"`
+	Name           string            `json:"name"`
+	Namespace      string            `json:"namespace"`
+	WorkspaceKind  WorkspaceKindInfo `json:"workspaceKind"`
+	DeferUpdates   bool              `json:"deferUpdates"`
+	Paused         bool              `json:"paused"`
+	PausedTime     int64             `json:"pausedTime"`
+	PendingRestart bool              `json:"pendingRestart"`
+	State          WorkspaceState    `json:"state"`
+	StateMessage   string            `json:"stateMessage"`
+	PodTemplate    PodTemplate       `json:"podTemplate"`
+	Activity       Activity          `json:"activity"`
+	Services       []Service         `json:"services"`
 }
 
 type WorkspaceState string


### PR DESCRIPTION
This PR is for adding missing field PendingRestart to workspace model for frontend use.