### PR TITLE
fix(ws): filter chip label spacings

### DIFF
--- a/workspaces/frontend/src/shared/style/MUI-theme.scss
+++ b/workspaces/frontend/src/shared/style/MUI-theme.scss
@@ -742,7 +742,6 @@
 .mui-theme .pf-v6-c-label.pf-m-outline {
   --pf-v6-c-label--BorderColor: none;
   --pf-v6-c-label--BackgroundColor: var(--mui-palette-grey-200);
-  padding: 4px;
 }
 
 .mui-theme .pf-v6-c-masthead {
@@ -758,8 +757,6 @@
 
 .mui-theme .pf-v6-c-button.pf-m-plain {
   --pf-v6-c-button--BorderRadius: 50%;
-  --pf-v6-c-button--PaddingInlineStart: none;
-  --pf-v6-c-button--PaddingInlineEnd: none;
 }
 
 .mui-theme .pf-v6-c-page__main-container {


### PR DESCRIPTION
 closes: #260 

Before:
<img width="120" alt="Screenshot 2025-05-12 at 11 52 34 AM" src="https://github.com/user-attachments/assets/7c48083e-9c2b-4d2d-a664-0d8ed8ef633d" />

After: 
<img width="146" alt="Screenshot 2025-05-12 at 11 49 50 AM" src="https://github.com/user-attachments/assets/f2ab167c-a673-46b8-8c67-167881b7bff0" />
