### PR TITLE
feat(ws): retry failed reconciles much less aggressively

### DIFF
--- a/workspaces/controller/cmd/main.go
+++ b/workspaces/controller/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -136,14 +137,14 @@ func main() {
 	if err = (&controllerInternal.WorkspaceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controller.Options{RateLimiter: helper.BuildRateLimiter()}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workspace")
 		os.Exit(1)
 	}
 	if err = (&controllerInternal.WorkspaceKindReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controller.Options{RateLimiter: helper.BuildRateLimiter()}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkspaceKind")
 		os.Exit(1)
 	}

--- a/workspaces/controller/cmd/main.go
+++ b/workspaces/controller/cmd/main.go
@@ -137,14 +137,18 @@ func main() {
 	if err = (&controllerInternal.WorkspaceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, controller.Options{RateLimiter: helper.BuildRateLimiter()}); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		RateLimiter: helper.BuildRateLimiter(),
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workspace")
 		os.Exit(1)
 	}
 	if err = (&controllerInternal.WorkspaceKindReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, controller.Options{RateLimiter: helper.BuildRateLimiter()}); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		RateLimiter: helper.BuildRateLimiter(),
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkspaceKind")
 		os.Exit(1)
 	}

--- a/workspaces/controller/internal/controller/suite_test.go
+++ b/workspaces/controller/internal/controller/suite_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -112,14 +113,18 @@ var _ = BeforeSuite(func() {
 	err = (&WorkspaceReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{
+		RateLimiter: helper.BuildRateLimiter(),
+	})
 	Expect(err).NotTo(HaveOccurred())
 
 	By("setting up the WorkspaceKind controller")
 	err = (&WorkspaceKindReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{
+		RateLimiter: helper.BuildRateLimiter(),
+	})
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -394,7 +395,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 
 	// NOTE: the SetupManagerFieldIndexers() helper in `helper/index.go` should have already been
 	//       called on `mgr` by the time this function is called, so the indexes are already set up
@@ -431,6 +432,9 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapPodToRequest),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}, predPodHasWSLabel),
 		).
+		WithOptions(controller.Options{
+			RateLimiter: helper.BuildRateLimiter(),
+		}).
 		Complete(r)
 }
 

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -419,6 +419,7 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager, opts controller
 	})
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&kubefloworgv1beta1.Workspace{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
@@ -432,9 +433,6 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager, opts controller
 			handler.EnqueueRequestsFromMapFunc(mapPodToRequest),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}, predPodHasWSLabel),
 		).
-		WithOptions(controller.Options{
-			RateLimiter: helper.BuildRateLimiter(),
-		}).
 		Complete(r)
 }
 

--- a/workspaces/controller/internal/controller/workspacekind_controller.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller.go
@@ -171,14 +171,12 @@ func (r *WorkspaceKindReconciler) SetupWithManager(mgr ctrl.Manager, opts contro
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&kubefloworgv1beta1.WorkspaceKind{}).
 		Watches(
 			&kubefloworgv1beta1.Workspace{},
 			handler.EnqueueRequestsFromMapFunc(mapWorkspaceToRequest),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
-		WithOptions(controller.Options{
-			RateLimiter: helper.BuildRateLimiter(),
-		}).
 		Complete(r)
 }

--- a/workspaces/controller/internal/controller/workspacekind_controller.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller.go
@@ -27,6 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -153,7 +154,7 @@ func (r *WorkspaceKindReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *WorkspaceKindReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *WorkspaceKindReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 
 	// NOTE: the SetupManagerFieldIndexers() helper in `helper/index.go` should have already been
 	//       called on `mgr` by the time this function is called, so the indexes are already set up
@@ -176,5 +177,8 @@ func (r *WorkspaceKindReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapWorkspaceToRequest),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
+		WithOptions(controller.Options{
+			RateLimiter: helper.BuildRateLimiter(),
+		}).
 		Complete(r)
 }

--- a/workspaces/controller/internal/controller/workspacekind_controller_test.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller_test.go
@@ -204,7 +204,12 @@ var _ = Describe("WorkspaceKind Controller", func() {
 			}, timeout, interval).Should(Equal(expectedStatus))
 
 			By("having a finalizer set on the WorkspaceKind")
-			Expect(workspaceKind.GetFinalizers()).To(ContainElement(WorkspaceKindFinalizer))
+			Eventually(func() []string {
+				if err := k8sClient.Get(ctx, workspaceKindKey, workspaceKind); err != nil {
+					return nil
+				}
+				return workspaceKind.GetFinalizers()
+			}, timeout, interval).Should(ContainElement(WorkspaceKindFinalizer))
 
 			By("deleting the Workspace")
 			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())

