### PR TITLE
feat(ws): Notebooks 2.0 // Backend // Add tests to repositories/namespaces

### DIFF
--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -93,6 +93,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/workspaces/backend/internal/repositories/namespaces/repo_test.go
+++ b/workspaces/backend/internal/repositories/namespaces/repo_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNamespaceRepository(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NamespaceRepository Suite")
+}
+
+var _ = Describe("Namespaces", Ordered, func() {
+	var (
+		scheme        *runtime.Scheme
+		fakeClient    client.Client
+		namespaceRepo *NamespaceRepository
+		ctx           context.Context
+	)
+	BeforeAll(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+	Context("with no existing Namespaces", func() {
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+			namespaceRepo = NewNamespaceRepository(fakeClient)
+
+		})
+		It("should return an empty list of Namespaces", func() {
+			namespaces, err := namespaceRepo.GetNamespaces(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(namespaces).To(BeEmpty())
+		})
+	})
+	Context("with existing Namespaces", func() {
+		BeforeEach(func() {
+			ns1 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns-1"}}
+			ns2 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns-2"}}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns1, ns2).Build()
+			namespaceRepo = NewNamespaceRepository(fakeClient)
+
+		})
+		It("should return all namespaces", func() {
+			namespaces, err := namespaceRepo.GetNamespaces(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(namespaces).To(HaveLen(2))
+			Expect(namespaces[0].Name).To(Equal("test-ns-1"))
+			Expect(namespaces[1].Name).To(Equal("test-ns-2"))
+		})
+	})
+	Context("when client.List returns an error", func() {
+		BeforeEach(func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			errorClient := &erroringClient{Client: fakeClient}
+			namespaceRepo = NewNamespaceRepository(errorClient)
+		})
+
+		It("should return an error", func() {
+			namespaces, err := namespaceRepo.GetNamespaces(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mocked list error"))
+			Expect(namespaces).To(BeNil())
+		})
+	})
+})
+
+// Define a wrapper client that forces an error on List() method of client
+type erroringClient struct {
+	client.Client
+}
+
+func (e *erroringClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return errors.New("mocked list error")
+}


### PR DESCRIPTION
this PR adds a test file to workspaces/backend/internal/repositories/namespaces/repo.go