### PR TITLE
feat(ws): Persist last used namespace across refreshes and tabs

### DIFF
--- a/workspaces/frontend/src/app/App.tsx
+++ b/workspaces/frontend/src/app/App.tsx
@@ -23,6 +23,7 @@ import AppRoutes from './AppRoutes';
 import NavSidebar from './NavSidebar';
 import { NotebookContextProvider } from './context/NotebookContext';
 import { isMUITheme, Theme } from './const';
+import { BrowserStorageContextProvider } from './context/BrowserStorageContext';
 
 const App: React.FC = () => {
   React.useEffect(() => {
@@ -66,17 +67,19 @@ const App: React.FC = () => {
   return (
     <ErrorBoundary>
       <NotebookContextProvider>
-        <NamespaceContextProvider>
-          <Page
-            mainContainerId="primary-app-container"
-            masthead={masthead}
-            isContentFilled
-            isManagedSidebar
-            sidebar={<NavSidebar />}
-          >
-            <AppRoutes />
-          </Page>
-        </NamespaceContextProvider>
+        <BrowserStorageContextProvider>
+          <NamespaceContextProvider>
+            <Page
+              mainContainerId="primary-app-container"
+              masthead={masthead}
+              isContentFilled
+              isManagedSidebar
+              sidebar={<NavSidebar />}
+            >
+              <AppRoutes />
+            </Page>
+          </NamespaceContextProvider>
+        </BrowserStorageContextProvider>
       </NotebookContextProvider>
     </ErrorBoundary>
   );

--- a/workspaces/frontend/src/app/context/BrowserStorageContext.tsx
+++ b/workspaces/frontend/src/app/context/BrowserStorageContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useCallback, useContext, useEffect } from 'react';
+
+export interface BrowserStorageContextType {
+  getValue: (key: string) => unknown;
+  setValue: (key: string, value: string) => void;
+}
+
+export interface BrowserStorageContextProviderProps {
+  children: React.ReactNode;
+}
+
+const BrowserStorageContext = createContext<BrowserStorageContextType>({
+  getValue: () => null,
+  setValue: () => undefined,
+});
+
+export const BrowserStorageContextProvider: React.FC<BrowserStorageContextProviderProps> = ({
+  children,
+}) => {
+  const [values, setValues] = React.useState<{ [key: string]: unknown }>({});
+  const valuesRef = React.useRef(values);
+  useEffect(() => {
+    valuesRef.current = values;
+  }, [values]);
+
+  const storageEventCb = useCallback(() => {
+    const keys = Object.keys(values);
+    setValues(Object.fromEntries(keys.map((k) => [k, localStorage.getItem(k)])));
+  }, [values, setValues]);
+
+  useEffect(() => {
+    window.addEventListener('storage', storageEventCb);
+    return () => {
+      window.removeEventListener('storage', storageEventCb);
+    };
+  }, [storageEventCb]);
+
+  const getValue = useCallback<BrowserStorageContextType['getValue']>(
+    (key: string) => localStorage.getItem(key),
+    [],
+  );
+
+  const setValue = useCallback<BrowserStorageContextType['setValue']>(
+    (key: string, value: string) => {
+      localStorage.setItem(key, value);
+      setValues((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const contextValue = React.useMemo(() => ({ getValue, setValue }), [getValue, setValue, values]);
+
+  return (
+    <BrowserStorageContext.Provider value={contextValue}>{children}</BrowserStorageContext.Provider>
+  );
+};
+
+export const useStorage = <T,>(
+  storageKey: string,
+  defaultValue: T,
+): [T, (key: string, value: string) => void] => {
+  const context = useContext(BrowserStorageContext);
+  const { getValue, setValue } = context;
+  const value = (getValue(storageKey) as T) ?? defaultValue;
+  return [value, setValue];
+};

--- a/workspaces/frontend/src/shared/components/NamespaceSelector.tsx
+++ b/workspaces/frontend/src/shared/components/NamespaceSelector.tsx
@@ -18,7 +18,8 @@ import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { useNamespaceContext } from '~/app/context/NamespaceContextProvider';
 
 const NamespaceSelector: FC = () => {
-  const { namespaces, selectedNamespace, setSelectedNamespace } = useNamespaceContext();
+  const { namespaces, selectedNamespace, setSelectedNamespace, updateLastUsedNamespace } =
+    useNamespaceContext();
   const [isNamespaceDropdownOpen, setIsNamespaceDropdownOpen] = useState<boolean>(false);
   const [searchInputValue, setSearchInputValue] = useState<string>('');
   const [filteredNamespaces, setFilteredNamespaces] = useState<string[]>(namespaces);
@@ -54,6 +55,7 @@ const NamespaceSelector: FC = () => {
 
   const onSelect: DropdownProps['onSelect'] = (_event, value) => {
     setSelectedNamespace(value as string);
+    updateLastUsedNamespace(value as string);
     setIsNamespaceDropdownOpen(false);
   };
 


### PR DESCRIPTION
 closes: #[318](https://github.com/kubeflow/notebooks/issues/318)

Previous behaviors: Always use the first namespace from fetch as selected namespace
Features: 

1. Persist selected namespace across refreshes. If no such namespace exists, select the one at index 0 of the `namespaces` array
2. If namespace is changed on one tab, that change will reflect on other tabs. That will ensure consistency and won't confuse users on what the "last" selected namespace was.