### PR TITLE
fix(ws): backend dockerfile

### DIFF
--- a/workspaces/.dockerignore
+++ b/workspaces/.dockerignore
@@ -1,0 +1,7 @@
+# NOTE: This file is used when building Docker images with context `..`
+# Primarily intended for backend/Dockerfile builds
+
+# Exclude frontend code, node_modules, and unnecessary binaries
+frontend/
+controller/bin/
+backend/bin/

--- a/workspaces/backend/Dockerfile
+++ b/workspaces/backend/Dockerfile
@@ -6,17 +6,20 @@ ARG TARGETARCH
 WORKDIR /workspace
 
 # Copy the Go Modules manifests
-COPY go.mod go.sum ./
+COPY backend/go.mod backend/go.sum ./
+
+# Copy controller directory and rewrite the go.mod to update the replace directive
+COPY controller /workspace/controller
+RUN go mod edit -replace=github.com/kubeflow/notebooks/workspaces/controller=./controller
 
 # Download dependencies
 RUN go mod download
 
 # Copy the go source files
-COPY cmd/ cmd/
-COPY api/ api/
-COPY config/ config/
-COPY data/ data/
-COPY integrations/ integrations/
+COPY backend/cmd/ cmd/
+COPY backend/api/ api/
+COPY backend/internal/ internal/
+COPY backend/openapi/ openapi/
 
 # Build the Go application
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o backend ./cmd/main.go
@@ -31,7 +34,7 @@ USER 65532:65532
 EXPOSE 4000
 
 # Define environment variables
-ENV PORT 4000
-ENV ENV development
+ENV PORT=4000
+ENV ENV=development
 
 ENTRYPOINT ["/backend"]

--- a/workspaces/backend/Dockerfile
+++ b/workspaces/backend/Dockerfile
@@ -8,12 +8,12 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY backend/go.mod backend/go.sum ./
 
-# Copy controller directory and rewrite the go.mod to update the replace directive
+# Copy controller directory 
 COPY controller /workspace/controller
-RUN go mod edit -replace=github.com/kubeflow/notebooks/workspaces/controller=./controller
 
-# Download dependencies
-RUN go mod download
+# Rewrite the go.mod to update the replace directive and download dependencies
+RUN go mod edit -replace=github.com/kubeflow/notebooks/workspaces/controller=./controller && \
+    go mod download
 
 # Copy the go source files
 COPY backend/cmd/ cmd/

--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -88,7 +88,7 @@ run: fmt vet swag ## Run a backend from your host.
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/11gg
 .PHONY: docker-build
 docker-build: ## Build docker image with the backend.
 	$(CONTAINER_TOOL) build -f Dockerfile -t $(IMG) ..
@@ -108,7 +108,7 @@ PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	sed '1,// s/^FROM/FROM --platform=$${BUILDPLATFORM}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross ..

--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -91,7 +91,8 @@ run: fmt vet swag ## Run a backend from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the backend.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build -f Dockerfile -t $(IMG) ..
+
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the backend.
@@ -110,7 +111,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross ..
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -88,7 +88,7 @@ run: fmt vet swag ## Run a backend from your host.
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/11gg
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the backend.
 	$(CONTAINER_TOOL) build -f Dockerfile -t $(IMG) ..


### PR DESCRIPTION
closes: #323 

In this pr I fixed the make docker-build + make docker-buildx.


NOTE: When you run "make docker-buildx" you will get this ERROR:
"ERROR: failed to solve: failed to push nbv2-backend:latest: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
make: [Makefile:135: docker-buildx] Error 1 (ignored)",
Because we didn't specify the right registry in the Makefile.

