### PR TITLE
feat(ws): Notebooks V2 GET /api/v1/workspacekinds Backend API support sorting #336

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -37,6 +37,7 @@ const (
 
 	NamespacePathParam    = "namespace"
 	ResourceNamePathParam = "name"
+	StatusPathParam       = "status"
 
 	// healthcheck
 	HealthCheckPath = PathPrefix + "/healthcheck"

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -193,6 +193,80 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			err = json.Unmarshal(dataJSON, &dataObject)
 			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal JSON to WorkspaceKind")
 		})
+
+		It("should retrieve WorkspaceKinds sorted by name in descending order", func() {
+
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodGet, AllWorkspaceKindsPath+"?orderBy=name&sortOrder=desc", http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetWorkspaceKindsHandler")
+			ps := httprouter.Params{}
+			rr := httptest.NewRecorder()
+			a.GetWorkspaceKindsHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response JSON to WorkspaceKindListEnvelope")
+			var response WorkspaceKindListEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying that WorkspaceKinds are sorted by name descending")
+			namesReturned := []string{}
+			for _, wk := range response.Data {
+				namesReturned = append(namesReturned, wk.Name)
+			}
+			Expect(namesReturned).To(Equal([]string{"workspacekind-2-wsk-exist-test", "workspacekind-1-wsk-exist-test"}))
+			fmt.Println(namesReturned)
+		})
+
+		It("should retrieve WorkspaceKinds sorted by name in ascending order", func() {
+
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodGet, AllWorkspaceKindsPath+"?orderBy=name&sortOrder=asc", http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetWorkspaceKindsHandler")
+			ps := httprouter.Params{}
+			rr := httptest.NewRecorder()
+			a.GetWorkspaceKindsHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response JSON to WorkspaceKindListEnvelope")
+			var response WorkspaceKindListEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying that WorkspaceKinds are sorted by name ascending")
+			namesReturned := []string{}
+			for _, wk := range response.Data {
+				namesReturned = append(namesReturned, wk.Name)
+			}
+			Expect(namesReturned).To(Equal([]string{"workspacekind-1-wsk-exist-test", "workspacekind-2-wsk-exist-test"}))
+			fmt.Println(namesReturned)
+		})
 	})
 
 	// NOTE: these tests assume a specific state of the cluster, so cannot be run in parallel with other tests.

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -101,6 +101,28 @@ const docTemplate = `{
                     "workspacekinds"
                 ],
                 "summary": "List workspace kinds",
+                "parameters": [
+                    {
+                        "enum": [
+                            "name",
+                            "status"
+                        ],
+                        "type": "string",
+                        "description": "Field to order by",
+                        "name": "orderBy",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "description": "Sort order",
+                        "name": "sortOrder",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful operation. Returns a list of all available workspace kinds.",

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -99,6 +99,28 @@
                     "workspacekinds"
                 ],
                 "summary": "List workspace kinds",
+                "parameters": [
+                    {
+                        "enum": [
+                            "name",
+                            "status"
+                        ],
+                        "type": "string",
+                        "description": "Field to order by",
+                        "name": "orderBy",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "description": "Sort order",
+                        "name": "sortOrder",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful operation. Returns a list of all available workspace kinds.",

--- a/workspaces/backend/openapi/swagger.yaml
+++ b/workspaces/backend/openapi/swagger.yaml
@@ -620,6 +620,21 @@ paths:
       - application/json
       description: Returns a list of all available workspace kinds. Workspace kinds
         define the different types of workspaces that can be created in the system.
+      parameters:
+      - description: Field to order by
+        enum:
+        - name
+        - status
+        in: query
+        name: orderBy
+        type: string
+      - description: Sort order
+        enum:
+        - asc
+        - desc
+        in: query
+        name: sortOrder
+        type: string
       produces:
       - application/json
       responses:


### PR DESCRIPTION
implementation for #336

Adds support for sorting in GET /api/v1/workspacekinds endpoint. 
for example: 
curl -i "http://localhost:4000/api/v1/workspacekinds?orderBy=status&sortOrder=asc"
curl -i "http://localhost:4000/api/v1/workspacekinds?orderBy=name&sortOrder=desc"

Changes:
- Introduced support for 'orderBy' (name or status) and  'sortOrder' (asc or desc) query parameters.
- Added unit test to verify the sorting api call.
- Auto-generated swagger documantion now include details about the sorting cal with new parameters.

 closes: #336


