### PR TITLE
fix(ws): Update Progress Stepper with UX feedback

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -9,9 +9,7 @@ import {
   ProgressStep,
   ProgressStepper,
   Stack,
-  StackItem,
 } from '@patternfly/react-core';
-import { CheckIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo, useState } from 'react';
 import useGenericObjectState from '~/app/hooks/useGenericObjectState';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
@@ -31,6 +29,14 @@ enum WorkspaceFormSteps {
   PodConfigSelection,
   Properties,
 }
+
+const stepDescriptions: { [key in WorkspaceFormSteps]?: string } = {
+  [WorkspaceFormSteps.KindSelection]: 'Select a workspace kind to use for the workspace.',
+  [WorkspaceFormSteps.ImageSelection]:
+    'Select a workspace image and image version to use for the workspace.',
+  [WorkspaceFormSteps.PodConfigSelection]: 'Select a pod config to use for the workspace.',
+  [WorkspaceFormSteps.Properties]: 'Configure properties for your workspace.',
+};
 
 const WorkspaceForm: React.FC = () => {
   const navigate = useTypedNavigate();
@@ -158,75 +164,54 @@ const WorkspaceForm: React.FC = () => {
       <PageGroup isFilled={false} stickyOnBreakpoint={{ default: 'top' }}>
         <PageSection>
           <Stack hasGutter>
-            <StackItem>
-              <Flex>
+            <Flex direction={{ default: 'column' }} rowGap={{ default: 'rowGapXl' }}>
+              <FlexItem>
                 <Content>
                   <h1>{`${mode === 'create' ? 'Create' : 'Edit'} workspace`}</h1>
+                  <p>{stepDescriptions[currentStep]}</p>
                 </Content>
-              </Flex>
-            </StackItem>
-            <StackItem>
-              <ProgressStepper aria-label="Workspace form stepper">
-                <ProgressStep
-                  variant={getStepVariant(WorkspaceFormSteps.KindSelection)}
-                  id="kind-selection-step"
-                  icon={
-                    getStepVariant(WorkspaceFormSteps.KindSelection) === 'success' ? (
-                      <CheckIcon />
-                    ) : (
-                      1
-                    )
-                  }
-                  titleId="kind-selection-step-title"
-                  aria-label="Kind selection step"
-                >
-                  Workspace Kind
-                </ProgressStep>
-                <ProgressStep
-                  variant={getStepVariant(WorkspaceFormSteps.ImageSelection)}
-                  isCurrent
-                  id="image-selection-step"
-                  icon={
-                    getStepVariant(WorkspaceFormSteps.ImageSelection) === 'success' ? (
-                      <CheckIcon />
-                    ) : (
-                      2
-                    )
-                  }
-                  titleId="image-selection-step-title"
-                  aria-label="Image selection step"
-                >
-                  Image
-                </ProgressStep>
-                <ProgressStep
-                  variant={getStepVariant(WorkspaceFormSteps.PodConfigSelection)}
-                  isCurrent
-                  id="pod-config-selection-step"
-                  icon={
-                    getStepVariant(WorkspaceFormSteps.PodConfigSelection) === 'success' ? (
-                      <CheckIcon />
-                    ) : (
-                      3
-                    )
-                  }
-                  titleId="pod-config-selection-step-title"
-                  aria-label="Pod config selection step"
-                >
-                  Pod Config
-                </ProgressStep>
-                <ProgressStep
-                  variant={getStepVariant(WorkspaceFormSteps.Properties)}
-                  id="properties-step"
-                  icon={
-                    getStepVariant(WorkspaceFormSteps.Properties) === 'success' ? <CheckIcon /> : 4
-                  }
-                  titleId="properties-step-title"
-                  aria-label="Properties step"
-                >
-                  Properties
-                </ProgressStep>
-              </ProgressStepper>
-            </StackItem>
+              </FlexItem>
+              <FlexItem>
+                <ProgressStepper aria-label="Workspace form stepper">
+                  <ProgressStep
+                    variant={getStepVariant(WorkspaceFormSteps.KindSelection)}
+                    isCurrent={currentStep === WorkspaceFormSteps.KindSelection}
+                    id="kind-selection-step"
+                    titleId="kind-selection-step-title"
+                    aria-label="Kind selection step"
+                  >
+                    Workspace Kind
+                  </ProgressStep>
+                  <ProgressStep
+                    variant={getStepVariant(WorkspaceFormSteps.ImageSelection)}
+                    isCurrent={currentStep === WorkspaceFormSteps.ImageSelection}
+                    id="image-selection-step"
+                    titleId="image-selection-step-title"
+                    aria-label="Image selection step"
+                  >
+                    Image
+                  </ProgressStep>
+                  <ProgressStep
+                    variant={getStepVariant(WorkspaceFormSteps.PodConfigSelection)}
+                    isCurrent={currentStep === WorkspaceFormSteps.PodConfigSelection}
+                    id="pod-config-selection-step"
+                    titleId="pod-config-selection-step-title"
+                    aria-label="Pod config selection step"
+                  >
+                    Pod Config
+                  </ProgressStep>
+                  <ProgressStep
+                    variant={getStepVariant(WorkspaceFormSteps.Properties)}
+                    isCurrent={currentStep === WorkspaceFormSteps.Properties}
+                    id="properties-step"
+                    titleId="properties-step-title"
+                    aria-label="Properties step"
+                  >
+                    Properties
+                  </ProgressStep>
+                </ProgressStepper>
+              </FlexItem>
+            </Flex>
           </Stack>
         </PageSection>
       </PageGroup>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react';
-import { Content, Divider, Split, SplitItem } from '@patternfly/react-core';
+import { Content, Split, SplitItem } from '@patternfly/react-core';
 import { WorkspaceFormImageDetails } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails';
 import { WorkspaceFormImageList } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageList';
 import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
@@ -57,8 +57,6 @@ const WorkspaceFormImageSelection: React.FunctionComponent<WorkspaceFormImageSel
 
   return (
     <Content style={{ height: '100%' }}>
-      <p>Select a workspace image and image version to use for the workspace.</p>
-      <Divider />
       <WorkspaceFormDrawer
         title="Image"
         info={imageDetailsContent}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useMemo, useCallback } from 'react';
-import { Content, Divider } from '@patternfly/react-core';
+import { Content } from '@patternfly/react-core';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { WorkspaceFormKindDetails } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindDetails';
@@ -59,8 +59,6 @@ const WorkspaceFormKindSelection: React.FunctionComponent<WorkspaceFormKindSelec
         onCloseClick={onCloseClick}
         onExpand={onExpand}
       >
-        <p>Select a workspace kind to use for the workspace.</p>
-        <Divider />
         <WorkspaceFormKindList
           allWorkspaceKinds={workspaceKinds}
           selectedKind={selectedKind}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Content, Divider, Split, SplitItem } from '@patternfly/react-core';
+import { Content, Split, SplitItem } from '@patternfly/react-core';
 import { WorkspaceFormPodConfigDetails } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigDetails';
 import { WorkspaceFormPodConfigList } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList';
 import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
@@ -55,9 +55,6 @@ const WorkspaceFormPodConfigSelection: React.FunctionComponent<
 
   return (
     <Content style={{ height: '100%' }}>
-      <p>Select a pod config to use for the workspace.</p>
-      <Divider />
-
       <WorkspaceFormDrawer
         title="Pod config"
         info={podConfigDetailsContent}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSelection.tsx
@@ -36,8 +36,6 @@ const WorkspaceFormPropertiesSelection: React.FunctionComponent<
 
   return (
     <Content style={{ height: '100%' }}>
-      <p>Configure properties for your workspace.</p>
-      <Divider />
       <Split hasGutter>
         <SplitItem style={{ minWidth: '200px' }}>{imageDetailsContent}</SplitItem>
         <SplitItem isFilled>

--- a/workspaces/frontend/src/shared/style/MUI-theme.scss
+++ b/workspaces/frontend/src/shared/style/MUI-theme.scss
@@ -573,20 +573,13 @@
 
 }
 
-.mui-theme .pf-v6-c-progress-stepper__step.pf-m-info,
-.mui-theme .pf-v6-c-progress-stepper__step.pf-m-success {
-  --pf-v6-c-progress-stepper__step-icon--BackgroundColor: var(--mui-palette-primary-main);
-  --pf-v6-c-progress-stepper__step-icon--Color: var(--mui-palette-common-white);
-}
+ .mui-theme .pf-v6-c-progress-stepper__step.pf-m-info {
+  --pf-v6-c-progress-stepper__step-icon--Color: var(--mui-palette-primary-main);
+ }
 
-.mui-theme .pf-v6-c-progress-stepper__step.pf-m-pending .pf-v6-c-progress-stepper__step-icon {
-  --pf-v6-c-progress-stepper__step-icon--BackgroundColor: var(--mui-palette-grey-500);
-  --pf-v6-c-progress-stepper__step-icon--Color: var(--mui-palette-common-white);
-}
-
-.mui-theme .pf-v6-c-progress-stepper__step-icon {
-  --pf-v6-c-progress-stepper__step-icon--BorderWidth: 0;
-}
+ .mui-theme .pf-v6-c-progress-stepper__step.pf-m-success {
+  --pf-v6-c-progress-stepper__step-icon--Color: var(--mui-palette-success-main);
+ }
 
 .mui-theme .pf-v6-c-radio.pf-m-standalone .pf-v6-c-radio__input {
   display: none;


### PR DESCRIPTION
Closes #371 

Changes:

- Relocated description text for progress steps to display as a subtitle. 
- Updated the ProgressStepper theming to align with UX recommendations and MUI theme color palette. 

Before:
<img width="1512" alt="Screenshot 2025-06-02 at 4 21 28 PM" src="https://github.com/user-attachments/assets/ed61a6b6-fb94-4c41-834e-9b26501f584f" />

After:
<img width="1512" alt="Screenshot 2025-06-02 at 4 20 36 PM" src="https://github.com/user-attachments/assets/d95a9c0a-e2ac-44c2-a424-a94e9114ebdc" />
