### PR TITLE
refactor(ws): Enhance "Create Workspace" Title Spacing

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Creation/WorkspaceCreation.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Creation/WorkspaceCreation.tsx
@@ -8,6 +8,8 @@ import {
   PageSection,
   ProgressStep,
   ProgressStepper,
+  Stack,
+  StackItem,
 } from '@patternfly/react-core';
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -68,69 +70,81 @@ const WorkspaceCreation: React.FunctionComponent = () => {
     <>
       <PageGroup stickyOnBreakpoint={{ default: 'top' }}>
         <PageSection isFilled={false}>
-          <Content>
-            <h1>Create workspace</h1>
-          </Content>
-          <ProgressStepper aria-label="Workspace creation stepper">
-            <ProgressStep
-              variant={getStepVariant(WorkspaceCreationSteps.KindSelection)}
-              id="kind-selection-step"
-              icon={
-                getStepVariant(WorkspaceCreationSteps.KindSelection) === 'success' ? (
-                  <CheckIcon />
-                ) : (
-                  1
-                )
-              }
-              titleId="kind-selection-step-title"
-              aria-label="Kind selection step"
-            >
-              Workspace Kind
-            </ProgressStep>
-            <ProgressStep
-              variant={getStepVariant(WorkspaceCreationSteps.ImageSelection)}
-              isCurrent
-              id="image-selection-step"
-              icon={
-                getStepVariant(WorkspaceCreationSteps.ImageSelection) === 'success' ? (
-                  <CheckIcon />
-                ) : (
-                  2
-                )
-              }
-              titleId="image-selection-step-title"
-              aria-label="Image selection step"
-            >
-              Image
-            </ProgressStep>
-            <ProgressStep
-              variant={getStepVariant(WorkspaceCreationSteps.PodConfigSelection)}
-              isCurrent
-              id="pod-config-selection-step"
-              icon={
-                getStepVariant(WorkspaceCreationSteps.PodConfigSelection) === 'success' ? (
-                  <CheckIcon />
-                ) : (
-                  3
-                )
-              }
-              titleId="pod-config-selection-step-title"
-              aria-label="Pod config selection step"
-            >
-              Pod Config
-            </ProgressStep>
-            <ProgressStep
-              variant={getStepVariant(WorkspaceCreationSteps.Properties)}
-              id="properties-step"
-              icon={
-                getStepVariant(WorkspaceCreationSteps.Properties) === 'success' ? <CheckIcon /> : 4
-              }
-              titleId="properties-step-title"
-              aria-label="Properties step"
-            >
-              Properties
-            </ProgressStep>
-          </ProgressStepper>
+          <Stack hasGutter>
+            <StackItem>
+              <Flex>
+                <Content>
+                  <h1>Create workspace</h1>
+                </Content>
+              </Flex>
+            </StackItem>
+            <StackItem>
+              <ProgressStepper aria-label="Workspace creation stepper">
+                <ProgressStep
+                  variant={getStepVariant(WorkspaceCreationSteps.KindSelection)}
+                  id="kind-selection-step"
+                  icon={
+                    getStepVariant(WorkspaceCreationSteps.KindSelection) === 'success' ? (
+                      <CheckIcon />
+                    ) : (
+                      1
+                    )
+                  }
+                  titleId="kind-selection-step-title"
+                  aria-label="Kind selection step"
+                >
+                  Workspace Kind
+                </ProgressStep>
+                <ProgressStep
+                  variant={getStepVariant(WorkspaceCreationSteps.ImageSelection)}
+                  isCurrent
+                  id="image-selection-step"
+                  icon={
+                    getStepVariant(WorkspaceCreationSteps.ImageSelection) === 'success' ? (
+                      <CheckIcon />
+                    ) : (
+                      2
+                    )
+                  }
+                  titleId="image-selection-step-title"
+                  aria-label="Image selection step"
+                >
+                  Image
+                </ProgressStep>
+                <ProgressStep
+                  variant={getStepVariant(WorkspaceCreationSteps.PodConfigSelection)}
+                  isCurrent
+                  id="pod-config-selection-step"
+                  icon={
+                    getStepVariant(WorkspaceCreationSteps.PodConfigSelection) === 'success' ? (
+                      <CheckIcon />
+                    ) : (
+                      3
+                    )
+                  }
+                  titleId="pod-config-selection-step-title"
+                  aria-label="Pod config selection step"
+                >
+                  Pod Config
+                </ProgressStep>
+                <ProgressStep
+                  variant={getStepVariant(WorkspaceCreationSteps.Properties)}
+                  id="properties-step"
+                  icon={
+                    getStepVariant(WorkspaceCreationSteps.Properties) === 'success' ? (
+                      <CheckIcon />
+                    ) : (
+                      4
+                    )
+                  }
+                  titleId="properties-step-title"
+                  aria-label="Properties step"
+                >
+                  Properties
+                </ProgressStep>
+              </ProgressStepper>
+            </StackItem>
+          </Stack>
         </PageSection>
       </PageGroup>
       <PageSection isFilled>


### PR DESCRIPTION

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Closes #242 

Applied Patternfly `Stack` component to ensure correct padding and spacing between the "Create workspace" title and the Patternfly progress stepper component. 

Before:
<img width="1512" alt="Screenshot 2025-04-25 at 10 31 39 AM" src="https://github.com/user-attachments/assets/a6f575d2-e3be-4d62-aa8a-9c3567045e07" />

After:
<img width="1510" alt="Screenshot 2025-04-25 at 11 19 32 AM" src="https://github.com/user-attachments/assets/ea9574e2-03a5-442c-8d1a-baf4f3f03cfc" />

