### PR TITLE
feat(ws): prepare frontend calls to pause and start endpoints

### DIFF
--- a/workspaces/frontend/src/app/context/useNotebookAPIState.tsx
+++ b/workspaces/frontend/src/app/context/useNotebookAPIState.tsx
@@ -14,6 +14,8 @@ import {
   listWorkspaces,
   patchWorkspace,
   patchWorkspaceKind,
+  pauseWorkspace,
+  startWorkspace,
   updateWorkspace,
   updateWorkspaceKind,
 } from '~/shared/api/notebookService';
@@ -33,6 +35,8 @@ import {
   mockListWorkspaces,
   mockPatchWorkspace,
   mockPatchWorkspaceKind,
+  mockPauseWorkspace,
+  mockStartWorkspace,
   mockUpdateWorkspace,
   mockUpdateWorkspaceKind,
 } from '~/shared/mock/mockNotebookService';
@@ -45,7 +49,7 @@ const useNotebookAPIState = (
   hostPath: string | null,
 ): [apiState: NotebookAPIState, refreshAPIState: () => void] => {
   const createApi = React.useCallback(
-    (path: string) => ({
+    (path: string): NotebookAPIs => ({
       // Health
       getHealthCheck: getHealthCheck(path),
       // Namespace
@@ -58,6 +62,8 @@ const useNotebookAPIState = (
       updateWorkspace: updateWorkspace(path),
       patchWorkspace: patchWorkspace(path),
       deleteWorkspace: deleteWorkspace(path),
+      pauseWorkspace: pauseWorkspace(path),
+      startWorkspace: startWorkspace(path),
       // WorkspaceKind
       listWorkspaceKinds: listWorkspaceKinds(path),
       createWorkspaceKind: createWorkspaceKind(path),
@@ -70,7 +76,7 @@ const useNotebookAPIState = (
   );
 
   const createMockApi = React.useCallback(
-    (path: string) => ({
+    (path: string): NotebookAPIs => ({
       // Health
       getHealthCheck: mockGetHealthCheck(path),
       // Namespace
@@ -83,6 +89,8 @@ const useNotebookAPIState = (
       updateWorkspace: mockUpdateWorkspace(path),
       patchWorkspace: mockPatchWorkspace(path),
       deleteWorkspace: mockDeleteWorkspace(path),
+      pauseWorkspace: mockPauseWorkspace(path),
+      startWorkspace: mockStartWorkspace(path),
       // WorkspaceKind
       listWorkspaceKinds: mockListWorkspaceKinds(path),
       createWorkspaceKind: mockCreateWorkspaceKind(path),

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -44,6 +44,7 @@ import {
 } from '~/app/actions/WorkspaceKindsActions';
 import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import useWorkspaces from '~/app/hooks/useWorkspaces';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { WorkspaceConnectAction } from '~/app/pages/Workspaces/WorkspaceConnectAction';
 import { WorkspaceStartActionModal } from '~/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal';
 import { WorkspaceRestartActionModal } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRestartActionModal';
@@ -96,8 +97,10 @@ export const Workspaces: React.FunctionComponent = () => {
     lastActivity: 'Last Activity',
   };
 
+  const { api } = useNotebookAPI();
   const { selectedNamespace } = useNamespaceContext();
-  const [initialWorkspaces, initialWorkspacesLoaded] = useWorkspaces(selectedNamespace);
+  const [initialWorkspaces, initialWorkspacesLoaded, , initialWorkspacesRefresh] =
+    useWorkspaces(selectedNamespace);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [expandedWorkspacesNames, setExpandedWorkspacesNames] = React.useState<string[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = React.useState<Workspace | null>(null);
@@ -329,6 +332,19 @@ export const Workspaces: React.FunctionComponent = () => {
             onClose={onCloseActionAlertDialog}
             isOpen={isActionAlertModalOpen}
             workspace={selectedWorkspace}
+            onActionDone={() => {
+              initialWorkspacesRefresh();
+            }}
+            onStart={async () => {
+              if (!selectedWorkspace) {
+                return;
+              }
+
+              await api.startWorkspace({}, selectedNamespace, selectedWorkspace.name);
+            }}
+            onUpdateAndStart={async () => {
+              // TODO: implement update and stop
+            }}
           />
         );
       case ActionType.Restart:
@@ -345,6 +361,18 @@ export const Workspaces: React.FunctionComponent = () => {
             onClose={onCloseActionAlertDialog}
             isOpen={isActionAlertModalOpen}
             workspace={selectedWorkspace}
+            onActionDone={() => {
+              initialWorkspacesRefresh();
+            }}
+            onStop={async () => {
+              if (!selectedWorkspace) {
+                return;
+              }
+              await api.pauseWorkspace({}, selectedNamespace, selectedWorkspace.name);
+            }}
+            onUpdateAndStop={async () => {
+              // TODO: implement update and stop
+            }}
           />
         );
     }

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/ActionButton.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/ActionButton.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+
+type ActionButtonProps = {
+  action: string;
+  titleOnLoading: string;
+  onClick: () => Promise<void>;
+} & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
+
+export const ActionButton: React.FC<ActionButtonProps> = ({
+  action,
+  titleOnLoading,
+  onClick,
+  ...props
+}) => {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleClick = React.useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await onClick();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onClick]);
+
+  return (
+    <Button
+      {...props}
+      spinnerAriaLabel={`Executing action '${action}'`}
+      spinnerAriaValueText={action}
+      onClick={handleClick}
+      isLoading={isLoading}
+      isDisabled={isLoading || props.isDisabled}
+    >
+      {isLoading ? titleOnLoading : props.children}
+    </Button>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -9,25 +9,73 @@ import {
 } from '@patternfly/react-core';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
+import { ActionButton } from '~/app/pages/Workspaces/workspaceActions/ActionButton';
 
 interface StartActionAlertProps {
   onClose: () => void;
   isOpen: boolean;
   workspace: Workspace | null;
+  onStart: () => Promise<void>;
+  onUpdateAndStart: () => Promise<void>;
+  onActionDone: () => void;
 }
+
+type StartAction = 'start' | 'updateAndStart';
 
 export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
   onClose,
   isOpen,
   workspace,
+  onStart,
+  onUpdateAndStart,
+  onActionDone,
 }) => {
-  const handleClick = (isUpdate = false) => {
-    if (isUpdate) {
-      console.log(`Update ${workspace?.name}`);
+  const [actionOnGoing, setActionOnGoing] = React.useState<StartAction | null>(null);
+
+  const executeAction = React.useCallback(
+    async (args: { action: StartAction; callback: () => Promise<void> }) => {
+      setActionOnGoing(args.action);
+      try {
+        return await args.callback();
+      } finally {
+        setActionOnGoing(null);
+      }
+    },
+    [],
+  );
+
+  const handleStart = React.useCallback(async () => {
+    try {
+      await executeAction({ action: 'start', callback: onStart });
+      // TODO: alert user about success
+      console.info('Workspace started successfully');
+      onActionDone();
+      onClose();
+    } catch (error) {
+      // TODO: alert user about error
+      console.error('Error starting workspace:', error);
     }
-    console.log(`Start ${workspace?.name}`);
-    onClose();
-  };
+  }, [executeAction, onActionDone, onClose, onStart]);
+
+  // TODO: combine handleStart and handleUpdateAndStart if they end up being similar
+  const handleUpdateAndStart = React.useCallback(async () => {
+    try {
+      await executeAction({ action: 'updateAndStart', callback: onUpdateAndStart });
+      // TODO: alert user about success
+      console.info('Workspace updated and started successfully');
+      onActionDone();
+      onClose();
+    } catch (error) {
+      // TODO: alert user about error
+      console.error('Error updating and stopping workspace:', error);
+    }
+  }, [executeAction, onActionDone, onClose, onUpdateAndStart]);
+
+  const shouldShowActionButton = React.useCallback(
+    (action: StartAction) => !actionOnGoing || actionOnGoing === action,
+    [actionOnGoing],
+  );
+
   return (
     <Modal
       variant="medium"
@@ -44,13 +92,30 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
         {workspace && <WorkspaceRedirectInformationView kind={workspace.workspaceKind.name} />}
       </ModalBody>
       <ModalFooter>
-        <Button onClick={() => handleClick(true)}>Update and Start</Button>
-        <Button onClick={() => handleClick(false)} variant="secondary">
-          Start
-        </Button>
-        <Button variant="link" onClick={onClose}>
-          Cancel
-        </Button>
+        {shouldShowActionButton('updateAndStart') && (
+          <ActionButton
+            action="Update and Start"
+            titleOnLoading="Starting ..."
+            onClick={() => handleUpdateAndStart()}
+          >
+            Update and Start
+          </ActionButton>
+        )}
+        {shouldShowActionButton('start') && (
+          <ActionButton
+            action="Start"
+            titleOnLoading="Starting ..."
+            onClick={() => handleStart()}
+            variant="secondary"
+          >
+            Start
+          </ActionButton>
+        )}
+        {!actionOnGoing && (
+          <Button variant="link" onClick={onClose}>
+            Cancel
+          </Button>
+        )}
       </ModalFooter>
     </Modal>
   );

--- a/workspaces/frontend/src/shared/api/backendApiTypes.ts
+++ b/workspaces/frontend/src/shared/api/backendApiTypes.ts
@@ -268,3 +268,8 @@ export interface WorkspaceUpdate {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface WorkspacePatch {}
+
+// TODO: Update these types when applicable; meanwhile, they are empty objects
+type EmptyObject = Record<string, never>;
+export type PauseWorkspaceResponse = EmptyObject;
+export type StartWorkspaceResponse = EmptyObject;

--- a/workspaces/frontend/src/shared/api/callTypes.ts
+++ b/workspaces/frontend/src/shared/api/callTypes.ts
@@ -12,6 +12,8 @@ import {
   ListWorkspaces,
   PatchWorkspace,
   PatchWorkspaceKind,
+  PauseWorkspace,
+  StartWorkspace,
   UpdateWorkspace,
   UpdateWorkspaceKind,
 } from '~/shared/api/notebookApi';
@@ -35,6 +37,8 @@ export type GetWorkspaceAPI = KubeflowAPICall<GetWorkspace>;
 export type UpdateWorkspaceAPI = KubeflowAPICall<UpdateWorkspace>;
 export type PatchWorkspaceAPI = KubeflowAPICall<PatchWorkspace>;
 export type DeleteWorkspaceAPI = KubeflowAPICall<DeleteWorkspace>;
+export type PauseWorkspaceAPI = KubeflowAPICall<PauseWorkspace>;
+export type StartWorkspaceAPI = KubeflowAPICall<StartWorkspace>;
 
 // WorkspaceKind
 export type ListWorkspaceKindsAPI = KubeflowAPICall<ListWorkspaceKinds>;

--- a/workspaces/frontend/src/shared/api/notebookApi.ts
+++ b/workspaces/frontend/src/shared/api/notebookApi.ts
@@ -1,6 +1,8 @@
 import {
   HealthCheckResponse,
   Namespace,
+  PauseWorkspaceResponse,
+  StartWorkspaceResponse,
   Workspace,
   WorkspaceCreate,
   WorkspaceKind,
@@ -48,6 +50,16 @@ export type DeleteWorkspace = (
   namespace: string,
   workspace: string,
 ) => Promise<void>;
+export type PauseWorkspace = (
+  opts: APIOptions,
+  namespace: string,
+  workspace: string,
+) => Promise<PauseWorkspaceResponse>;
+export type StartWorkspace = (
+  opts: APIOptions,
+  namespace: string,
+  workspace: string,
+) => Promise<StartWorkspaceResponse>;
 
 // WorkspaceKind
 export type ListWorkspaceKinds = (opts: APIOptions) => Promise<WorkspaceKind[]>;
@@ -81,6 +93,8 @@ export type NotebookAPIs = {
   updateWorkspace: UpdateWorkspace;
   patchWorkspace: PatchWorkspace;
   deleteWorkspace: DeleteWorkspace;
+  pauseWorkspace: PauseWorkspace;
+  startWorkspace: StartWorkspace;
   // WorkspaceKind
   listWorkspaceKinds: ListWorkspaceKinds;
   getWorkspaceKind: GetWorkspaceKind;

--- a/workspaces/frontend/src/shared/api/notebookService.ts
+++ b/workspaces/frontend/src/shared/api/notebookService.ts
@@ -7,12 +7,7 @@ import {
   restUPDATE,
 } from '~/shared/api/apiUtils';
 import { handleRestFailures } from '~/shared/api/errorUtils';
-import {
-  HealthCheckResponse,
-  Namespace,
-  Workspace,
-  WorkspaceKind,
-} from '~/shared/api/backendApiTypes';
+import { Namespace, Workspace, WorkspaceKind } from '~/shared/api/backendApiTypes';
 import {
   CreateWorkspaceAPI,
   CreateWorkspaceKindAPI,
@@ -27,14 +22,14 @@ import {
   ListWorkspacesAPI,
   PatchWorkspaceAPI,
   PatchWorkspaceKindAPI,
+  PauseWorkspaceAPI,
+  StartWorkspaceAPI,
   UpdateWorkspaceAPI,
   UpdateWorkspaceKindAPI,
 } from './callTypes';
 
 export const getHealthCheck: GetHealthCheckAPI = (hostPath) => (opts) =>
-  handleRestFailures(restGET(hostPath, `/healthcheck`, {}, opts)).then((response) =>
-    extractNotebookResponse<HealthCheckResponse>(response),
-  );
+  handleRestFailures(restGET(hostPath, `/healthcheck`, {}, opts));
 
 export const listNamespaces: ListNamespacesAPI = (hostPath) => (opts) =>
   handleRestFailures(restGET(hostPath, `/namespaces`, {}, opts)).then((response) =>
@@ -76,6 +71,16 @@ export const deleteWorkspace: DeleteWorkspaceAPI = (hostPath) => (opts, namespac
   handleRestFailures(
     restDELETE(hostPath, `/workspaces/${namespace}/${workspace}`, {}, {}, opts),
   ).then((response) => extractNotebookResponse<void>(response));
+
+export const pauseWorkspace: PauseWorkspaceAPI = (hostPath) => (opts, namespace, workspace) =>
+  handleRestFailures(
+    restCREATE(hostPath, `/workspaces/${namespace}/${workspace}/actions/pause`, {}, opts),
+  );
+
+export const startWorkspace: StartWorkspaceAPI = (hostPath) => (opts, namespace, workspace) =>
+  handleRestFailures(
+    restCREATE(hostPath, `/workspaces/${namespace}/${workspace}/actions/start`, {}, opts),
+  );
 
 export const listWorkspaceKinds: ListWorkspaceKindsAPI = (hostPath) => (opts) =>
   handleRestFailures(restGET(hostPath, `/workspacekinds`, {}, opts)).then((response) =>

--- a/workspaces/frontend/src/shared/mock/mockNotebookService.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookService.ts
@@ -12,6 +12,8 @@ import {
   ListWorkspacesAPI,
   PatchWorkspaceAPI,
   PatchWorkspaceKindAPI,
+  PauseWorkspaceAPI,
+  StartWorkspaceAPI,
   UpdateWorkspaceAPI,
   UpdateWorkspaceKindAPI,
 } from '~/shared/api/callTypes';
@@ -23,6 +25,11 @@ import {
   mockWorkspaceKind1,
   mockWorkspaceKinds,
 } from '~/shared/mock/mockNotebookServiceData';
+
+const delay = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 export const mockGetHealthCheck: GetHealthCheckAPI = () => async () => mockedHealthCheckResponse;
 
@@ -43,7 +50,17 @@ export const mockUpdateWorkspace: UpdateWorkspaceAPI = () => async () => mockWor
 export const mockPatchWorkspace: PatchWorkspaceAPI = () => async () => mockWorkspace1;
 
 export const mockDeleteWorkspace: DeleteWorkspaceAPI = () => async () => {
-  /* no-op */
+  await delay(1500);
+};
+
+export const mockPauseWorkspace: PauseWorkspaceAPI = () => async () => {
+  await delay(1500);
+  return {};
+};
+
+export const mockStartWorkspace: StartWorkspaceAPI = () => async () => {
+  await delay(1500);
+  return {};
 };
 
 export const mockListWorkspaceKinds: ListWorkspaceKindsAPI = () => async () => mockWorkspaceKinds;
@@ -58,5 +75,5 @@ export const mockUpdateWorkspaceKind: UpdateWorkspaceKindAPI = () => async () =>
 export const mockPatchWorkspaceKind: PatchWorkspaceKindAPI = () => async () => mockWorkspaceKind1;
 
 export const mockDeleteWorkspaceKind: DeleteWorkspaceKindAPI = () => async () => {
-  /* no-op */
+  await delay(1500);
 };


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Closes https://github.com/kubeflow/notebooks/issues/339

Start and Stop buttons are now calling their respective backend endpoints.