### PR TITLE
fix(ws): Action Button Alignment and Jupyter Image Display

### DIFF
--- a/workspaces/frontend/src/app/actions/WorkspaceKindsActions.tsx
+++ b/workspaces/frontend/src/app/actions/WorkspaceKindsActions.tsx
@@ -12,7 +12,7 @@ export function buildKindLogoDictionary(workspaceKinds: WorkspaceKind[] | []): K
 
   for (const workspaceKind of workspaceKinds) {
     try {
-      kindLogoDict[workspaceKind.name] = workspaceKind.logo.url;
+      kindLogoDict[workspaceKind.name] = workspaceKind.icon.url;
     } catch {
       kindLogoDict[workspaceKind.name] = '';
     }

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
@@ -115,9 +115,9 @@ export const WorkspaceFormKindList: React.FunctionComponent<WorkspaceFormKindLis
                     onChange,
                   }}
                 >
-                  <img src={kind.icon.url} alt={`${kind.name} icon`} style={{ maxWidth: '60px' }} />
-                  <CardTitle>{kind.displayName}</CardTitle>
+                  <img src={kind.logo.url} alt={`${kind.name} logo`} style={{ maxWidth: '60px' }} />
                 </CardHeader>
+                <CardTitle>{kind.displayName}</CardTitle>
                 <CardBody>{kind.description}</CardBody>
               </Card>
             ))}

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -627,7 +627,7 @@ export const Workspaces: React.FunctionComponent = () => {
                           })}
                         </Timestamp>
                       </Td>
-                      <Td>
+                      <Td isActionCell>
                         <WorkspaceConnectAction workspace={workspace} />
                       </Td>
                       <Td isActionCell data-testid="action-column">


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Closes #376 and #377 

Before:
<img width="210" alt="Screenshot 2025-06-05 at 4 38 31 PM" src="https://github.com/user-attachments/assets/3ec8fe27-9da6-43f8-bb9e-7c1d21bf13d9" />
<img width="1512" alt="Screenshot 2025-06-05 at 4 39 43 PM" src="https://github.com/user-attachments/assets/78ecb672-ae67-4471-a7e1-69647baed81a" />
<img width="1512" alt="Screenshot 2025-06-05 at 4 39 50 PM" src="https://github.com/user-attachments/assets/661438ac-3217-45b4-bbf2-99ca10abaeb3" />

After:
<img width="210" alt="Screenshot 2025-06-05 at 4 38 14 PM" src="https://github.com/user-attachments/assets/77a7ae93-1dcb-495a-87ec-72dffcf45434" />
<img width="1512" alt="Screenshot 2025-06-05 at 4 38 48 PM" src="https://github.com/user-attachments/assets/006dfb53-222b-4cad-9944-b56e9cd5c085" />
<img width="1512" alt="Screenshot 2025-06-05 at 4 38 55 PM" src="https://github.com/user-attachments/assets/cf51bd2b-c339-489e-b78f-b001a2faae06" />


