### PR TITLE
feat: Create Makefile target for a fresh kind cluster

### DIFF
--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -63,6 +63,37 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+# Creates a local Kubernetes cluster named kind-notebooks. By default, it proceeds to install essential cluster components: cert-manager and metrics-server.
+#  Metrics Server installation can be optionally skipped via a flag.
+# - INSTALL_METRICS_SERVER=false
+# Override cluster name with:
+# - CLUSTER_NAME=<your-custom-name>
+CLUSTER_NAME ?= kind-notebooks
+INSTALL_METRICS_SERVER ?= true
+
+.PHONY: kind-notebooks
+kind-notebooks:
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_TOOL) kind delete cluster --name $(CLUSTER_NAME) || true
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_TOOL) kind create cluster --name $(CLUSTER_NAME)
+
+	@echo "--- Installing cert-manager ---"
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+
+	kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=300s
+	@echo "Cert Manager installed. Version: $$(bash -c "kubectl get deployment cert-manager -n cert-manager -o jsonpath='{.spec.template.spec.containers[0].image}' | cut -d: -f2")"
+ifeq ($(INSTALL_METRICS_SERVER),true)
+	@echo "--- Installing metrics-server ---"
+	kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+	kubectl patch deployment metrics-server --namespace kube-system --type='json' --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
+	
+	kubectl wait --for=condition=Available deployment/metrics-server -n kube-system --timeout=300s
+	@echo "Metrics Server installed. Version: $$(bash -c "kubectl get deployment metrics-server -n kube-system -o jsonpath='{.spec.template.spec.containers[0].image}' | cut -d: -f2")"
+else
+	@echo "--- Skipping metrics-server installation (INSTALL_METRICS_SERVER set to $(INSTALL_METRICS_SERVER)) ---"
+endif
+	@echo "--- Setting the current context to $(CLUSTER_NAME) cluster ---"
+	kubectl config set-context kind-$(CLUSTER_NAME) --namespace=workspace-controller-system
+
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # Prometheus and CertManager are installed by default; skip with:
 # - PROMETHEUS_INSTALL_SKIP=true


### PR DESCRIPTION
Solves: https://github.com/kubeflow/notebooks/issues/409

This Makefile target automates the creation and configuration of a local Kubernetes cluster using Kind. It's designed to set up a development environment with essential components pre-installed.

**Key Features**
- **Cluster Creation:** It creates a Kind Kubernetes cluster. By default, the cluster is named kind-notebooks, but you can customize this by setting the CLUSTER_NAME variable (e.g., make kind-notebooks CLUSTER_NAME=my-dev-cluster).
- **Cert-Manager Installation**: Automatically installs cert-manager, a crucial component for issuing and managing TLS certificates within the Kubernetes cluster. The Makefile waits for cert-manager to be fully available before proceeding.
**Note**: The deployment of cert-manager should be patched by appending the `--kubelet-insecure-tls` arg, because the Metrics Server in Kind clusters, especially when the Kubelets' certificates don't contain the node's IP addresses as Subject Alternative Names (SANs) cause the following error: 
`E0610 11:58:11.888437       1 scraper.go:149] "Failed to scrape node" err="Get \"https://10.89.0.22:10250/metrics/resource\": tls: failed to verify certificate: x509: cannot validate certificate for 10.89.0.22 because it doesn't contain any IP SANs" node="kind-notebooks-control-plane"
I0610 11:58:18.413843       1 server.go:191] "Failed probe" probe="metric-storage-ready" err="no metrics to serve"`

- **Metrics Server Installation (Optional):** By default, it installs the Metrics Server, which enables Kubernetes to collect resource usage data from nodes and pods. This installation can be skipped by setting the INSTALL_METRICS_SERVER variable to false (e.g., make kind-notebooks INSTALL_METRICS_SERVER=false).

- **Kubectl Context**: After setting up the cluster and its components, the Makefile automatically sets your kubectl context to the newly created Kind cluster, making it easy to interact with it immediately.
Idempotency: The kind delete cluster command at the beginning ensures that if a cluster with the same name already exists, it's removed before a new one is created. This makes the target idempotent, meaning you can run it multiple times without issues.

**How to Use**
To use this Makefile, you'll need Kind and kubectl installed on your system.

To create the cluster with default settings:
`make kind-notebooks`

To create a cluster with a custom name:

`make kind-notebooks CLUSTER_NAME=my-custom-cluster`

To create a cluster without installing the Metrics Server:
`make kind-notebooks INSTALL_METRICS_SERVER=false`

**Output logs of the target:**

```
controller/ git:(local-setup-kind) $ make kind-notebooks 
KIND_EXPERIMENTAL_PROVIDER=podman kind delete cluster --name kind-notebooks || true
using podman due to KIND_EXPERIMENTAL_PROVIDER
enabling experimental podman provider
Deleting cluster "kind-notebooks" ...
Deleted nodes: ["kind-notebooks-control-plane"]
KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --name kind-notebooks
using podman due to KIND_EXPERIMENTAL_PROVIDER
enabling experimental podman provider
Creating cluster "kind-notebooks" ...
 ✓ Ensuring node image (kindest/node:v1.32.2) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-kind-notebooks"
You can now use your cluster with:

kubectl cluster-info --context kind-kind-notebooks

Have a nice day! 👋
--- Installing cert-manager ---
kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
namespace/cert-manager created
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
serviceaccount/cert-manager-cainjector created
serviceaccount/cert-manager created
serviceaccount/cert-manager-webhook created
clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrole.rbac.authorization.k8s.io/cert-manager-cluster-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
role.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
role.rbac.authorization.k8s.io/cert-manager:leaderelection created
role.rbac.authorization.k8s.io/cert-manager-tokenrequest created
role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
rolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager-cert-manager-tokenrequest created
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
service/cert-manager-cainjector created
service/cert-manager created
service/cert-manager-webhook created
deployment.apps/cert-manager-cainjector created
deployment.apps/cert-manager created
deployment.apps/cert-manager-webhook created
mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=300s
deployment.apps/cert-manager condition met
Cert Manager installed. Version: v1.17.2
--- Installing metrics-server ---
kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
serviceaccount/metrics-server created
clusterrole.rbac.authorization.k8s.io/system:aggregated-metrics-reader created
clusterrole.rbac.authorization.k8s.io/system:metrics-server created
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader created
clusterrolebinding.rbac.authorization.k8s.io/metrics-server:system:auth-delegator created
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-server created
service/metrics-server created
deployment.apps/metrics-server created
apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io created
kubectl patch deployment metrics-server --namespace kube-system --type='json' --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
deployment.apps/metrics-server patched
kubectl wait --for=condition=Available deployment/metrics-server -n kube-system --timeout=300s
deployment.apps/metrics-server condition met
Metrics Server installed. Version: v0.7.2
--- Setting the current context to kind-notebooks cluster ---
kubectl config set-context kind-kind-notebooks --namespace=workspace-controller-system
Context "kind-kind-notebooks" modified.
```
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->