--- a/workspaces/controller/internal/helper/build_rate_limiter.go
+++ b/workspaces/controller/internal/helper/build_rate_limiter.go
@@ -1,0 +1,48 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// BuildRateLimiter creates a new rate limiter for our controllers.
+// NOTE: we dont use `DefaultTypedControllerRateLimiter` because it retries very aggressively, starting at 5ms!
+func BuildRateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
+	// exponential backoff rate limiter
+	//  - this handles per-item rate limiting for ~failures~
+	//  - it uses an exponential backoff strategy were: delay = baseDelay * 2^failures
+	//  - graph visualization: https://www.desmos.com/calculator/fexlpdmiti
+	failureBaseDelay := 1 * time.Second
+	failureMaxDelay := 7 * time.Minute
+	failureRateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](failureBaseDelay, failureMaxDelay)
+
+	// overall rate limiter
+	//  - this handles overall rate limiting, ignoring individual items and only considering the overall rate
+	//  - it implements a "token bucket" of size totalMaxBurst that is initially full,
+	//    and which is refilled at rate totalEventsPerSecond tokens per second.
+	totalEventsPerSecond := 10
+	totalMaxBurst := 100
+	totalRateLimiter := &workqueue.TypedBucketRateLimiter[reconcile.Request]{
+		Limiter: rate.NewLimiter(rate.Limit(totalEventsPerSecond), totalMaxBurst),
+	}
+
+	// return the worst-case (longest) of the rate limiters for a given item
+	return workqueue.NewTypedMaxOfRateLimiter(failureRateLimiter, totalRateLimiter)
+}

