### PR TITLE
feat(ws): workspaces connect button sizing

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
@@ -50,7 +50,6 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
           ref={toggleRef}
           onClick={onToggleClick}
           isExpanded={open}
-          isFullWidth
           isDisabled={workspace.status.state !== WorkspaceState.Running}
           splitButtonItems={[
             <MenuToggleAction


### PR DESCRIPTION
 closes: #248 

Before: 
![Screenshot 2025-05-07 at 1 39 38 PM](https://github.com/user-attachments/assets/72fd3452-ab19-418e-a7fb-cae59ff7979b)

After:
![Screenshot 2025-05-07 at 1 40 14 PM](https://github.com/user-attachments/assets/950c7a92-bd02-4e52-9abc-fa1952f20155)
