### PR TITLE
feat(ws): Notebooks V2 GET /api/v1/workspacekinds Backend API support…

### DIFF
--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -90,7 +90,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns a list of all available workspace kinds. Workspace kinds define the different types of workspaces that can be created in the system.",
+                "description": "Returns a list of all available workspace kinds, optionally filtered. Workspace kinds define the different types of workspaces that can be created in the system.",
                 "consumes": [
                     "application/json"
                 ],
@@ -101,6 +101,14 @@ const docTemplate = `{
                     "workspacekinds"
                 ],
                 "summary": "List workspace kinds",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filters the workspace kinds based on specified criteria.  This parameter is a comma-separated list of filters, using the format 'field::value'.  For example: 'name::sama,status::active'.  Allowed fields are: name, description, status.",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful operation. Returns a list of all available workspace kinds.",

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -88,7 +88,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns a list of all available workspace kinds. Workspace kinds define the different types of workspaces that can be created in the system.",
+                "description": "Returns a list of all available workspace kinds, optionally filtered. Workspace kinds define the different types of workspaces that can be created in the system.",
                 "consumes": [
                     "application/json"
                 ],
@@ -99,6 +99,14 @@
                     "workspacekinds"
                 ],
                 "summary": "List workspace kinds",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filters the workspace kinds based on specified criteria.  This parameter is a comma-separated list of filters, using the format 'field::value'.  For example: 'name::sama,status::active'.  Allowed fields are: name, description, status.",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful operation. Returns a list of all available workspace kinds.",

--- a/workspaces/backend/openapi/swagger.yaml
+++ b/workspaces/backend/openapi/swagger.yaml
@@ -618,8 +618,17 @@ paths:
     get:
       consumes:
       - application/json
-      description: Returns a list of all available workspace kinds. Workspace kinds
-        define the different types of workspaces that can be created in the system.
+      description: Returns a list of all available workspace kinds, optionally filtered.
+        Workspace kinds define the different types of workspaces that can be created
+        in the system.
+      parameters:
+      - description: 'Filters the workspace kinds based on specified criteria.  This
+          parameter is a comma-separated list of filters, using the format ''field::value''.  For
+          example: ''name::sama,status::active''.  Allowed fields are: name, description,
+          status.'
+        in: query
+        name: filter
+        type: string
       produces:
       - application/json
       responses:


### PR DESCRIPTION
fix for #335 
adding filter option for the returned workspacekinds
an example
 curl -i http://localhost:4000/api/v1/workspacekinds?filter=name::abc,status::active
 will return workinds that have name prefix abc and status active (deprecated false)
 