--- a/workspaces/controller/internal/helper/reconcile.go
+++ b/workspaces/controller/internal/helper/reconcile.go
@@ -1,4 +1,6 @@
 /*
+Copyright 2024.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -44,5 +46,5 @@ func BuildRateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
 	}
 
 	// return the worst-case (longest) of the rate limiters for a given item
-	return workqueue.NewTypedMaxOfRateLimiter(failureRateLimiter, totalRateLimiter)
+	return workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](failureRateLimiter, totalRateLimiter)
 }


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

closes: https://github.com/kubeflow/notebooks/issues/245
based on: https://github.com/external-secrets/external-secrets/pull/4339

This PR is based on the implementation found in [external-secrets#4339](https://github.com/external-secrets/external-secrets/pull/4339).

The `BuildRateLimiter()` function has been implemented and added under the `controller/helper` directory.

The controller was deployed using the image from this PR. I also spun up a JupyterLab with `kubectl apply -k config/samples/`, and the logs look good.
```
kubectl logs pod/workspace-controller-controller-manager-6df69d664c-pg4kj 
2025-04-10T08:35:01Z    INFO    controller-runtime.builder      skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called     {"GVK": "kubeflow.org/v1beta1, Kind=Workspace"}
2025-04-10T08:35:01Z    INFO    controller-runtime.builder      Registering a validating webhook        {"GVK": "kubeflow.org/v1beta1, Kind=Workspace", "path": "/validate-kubeflow-org-v1beta1-workspace"}
2025-04-10T08:35:01Z    INFO    controller-runtime.webhook      Registering webhook     {"path": "/validate-kubeflow-org-v1beta1-workspace"}
2025-04-10T08:35:01Z    INFO    controller-runtime.builder      skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called     {"GVK": "kubeflow.org/v1beta1, Kind=WorkspaceKind"}
2025-04-10T08:35:01Z    INFO    controller-runtime.builder      Registering a validating webhook        {"GVK": "kubeflow.org/v1beta1, Kind=WorkspaceKind", "path": "/validate-kubeflow-org-v1beta1-workspacekind"}
2025-04-10T08:35:01Z    INFO    controller-runtime.webhook      Registering webhook     {"path": "/validate-kubeflow-org-v1beta1-workspacekind"}
2025-04-10T08:35:01Z    INFO    setup   starting manager
2025-04-10T08:35:01Z    INFO    starting server {"name": "health probe", "addr": "[::]:8081"}
2025-04-10T08:35:01Z    INFO    controller-runtime.webhook      Starting webhook server
2025-04-10T08:35:01Z    INFO    setup   disabling http/2
2025-04-10T08:35:01Z    INFO    controller-runtime.certwatcher  Updated current TLS certificate
2025-04-10T08:35:01Z    INFO    controller-runtime.webhook      Serving webhook server  {"host": "", "port": 9443}
2025-04-10T08:35:01Z    INFO    controller-runtime.certwatcher  Starting certificate watcher
I0410 08:35:01.455203       1 leaderelection.go:254] attempting to acquire leader lease workspace-controller-system/kubeflow-workspace-controller...
I0410 08:35:01.458810       1 leaderelection.go:268] successfully acquired lease workspace-controller-system/kubeflow-workspace-controller
2025-04-10T08:35:01Z    DEBUG   events  workspace-controller-controller-manager-6df69d664c-pg4kj_e04a745b-c5c6-4d90-8357-411f73539ca3 became leader     {"type": "Normal", "object": {"kind":"Lease","namespace":"workspace-controller-system","name":"kubeflow-workspace-controller","uid":"bd3dd280-165d-449b-a8ba-47a32bd059c8","apiVersion":"coordination.k8s.io/v1","resourceVersion":"1011"}, "reason": "LeaderElection"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace", "source": "kind source: *v1beta1.Workspace"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace", "source": "kind source: *v1.StatefulSet"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace", "source": "kind source: *v1.Service"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace", "source": "kind source: *v1beta1.WorkspaceKind"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspacekind", "controllerGroup": "kubeflow.org", "controllerKind": "WorkspaceKind", "source": "kind source: *v1beta1.WorkspaceKind"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspacekind", "controllerGroup": "kubeflow.org", "controllerKind": "WorkspaceKind", "source": "kind source: *v1beta1.Workspace"}
2025-04-10T08:35:01Z    INFO    Starting Controller     {"controller": "workspacekind", "controllerGroup": "kubeflow.org", "controllerKind": "WorkspaceKind"}
2025-04-10T08:35:01Z    INFO    Starting EventSource    {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace", "source": "kind source: *v1.Pod"}
2025-04-10T08:35:01Z    INFO    Starting Controller     {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace"}
2025-04-10T08:35:01Z    INFO    Starting workers        {"controller": "workspace", "controllerGroup": "kubeflow.org", "controllerKind": "Workspace", "worker count": 1}
2025-04-10T08:35:01Z    INFO    Starting workers        {"controller": "workspacekind", "controllerGroup": "kubeflow.org", "controllerKind": "WorkspaceKind", "worker count": 1}
2025-04-10T08:40:54Z    DEBUG   admission       validating Workspace create     {"webhookGroup": "kubeflow.org", "webhookKind": "Workspace", "Workspace": {"name":"jupyterlab-workspace","namespace":"default"}, "namespace": "default", "name": "jupyterlab-workspace", "resource": {"group":"kubeflow.org","version":"v1beta1","resource":"workspaces"}, "user": "kubernetes-admin", "requestID": "1dd16f7f-33bd-485d-b679-206f35f1d1be"}
2025-04-10T08:40:54Z    DEBUG   admission       validating WorkspaceKind create {"webhookGroup": "kubeflow.org", "webhookKind": "WorkspaceKind", "WorkspaceKind": {"name":"jupyterlab"}, "namespace": "", "name": "jupyterlab", "resource": {"group":"kubeflow.org","version":"v1beta1","resource":"workspacekinds"}, "user": "kubernetes-admin", "requestID": "cea45b07-52ba-4c90-b48a-9d33d0aa5f5f"}
2025-04-10T09:45:02Z    DEBUG   admission       validating Workspace create     {"webhookGroup": "kubeflow.org", "webhookKind": "Workspace", "Workspace": {"name":"jupyterlab-workspace","namespace":"workspace-controller-system"}, "namespace": "workspace-controller-system", "name": "jupyterlab-workspace", "resource": {"group":"kubeflow.org","version":"v1beta1","resource":"workspaces"}, "user": "kubernetes-admin", "requestID": "bc056fbb-1666-4fd9-852c-ccbef443c36b"}
2025-04-10T09:45:02Z    DEBUG   admission       validating WorkspaceKind update {"webhookGroup": "kubeflow.org", "webhookKind": "WorkspaceKind", "WorkspaceKind": {"name":"jupyterlab"}, "namespace": "", "name": "jupyterlab", "resource": {"group":"kubeflow.org","version":"v1beta1","resource":"workspacekinds"}, "user": "system:serviceaccount:workspace-controller-system:workspace-controller-controller-manager", "requestID": "cb066176-9d3f-4c21-acac-8e8613c26570"}
2025-04-10T09:45:02Z    DEBUG   admission       validating WorkspaceKind update {"webhookGroup": "kubeflow.org", "webhookKind": "WorkspaceKind", "WorkspaceKind": {"name":"jupyterlab"}, "namespace": "", "name": "jupyterlab", "resource": {"group":"kubeflow.org","version":"v1beta1","resource":"workspacekinds"}, "user": "kubernetes-admin", "requestID": "fd0c2d3d-5df9-4ddd-8f09-05dacb8a8752"}
2025-04-10T09:45:03Z    DEBUG   admission       validating WorkspaceKind update {"webhookGroup": "kubeflow.org", "webhookKind": "WorkspaceKind", "WorkspaceKind": {"name":"jupyterlab"}, "namespace": "", "name": "jupyterlab", "resource": {"group":"kubeflow.org","version":"v1beta1","resource":"workspacekinds"}, "user": "system:serviceaccount:workspace-controller-system:workspace-controller-controller-manager", "requestID": "84bbe00e-f216-4dc7-b129-b888633edb73"}
```
