### PR TITLE
feat(ws): backend api to create wsk with YAML

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -56,6 +56,9 @@ const (
 	// swagger
 	SwaggerPath    = PathPrefix + "/swagger/*any"
 	SwaggerDocPath = PathPrefix + "/swagger/doc.json"
+
+	// YAML manifest content type
+	ContentTypeYAMLManifest = "application/vnd.kubeflow-notebooks.manifest+yaml"
 )
 
 type App struct {
@@ -106,6 +109,7 @@ func (a *App) Routes() http.Handler {
 	// workspacekinds
 	router.GET(AllWorkspaceKindsPath, a.GetWorkspaceKindsHandler)
 	router.GET(WorkspaceKindsByNamePath, a.GetWorkspaceKindHandler)
+	router.POST(AllWorkspaceKindsPath, a.CreateWorkspaceKindHandler)
 
 	// swagger
 	router.GET(SwaggerPath, a.GetSwaggerHandler)

--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime"
 	"net/http"
@@ -46,7 +47,7 @@ func (a *App) WriteJSON(w http.ResponseWriter, status int, data any, headers htt
 		w.Header()[key] = value
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", MediaTypeJson)
 	w.WriteHeader(status)
 	_, err = w.Write(js)
 	if err != nil {
@@ -61,9 +62,19 @@ func (a *App) DecodeJSON(r *http.Request, v any) error {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(v); err != nil {
+		// NOTE: we don't wrap this error so we can unpack it in the caller
+		if a.IsMaxBytesError(err) {
+			return err
+		}
 		return fmt.Errorf("error decoding JSON: %w", err)
 	}
 	return nil
+}
+
+// IsMaxBytesError checks if the error is an instance of http.MaxBytesError.
+func (a *App) IsMaxBytesError(err error) bool {
+	var maxBytesError *http.MaxBytesError
+	return errors.As(err, &maxBytesError)
 }
 
 // ValidateContentType validates the Content-Type header of the request.

--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -94,3 +94,9 @@ func (a *App) LocationGetWorkspace(namespace, name string) string {
 	path = strings.Replace(path, ":"+ResourceNamePathParam, name, 1)
 	return path
 }
+
+// LocationGetWorkspaceKind returns the GET location (HTTP path) for a workspace kind resource.
+func (a *App) LocationGetWorkspaceKind(name string) string {
+	path := strings.Replace(WorkspaceKindsByNamePath, ":"+ResourceNamePathParam, name, 1)
+	return path
+}

--- a/workspaces/backend/api/response_errors.go
+++ b/workspaces/backend/api/response_errors.go
@@ -156,6 +156,18 @@ func (a *App) conflictResponse(w http.ResponseWriter, r *http.Request, err error
 	a.errorResponse(w, r, httpError)
 }
 
+// HTTP:413
+func (a *App) requestEntityTooLargeResponse(w http.ResponseWriter, r *http.Request, err error) {
+	httpError := &HTTPError{
+		StatusCode: http.StatusRequestEntityTooLarge,
+		ErrorResponse: ErrorResponse{
+			Code:    strconv.Itoa(http.StatusRequestEntityTooLarge),
+			Message: err.Error(),
+		},
+	}
+	a.errorResponse(w, r, httpError)
+}
+
 // HTTP:415
 func (a *App) unsupportedMediaTypeResponse(w http.ResponseWriter, r *http.Request, err error) {
 	httpError := &HTTPError{

--- a/workspaces/backend/api/suite_test.go
+++ b/workspaces/backend/api/suite_test.go
@@ -150,6 +150,7 @@ var _ = BeforeSuite(func() {
 	By("creating the application")
 	// NOTE: we use the `k8sClient` rather than `k8sManager.GetClient()` to avoid race conditions with the cached client
 	a, err = NewApp(&config.EnvConfig{}, appLogger, k8sClient, k8sManager.GetScheme(), reqAuthN, reqAuthZ)
+	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -18,11 +18,17 @@ package api
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
@@ -34,6 +40,74 @@ import (
 type WorkspaceKindListEnvelope Envelope[[]models.WorkspaceKind]
 
 type WorkspaceKindEnvelope Envelope[models.WorkspaceKind]
+
+// cachedRestrictedScheme holds the pre-built runtime scheme that only knows about WorkspaceKind.
+var cachedRestrictedScheme *runtime.Scheme
+
+// cachedUniversalDeserializer holds the pre-built universal deserializer for the restricted scheme.
+var cachedUniversalDeserializer runtime.Decoder
+
+// cachedExpectedGVK holds the expected GVK for WorkspaceKind, derived programmatically.
+var cachedExpectedGVK schema.GroupVersionKind
+
+// init builds the restricted scheme and deserializer once at package initialization time.
+func init() {
+	restrictedScheme := runtime.NewScheme()
+	if err := kubefloworgv1beta1.AddToScheme(restrictedScheme); err != nil {
+		panic(fmt.Sprintf("failed to add WorkspaceKind types to restricted scheme: %v", err))
+	}
+	cachedRestrictedScheme = restrictedScheme
+
+	codecs := serializer.NewCodecFactory(cachedRestrictedScheme)
+	cachedUniversalDeserializer = codecs.UniversalDeserializer()
+
+	workspaceKind := &kubefloworgv1beta1.WorkspaceKind{}
+	gvks, _, err := cachedRestrictedScheme.ObjectKinds(workspaceKind)
+	if err != nil || len(gvks) == 0 {
+		panic(fmt.Sprintf("failed to derive GVK from WorkspaceKind type: %v", err))
+	}
+	cachedExpectedGVK = gvks[0]
+}
+
+// ParseWorkspaceKindManifestBody reads and decodes a YAML request body into a WorkspaceKind object
+// using Kubernetes runtime validation to ensure maximum security.
+func (a *App) ParseWorkspaceKindManifestBody(w http.ResponseWriter, r *http.Request) (*kubefloworgv1beta1.WorkspaceKind, bool) {
+	// NOTE: A server-level middleware should enforce a max body size.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		a.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return nil, false
+	}
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			a.LogWarn(r, fmt.Sprintf("failed to close request body: %v", err))
+		}
+	}()
+
+	if len(body) == 0 {
+		a.badRequestResponse(w, r, errors.New("request body is empty"))
+		return nil, false
+	}
+
+	obj, gvk, err := cachedUniversalDeserializer.Decode(body, nil, nil)
+	if err != nil {
+		a.badRequestResponse(w, r, fmt.Errorf("failed to decode YAML manifest: %w", err))
+		return nil, false
+	}
+
+	if gvk.Kind != cachedExpectedGVK.Kind || gvk.Version != cachedExpectedGVK.Version {
+		a.badRequestResponse(w, r, fmt.Errorf("invalid GVK: expected %s, got %s", cachedExpectedGVK.Kind, gvk.Kind))
+		return nil, false
+	}
+
+	workspaceKind, ok := obj.(*kubefloworgv1beta1.WorkspaceKind)
+	if !ok {
+		a.badRequestResponse(w, r, fmt.Errorf("unexpected type: got %T, want *WorkspaceKind", obj))
+		return nil, false
+	}
+
+	return workspaceKind, true
+}
 
 // GetWorkspaceKindHandler retrieves a specific workspace kind by name.
 //
@@ -122,4 +196,74 @@ func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _
 
 	responseEnvelope := &WorkspaceKindListEnvelope{Data: workspaceKinds}
 	a.dataResponse(w, r, responseEnvelope)
+}
+
+// CreateWorkspaceKindHandler creates a new workspace kind from a YAML manifest.
+
+// @Summary		Create workspace kind
+// @Description	Creates a new workspace kind from a raw YAML manifest.
+// @Tags			workspacekinds
+// @Accept			application/vnd.kubeflow-notebooks.manifest+yaml
+// @Produce		json
+// @Param			body	body		string					true	"Raw YAML manifest of the WorkspaceKind"
+// @Success		201		{object}	WorkspaceKindEnvelope	"Successful creation. Returns the newly created workspace kind details."
+// @Failure		400		{object}	ErrorEnvelope			"Bad Request. The YAML is invalid or a required field is missing."
+// @Failure		401		{object}	ErrorEnvelope			"Unauthorized. Authentication is required."
+// @Failure		403		{object}	ErrorEnvelope			"Forbidden. User does not have permission to create the workspace kind."
+// @Failure		409		{object}	ErrorEnvelope			"Conflict. A WorkspaceKind with the same name already exists."
+// @Failure		415		{object}	ErrorEnvelope			"Unsupported Media Type. Content-Type header is not correct."
+// @Failure		500		{object}	ErrorEnvelope			"Internal server error."
+// @Router			/workspacekinds [post]
+func (a *App) CreateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// === Content-Type check ===
+	if ok := a.ValidateContentType(w, r, ContentTypeYAMLManifest); !ok {
+		return
+	}
+
+	// === Read body and parse with secure parser ===
+	newWsk, ok := a.ParseWorkspaceKindManifestBody(w, r)
+	if !ok {
+		return
+	}
+
+	// === Validate name exists in YAML ===
+	if newWsk.Name == "" {
+		a.badRequestResponse(w, r, errors.New("'.metadata.name' is a required field in the YAML manifest"))
+		return
+	}
+
+	// === AUTH ===
+	authPolicies := []*auth.ResourcePolicy{
+		auth.NewResourcePolicy(
+			auth.ResourceVerbCreate,
+			&kubefloworgv1beta1.WorkspaceKind{
+				ObjectMeta: metav1.ObjectMeta{Name: newWsk.Name},
+			},
+		),
+	}
+	if success := a.requireAuth(w, r, authPolicies); !success {
+		return
+	}
+
+	// === Create ===
+	createdModel, err := a.repositories.WorkspaceKind.Create(r.Context(), newWsk)
+	if err != nil {
+		if errors.Is(err, repository.ErrWorkspaceKindAlreadyExists) {
+			a.conflictResponse(w, r, err)
+			return
+		}
+		// This handles validation errors from the K8s API Server (webhook)
+		if apierrors.IsInvalid(err) {
+			causes := helper.StatusCausesFromAPIStatus(err)
+			a.failedValidationResponse(w, r, errMsgKubernetesValidation, nil, causes)
+			return
+		}
+		a.serverErrorResponse(w, r, err)
+		return
+	}
+
+	// === Return created object in envelope ===
+	location := a.LocationGetWorkspaceKind(createdModel.Name)
+	responseEnvelope := &WorkspaceKindEnvelope{Data: createdModel}
+	a.createdResponse(w, r, responseEnvelope, location)
 }

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds"
 )
@@ -196,6 +197,8 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 		})
 	})
 
