### PR TITLE
fix(ws): add secrets field to backend API schema

### DIFF
--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -67,14 +67,21 @@ type PodMetadata struct {
 }
 
 type PodVolumes struct {
-	Home *PodVolumeInfo  `json:"home,omitempty"`
-	Data []PodVolumeInfo `json:"data"`
+	Home    *PodVolumeInfo  `json:"home,omitempty"`
+	Data    []PodVolumeInfo `json:"data"`
+	Secrets []PodSecretInfo `json:"secrets,omitempty"`
 }
 
 type PodVolumeInfo struct {
 	PVCName   string `json:"pvcName"`
 	MountPath string `json:"mountPath"`
 	ReadOnly  bool   `json:"readOnly"`
+}
+
+type PodSecretInfo struct {
+	SecretName  string `json:"secretName"`
+	MountPath   string `json:"mountPath"`
+	DefaultMode int32  `json:"defaultMode,omitempty"`
 }
 
 type PodTemplateOptions struct {

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -137,6 +137,17 @@ func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, workspaceCrea
 		}
 	}
 
+	// get secrets from workspace model
+	// TODO: uncomment this once #240 is merged
+	// secretMounts := make([]kubefloworgv1beta1.PodSecretMount, len(workspaceCreate.PodTemplate.Volumes.Secrets))
+	// for i, secret := range workspaceCreate.PodTemplate.Volumes.Secrets {
+	// 	secretMounts[i] = kubefloworgv1beta1.PodSecretMount{
+	// 		SecretName:  secret.SecretName,
+	// 		MountPath:   secret.MountPath,
+	// 		DefaultMode: secret.DefaultMode,
+	// 	}
+	// }
+
 	// define workspace object from model
 	workspaceName := workspaceCreate.Name
 	workspaceKindName := workspaceCreate.Kind
@@ -157,6 +168,7 @@ func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, workspaceCrea
 				Volumes: kubefloworgv1beta1.WorkspacePodVolumes{
 					Home: workspaceCreate.PodTemplate.Volumes.Home,
 					Data: dataVolumeMounts,
+					// Secrets: secretMounts,
 				},
 				Options: kubefloworgv1beta1.WorkspacePodOptions{
 					ImageConfig: workspaceCreate.PodTemplate.Options.ImageConfig,

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -1072,6 +1072,34 @@ const docTemplate = `{
                 }
             }
         },
+        "workspaces.PodSecretInfo": {
+            "type": "object",
+            "properties": {
+                "defaultMode": {
+                    "type": "integer"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "secretName": {
+                    "type": "string"
+                }
+            }
+        },
+        "workspaces.PodSecretMount": {
+            "type": "object",
+            "properties": {
+                "defaultMode": {
+                    "type": "integer"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "secretName": {
+                    "type": "string"
+                }
+            }
+        },
         "workspaces.PodTemplate": {
             "type": "object",
             "properties": {
@@ -1161,6 +1189,12 @@ const docTemplate = `{
                 },
                 "home": {
                     "$ref": "#/definitions/workspaces.PodVolumeInfo"
+                },
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspaces.PodSecretInfo"
+                    }
                 }
             }
         },
@@ -1175,6 +1209,12 @@ const docTemplate = `{
                 },
                 "home": {
                     "type": "string"
+                },
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspaces.PodSecretMount"
+                    }
                 }
             }
         },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -1070,6 +1070,34 @@
                 }
             }
         },
+        "workspaces.PodSecretInfo": {
+            "type": "object",
+            "properties": {
+                "defaultMode": {
+                    "type": "integer"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "secretName": {
+                    "type": "string"
+                }
+            }
+        },
+        "workspaces.PodSecretMount": {
+            "type": "object",
+            "properties": {
+                "defaultMode": {
+                    "type": "integer"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "secretName": {
+                    "type": "string"
+                }
+            }
+        },
         "workspaces.PodTemplate": {
             "type": "object",
             "properties": {
@@ -1159,6 +1187,12 @@
                 },
                 "home": {
                     "$ref": "#/definitions/workspaces.PodVolumeInfo"
+                },
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspaces.PodSecretInfo"
+                    }
                 }
             }
         },
@@ -1173,6 +1207,12 @@
                 },
                 "home": {
                     "type": "string"
+                },
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspaces.PodSecretMount"
+                    }
                 }
             }
         },

--- a/workspaces/backend/openapi/swagger.yaml
+++ b/workspaces/backend/openapi/swagger.yaml
@@ -356,6 +356,24 @@ definitions:
           type: string
         type: object
     type: object
+  workspaces.PodSecretInfo:
+    properties:
+      defaultMode:
+        type: integer
+      mountPath:
+        type: string
+      secretName:
+        type: string
+    type: object
+  workspaces.PodSecretMount:
+    properties:
+      defaultMode:
+        type: integer
+      mountPath:
+        type: string
+      secretName:
+        type: string
+    type: object
   workspaces.PodTemplate:
     properties:
       options:
@@ -414,6 +432,10 @@ definitions:
         type: array
       home:
         $ref: '#/definitions/workspaces.PodVolumeInfo'
+      secrets:
+        items:
+          $ref: '#/definitions/workspaces.PodSecretInfo'
+        type: array
     type: object
   workspaces.PodVolumesMutate:
     properties:
@@ -423,6 +445,10 @@ definitions:
         type: array
       home:
         type: string
+      secrets:
+        items:
+          $ref: '#/definitions/workspaces.PodSecretMount'
+        type: array
     type: object
   workspaces.ProbeResult:
     enum:


### PR DESCRIPTION
related: #239

This commit brings partial support for secrets to the backend API.  It enables the `frontend` component to successfully create a Workspace through the "wizard flow".

**HOWEVER**, it is important to note this secrets attribute is not supported within the `controller` component yet - as #240 is not yet merged. To unblock the `frontend` - the logic contained in this commit simply adds the necessary scaffolding to accept the `secrets` attribute defined within `volumes`.  Once umarshalled, the backend essentially ignores this data.  Code to fully enable the end to end flow is included in this PR - but simply commented out with `TODO:` comments denoting what can be uncommented once #240 is merged into `notebooks-v2`.  A test is also presently disabled with `XIt` - and can also be enabled when required code present.

Changes were initially coded against the branch provided on #240 to verify full end-to-end behavior.  Once confirmed, commit was rebased onto `notebooks-v2`, relevant code commented out as described above, and behavior retested to ensure desired outcome.

In summary, with these changes:
- `backend` API accepts `volumes.secrets` in the _Create_ payload
- secrets data is **NOT USED** when programmatically constructing the Workspace CR
- Resultant workspace has no `secrets` data - irrespective of it if was provided in the payload or not.