+	// NOTE: these tests assume a specific state of the cluster, so cannot be run in parallel with other tests.
+	//       therefore, we run them using the `Serial` Ginkgo decorators.
 	Context("with no existing WorkspaceKinds", Serial, func() {
 
 		It("should return an empty list of WorkspaceKinds", func() {
@@ -261,7 +264,6 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 		var newWorkspaceKindName = "wsk-create-test"
 		var validYAML []byte
 
-		// BeforeEach runs before each "It" block, ensuring the validYAML is always available.
 		BeforeEach(func() {
 			validYAML = []byte(fmt.Sprintf(`
 apiVersion: kubeflow.org/v1beta1
@@ -270,47 +272,47 @@ metadata:
   name: %s
 spec:
   spawner:
-    displayName: "Test Jupyter Environment"
-    description: "A valid description for testing."
+    displayName: "JupyterLab Notebook"
+    description: "A Workspace which runs JupyterLab in a Pod"
     icon:
-      url: "https://example.com/icon.png"
+      url: "https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"
     logo:
-      url: "https://example.com/logo.svg"
+      url: "https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg"
   podTemplate:
+    serviceAccount:
+      name: "default-editor"
+    volumeMounts:
+      home: "/home/jovyan"
     options:
       imageConfig:
         spawner:
-          default: "default-image"
+          default: "jupyterlab_scipy_190"
         values:
-        - id: "default-image"
-          name: "Jupyter Scipy"
-          path: "kubeflownotebooks/jupyter-scipy:v1.9.0"
-          spawner:
-            displayName: "Jupyter with SciPy v1.9.0"
-          spec:
-            image: "kubeflownotebooks/jupyter-scipy:v1.9.0"
-            ports:
-            - id: "notebook-port"
-              displayName: "Notebook Port"
-              port: 8888
-              protocol: "HTTP"
+          - id: "jupyterlab_scipy_190"
+            spawner:
+              displayName: "jupyter-scipy:v1.9.0"
+              description: "JupyterLab, with SciPy Packages"
+            spec:
+              image: "ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.9.0"
+              imagePullPolicy: "IfNotPresent"
+              ports:
+                - id: "jupyterlab"
+                  displayName: "JupyterLab"
+                  port: 8888
+                  protocol: "HTTP"
       podConfig:
         spawner:
-          default: "default-pod-config"
+          default: "tiny_cpu"
         values:
-        - id: "default-pod-config"
-          name: "Default Resources"
-          spawner:
-            displayName: "Small CPU/RAM"
-          resources:
-            requests:
-              cpu: "500m"
-              memory: "1Gi"
-            limits:
-              cpu: "1"
-              memory: "2Gi"
-    volumeMounts:
-      home: "/home/jovyan"
+          - id: "tiny_cpu"
+            spawner:
+              displayName: "Tiny CPU"
+              description: "Pod with 0.1 CPU, 128 Mb RAM"
+            spec:
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
 `, newWorkspaceKindName))
 		})
 
@@ -324,72 +326,185 @@ spec:
 			_ = k8sClient.Delete(ctx, wsk)
 		})
 
-		It("should succeed when creating a new WorkspaceKind with valid YAML", func() {
+		It("should succeed when creating a WorkspaceKind with valid YAML", func() {
+			By("creating the HTTP request")
 			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req.Header.Set("Content-Type", MediaTypeYaml)
 			req.Header.Set(userIdHeader, adminUser)
 
+			By("executing CreateWorkspaceKindHandler")
 			rr := httptest.NewRecorder()
 			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
 			rs := rr.Result()
 			defer rs.Body.Close()
 
-			Expect(rs.StatusCode).To(Equal(http.StatusCreated), "Body: %s", rr.Body.String())
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("verifying the resource was created in the cluster")
+			createdWsk := &kubefloworgv1beta1.WorkspaceKind{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: newWorkspaceKindName}, createdWsk)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return a 409 Conflict when creating a WorkspaceKind that already exists", func() {
-			By("creating the resource once successfully")
-			req1, _ := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
-			req1.Header.Set("Content-Type", ContentTypeYAMLManifest)
+		It("should fail to create a WorkspaceKind with no name in the YAML", func() {
+			missingNameYAML := []byte(`
+apiVersion: kubeflow.org/v1beta1
+kind: WorkspaceKind
+metadata: {}
+spec:
+  spawner:
+    displayName: "This will fail"`)
+
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(missingNameYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", MediaTypeYaml)
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing CreateWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("decoding the error response")
+			var response ErrorEnvelope
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error message indicates a validation failure")
+			Expect(response.Error.Cause.ValidationErrors).To(BeComparableTo(
+				[]ValidationError{
+					{
+						Type:    field.ErrorTypeRequired,
+						Field:   "metadata.name",
+						Message: field.ErrorTypeRequired.String(),
+					},
+				},
+			))
+		})
+
+		It("should fail to create a WorkspaceKind that already exists", func() {
+			By("creating the HTTP request")
+			req1, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req1.Header.Set("Content-Type", MediaTypeYaml)
 			req1.Header.Set(userIdHeader, adminUser)
+
+			By("executing CreateWorkspaceKindHandler for the first time")
 			rr1 := httptest.NewRecorder()
 			a.CreateWorkspaceKindHandler(rr1, req1, httprouter.Params{})
-			Expect(rr1.Code).To(Equal(http.StatusCreated))
+			rs1 := rr1.Result()
+			defer rs1.Body.Close()
 
-			By("attempting to create the exact same resource a second time")
-			req2, _ := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
-			req2.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			By("verifying the HTTP response status code for the first request")
+			Expect(rs1.StatusCode).To(Equal(http.StatusCreated), descUnexpectedHTTPStatus, rr1.Body.String())
+
+			By("creating a second HTTP request")
+			req2, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req2.Header.Set("Content-Type", MediaTypeYaml)
 			req2.Header.Set(userIdHeader, adminUser)
+
+			By("executing CreateWorkspaceKindHandler for the second time")
 			rr2 := httptest.NewRecorder()
 			a.CreateWorkspaceKindHandler(rr2, req2, httprouter.Params{})
+			rs2 := rr2.Result()
+			defer rs2.Body.Close()
 
-			Expect(rr2.Code).To(Equal(http.StatusConflict))
+			By("verifying the HTTP response status code for the second request")
+			Expect(rs2.StatusCode).To(Equal(http.StatusConflict), descUnexpectedHTTPStatus, rr1.Body.String())
 		})
 
-		It("should fail with 400 Bad Request when the YAML has the wrong kind", func() {
-			wrongKindYAML := []byte(`apiVersion: v1
+		It("should fail when the YAML has the wrong kind", func() {
+			wrongKindYAML := []byte(`
+apiVersion: v1
 kind: Pod
 metadata:
   name: i-am-the-wrong-kind`)
-			req, _ := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(wrongKindYAML))
-			req.Header.Set("Content-Type", ContentTypeYAMLManifest)
-			req.Header.Set(userIdHeader, adminUser)
 
-			rr := httptest.NewRecorder()
-			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
-
-			Expect(rr.Code).To(Equal(http.StatusBadRequest))
-			// UPDATED: Check for the new, more specific error message
-			Expect(rr.Body.String()).To(ContainSubstring("no kind \\\"Pod\\\" is registered"))
-		})
-
-		It("should fail with 400 Bad Request for an empty YAML object", func() {
-			invalidYAML := []byte("{}")
-			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(invalidYAML))
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(wrongKindYAML))
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req.Header.Set("Content-Type", MediaTypeYaml)
 			req.Header.Set(userIdHeader, adminUser)
 
+			By("executing CreateWorkspaceKindHandler")
 			rr := httptest.NewRecorder()
 			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
 			rs := rr.Result()
 			defer rs.Body.Close()
 
-			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
-			body, _ := io.ReadAll(rs.Body)
-			// UPDATED: Check for the new, more specific error message from the secure parser
-			Expect(string(body)).To(ContainSubstring("failed to decode YAML manifest"))
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest), descUnexpectedHTTPStatus, rr.Body.String())
+			Expect(rr.Body.String()).To(ContainSubstring("unable to decode /v1, Kind=Pod into *v1beta1.WorkspaceKind"))
+		})
+
+		It("should fail when the body is not valid YAML", func() {
+			notYAML := []byte(`this is not yaml {`)
+
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(notYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", MediaTypeYaml)
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing CreateWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("decoding the error response")
+			var response ErrorEnvelope
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error message indicates a decoding failure")
+			Expect(response.Error.Message).To(ContainSubstring("error decoding request body: couldn't get version/kind; json parse error"))
+		})
+
+		It("should fail for an empty YAML object", func() {
+			invalidYAML := []byte("{}")
+
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(invalidYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", MediaTypeYaml)
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing the CreateWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("decoding the error response")
+			var response ErrorEnvelope
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error message indicates a validation failure")
+			Expect(response.Error.Cause.ValidationErrors).To(BeComparableTo(
+				[]ValidationError{
+					{
+						Type:    field.ErrorTypeRequired,
+						Field:   "metadata.name",
+						Message: field.ErrorTypeRequired.String(),
+					},
+				},
+			))
 		})
 	})
 })

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -195,8 +196,6 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 		})
 	})
 
-	// NOTE: these tests assume a specific state of the cluster, so cannot be run in parallel with other tests.
-	//       therefore, we run them using the `Serial` Ginkgo decorators.
 	Context("with no existing WorkspaceKinds", Serial, func() {
 
 		It("should return an empty list of WorkspaceKinds", func() {
@@ -252,6 +251,145 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 
 			By("verifying the HTTP response status code")
 			Expect(rs.StatusCode).To(Equal(http.StatusNotFound), descUnexpectedHTTPStatus, rr.Body.String())
+		})
+	})
+
+	// NOTE: these tests create and delete resources on the cluster, so cannot be run in parallel.
+	//       therefore, we run them using the `Serial` Ginkgo decorator.
+	Context("when creating a WorkspaceKind", Serial, func() {
+
+		var newWorkspaceKindName = "wsk-create-test"
+		var validYAML []byte
+
+		// BeforeEach runs before each "It" block, ensuring the validYAML is always available.
+		BeforeEach(func() {
+			validYAML = []byte(fmt.Sprintf(`
+apiVersion: kubeflow.org/v1beta1
+kind: WorkspaceKind
+metadata:
+  name: %s
+spec:
+  spawner:
+    displayName: "Test Jupyter Environment"
+    description: "A valid description for testing."
+    icon:
+      url: "https://example.com/icon.png"
+    logo:
+      url: "https://example.com/logo.svg"
+  podTemplate:
+    options:
+      imageConfig:
+        spawner:
+          default: "default-image"
+        values:
+        - id: "default-image"
+          name: "Jupyter Scipy"
+          path: "kubeflownotebooks/jupyter-scipy:v1.9.0"
+          spawner:
+            displayName: "Jupyter with SciPy v1.9.0"
+          spec:
+            image: "kubeflownotebooks/jupyter-scipy:v1.9.0"
+            ports:
+            - id: "notebook-port"
+              displayName: "Notebook Port"
+              port: 8888
+              protocol: "HTTP"
+      podConfig:
+        spawner:
+          default: "default-pod-config"
+        values:
+        - id: "default-pod-config"
+          name: "Default Resources"
+          spawner:
+            displayName: "Small CPU/RAM"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+    volumeMounts:
+      home: "/home/jovyan"
+`, newWorkspaceKindName))
+		})
+
+		AfterEach(func() {
+			By("cleaning up the created WorkspaceKind")
+			wsk := &kubefloworgv1beta1.WorkspaceKind{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: newWorkspaceKindName,
+				},
+			}
+			_ = k8sClient.Delete(ctx, wsk)
+		})
+
+		It("should succeed when creating a new WorkspaceKind with valid YAML", func() {
+			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req.Header.Set(userIdHeader, adminUser)
+
+			rr := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated), "Body: %s", rr.Body.String())
+		})
+
+		It("should return a 409 Conflict when creating a WorkspaceKind that already exists", func() {
+			By("creating the resource once successfully")
+			req1, _ := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
+			req1.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req1.Header.Set(userIdHeader, adminUser)
+			rr1 := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr1, req1, httprouter.Params{})
+			Expect(rr1.Code).To(Equal(http.StatusCreated))
+
+			By("attempting to create the exact same resource a second time")
+			req2, _ := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(validYAML))
+			req2.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req2.Header.Set(userIdHeader, adminUser)
+			rr2 := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr2, req2, httprouter.Params{})
+
+			Expect(rr2.Code).To(Equal(http.StatusConflict))
+		})
+
+		It("should fail with 400 Bad Request when the YAML has the wrong kind", func() {
+			wrongKindYAML := []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: i-am-the-wrong-kind`)
+			req, _ := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(wrongKindYAML))
+			req.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req.Header.Set(userIdHeader, adminUser)
+
+			rr := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
+
+			Expect(rr.Code).To(Equal(http.StatusBadRequest))
+			// UPDATED: Check for the new, more specific error message
+			Expect(rr.Body.String()).To(ContainSubstring("no kind \\\"Pod\\\" is registered"))
+		})
+
+		It("should fail with 400 Bad Request for an empty YAML object", func() {
+			invalidYAML := []byte("{}")
+			req, err := http.NewRequest(http.MethodPost, AllWorkspaceKindsPath, bytes.NewReader(invalidYAML))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", ContentTypeYAMLManifest)
+			req.Header.Set(userIdHeader, adminUser)
+
+			rr := httptest.NewRecorder()
+			a.CreateWorkspaceKindHandler(rr, req, httprouter.Params{})
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			body, _ := io.ReadAll(rs.Body)
+			// UPDATED: Check for the new, more specific error message from the secure parser
+			Expect(string(body)).To(ContainSubstring("failed to decode YAML manifest"))
 		})
 	})
 })

--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -729,7 +729,7 @@ var _ = Describe("Workspaces Handler", func() {
 			path := strings.Replace(WorkspacesByNamespacePath, ":"+NamespacePathParam, namespaceNameCrud, 1)
 			req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(string(bodyEnvelopeJSON)))
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Type", MediaTypeJson)
 
 			By("setting the auth headers")
 			req.Header.Set(userIdHeader, adminUser)
@@ -845,7 +845,7 @@ var _ = Describe("Workspaces Handler", func() {
 			path := strings.Replace(WorkspacesByNamespacePath, ":"+NamespacePathParam, namespaceNameCrud, 1)
 			req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(string(bodyEnvelopeJSON)))
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Type", MediaTypeJson)
 			req.Header.Set(userIdHeader, adminUser)
 
 			rr := httptest.NewRecorder()

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -70,20 +70,25 @@ func (r *WorkspaceKindRepository) GetWorkspaceKinds(ctx context.Context) ([]mode
 	return workspaceKindsModels, nil
 }
 
-func (r *WorkspaceKindRepository) Create(ctx context.Context, wk *kubefloworgv1beta1.WorkspaceKind) (models.WorkspaceKind, error) {
-	if err := r.client.Create(ctx, wk); err != nil {
+func (r *WorkspaceKindRepository) Create(ctx context.Context, workspaceKind *kubefloworgv1beta1.WorkspaceKind) (*models.WorkspaceKind, error) {
+	// create workspace kind
+	if err := r.client.Create(ctx, workspaceKind); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			return models.WorkspaceKind{}, ErrWorkspaceKindAlreadyExists
+			return nil, ErrWorkspaceKindAlreadyExists
 		}
 		if apierrors.IsInvalid(err) {
 			// NOTE: we don't wrap this error so we can unpack it in the caller
-			return models.WorkspaceKind{}, err
+			//       and extract the validation errors returned by the Kubernetes API server
+			return nil, err
 		}
-		return models.WorkspaceKind{}, err
+		return nil, err
 	}
 
-	// Convert the created k8s object to our backend model before returning
-	createdModel := models.NewWorkspaceKindModelFromWorkspaceKind(wk)
+	// convert the created workspace to a WorkspaceKindUpdate model
+	//
+	// TODO: this function should return the WorkspaceKindUpdate model, once the update WSK api is implemented
+	//
+	createdWorkspaceKindModel := models.NewWorkspaceKindModelFromWorkspaceKind(workspaceKind)
 
-	return createdModel, nil
+	return &createdWorkspaceKindModel, nil
 }

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -122,6 +122,74 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "Creates a new workspace kind from a raw YAML manifest.",
+                "consumes": [
+                    "application/vnd.kubeflow-notebooks.manifest+yaml"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspacekinds"
+                ],
+                "summary": "Create workspace kind",
+                "parameters": [
+                    {
+                        "description": "Raw YAML manifest of the WorkspaceKind",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successful creation. Returns the newly created workspace kind details.",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkspaceKindEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request. The YAML is invalid or a required field is missing.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to create the workspace kind.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict. A WorkspaceKind with the same name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type. Content-Type header is not correct.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
             }
         },
         "/workspacekinds/{name}": {

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -124,9 +124,9 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Creates a new workspace kind from a raw YAML manifest.",
+                "description": "Creates a new workspace kind.",
                 "consumes": [
-                    "application/vnd.kubeflow-notebooks.manifest+yaml"
+                    "application/yaml"
                 ],
                 "produces": [
                     "application/json"
@@ -137,7 +137,7 @@ const docTemplate = `{
                 "summary": "Create workspace kind",
                 "parameters": [
                     {
-                        "description": "Raw YAML manifest of the WorkspaceKind",
+                        "description": "Kubernetes YAML manifest of a WorkspaceKind",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -148,13 +148,13 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Successful creation. Returns the newly created workspace kind details.",
+                        "description": "WorkspaceKind created successfully",
                         "schema": {
                             "$ref": "#/definitions/api.WorkspaceKindEnvelope"
                         }
                     },
                     "400": {
-                        "description": "Bad Request. The YAML is invalid or a required field is missing.",
+                        "description": "Bad Request.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -166,13 +166,19 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Forbidden. User does not have permission to create the workspace kind.",
+                        "description": "Forbidden. User does not have permission to create WorkspaceKind.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
                     },
                     "409": {
-                        "description": "Conflict. A WorkspaceKind with the same name already exists.",
+                        "description": "Conflict. WorkspaceKind with the same name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large. The request body is too large.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -183,8 +189,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
                     },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
                     "500": {
-                        "description": "Internal server error.",
+                        "description": "Internal server error. An unexpected error occurred on the server.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -416,6 +428,18 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict. Workspace with the same name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large. The request body is too large.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type. Content-Type header is not correct.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -120,6 +120,74 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "Creates a new workspace kind from a raw YAML manifest.",
+                "consumes": [
+                    "application/vnd.kubeflow-notebooks.manifest+yaml"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspacekinds"
+                ],
+                "summary": "Create workspace kind",
+                "parameters": [
+                    {
+                        "description": "Raw YAML manifest of the WorkspaceKind",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successful creation. Returns the newly created workspace kind details.",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkspaceKindEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request. The YAML is invalid or a required field is missing.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to create the workspace kind.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict. A WorkspaceKind with the same name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type. Content-Type header is not correct.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
             }
         },
         "/workspacekinds/{name}": {

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -122,9 +122,9 @@
                 }
             },
             "post": {
-                "description": "Creates a new workspace kind from a raw YAML manifest.",
+                "description": "Creates a new workspace kind.",
                 "consumes": [
-                    "application/vnd.kubeflow-notebooks.manifest+yaml"
+                    "application/yaml"
                 ],
                 "produces": [
                     "application/json"
@@ -135,7 +135,7 @@
                 "summary": "Create workspace kind",
                 "parameters": [
                     {
-                        "description": "Raw YAML manifest of the WorkspaceKind",
+                        "description": "Kubernetes YAML manifest of a WorkspaceKind",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -146,13 +146,13 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Successful creation. Returns the newly created workspace kind details.",
+                        "description": "WorkspaceKind created successfully",
                         "schema": {
                             "$ref": "#/definitions/api.WorkspaceKindEnvelope"
                         }
                     },
                     "400": {
-                        "description": "Bad Request. The YAML is invalid or a required field is missing.",
+                        "description": "Bad Request.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -164,13 +164,19 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden. User does not have permission to create the workspace kind.",
+                        "description": "Forbidden. User does not have permission to create WorkspaceKind.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
                     },
                     "409": {
-                        "description": "Conflict. A WorkspaceKind with the same name already exists.",
+                        "description": "Conflict. WorkspaceKind with the same name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large. The request body is too large.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -181,8 +187,14 @@
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
                     },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
                     "500": {
-                        "description": "Internal server error.",
+                        "description": "Internal server error. An unexpected error occurred on the server.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -414,6 +426,18 @@
                     },
                     "409": {
                         "description": "Conflict. Workspace with the same name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large. The request body is too large.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type. Content-Type header is not correct.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }


### PR DESCRIPTION
This PR adds the POST /api/v1/workspacekinds endpoint for creating a WorkspaceKind from a raw YAML upload.

The implementation adds a Create() method to the repository and the CreateWorkspaceKindHandler to process the request. The corresponding integration tests verify the success path using a static file payload and also cover key failure cases.

 closes: #278