### PR TITLE
feat(ws): validate podMetadata for ws and wsk in webhook

### DIFF
--- a/workspaces/controller/internal/webhook/suite_test.go
+++ b/workspaces/controller/internal/webhook/suite_test.go
@@ -511,6 +511,28 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 	}
 }
 
+// NewExampleWorkspaceKindWithInvalidPodMetadataLabelKey returns a WorkspaceKind with an invalid PodMetadata label key.
+func NewExampleWorkspaceKindWithInvalidPodMetadataLabelKey(name string) *kubefloworgv1beta1.WorkspaceKind {
+	workspaceKind := NewExampleWorkspaceKind(name)
+	workspaceKind.Spec.PodTemplate.PodMetadata = &kubefloworgv1beta1.WorkspaceKindPodMetadata{
+		Labels: map[string]string{
+			"!bad_key!": "value",
+		},
+	}
+	return workspaceKind
+}
+
+// NewExampleWorkspaceKindWithInvalidPodMetadataAnnotationKey returns a WorkspaceKind with an invalid PodMetadata annotation key.
+func NewExampleWorkspaceKindWithInvalidPodMetadataAnnotationKey(name string) *kubefloworgv1beta1.WorkspaceKind {
+	workspaceKind := NewExampleWorkspaceKind(name)
+	workspaceKind.Spec.PodTemplate.PodMetadata = &kubefloworgv1beta1.WorkspaceKindPodMetadata{
+		Annotations: map[string]string{
+			"!bad_key!": "value",
+		},
+	}
+	return workspaceKind
+}
+
 // NewExampleWorkspaceKindWithImageConfigCycle returns a WorkspaceKind with a cycle in the ImageConfig options.
 func NewExampleWorkspaceKindWithImageConfigCycle(name string) *kubefloworgv1beta1.WorkspaceKind {
 	workspaceKind := NewExampleWorkspaceKind(name)

--- a/workspaces/controller/internal/webhook/workspacekind_webhook_test.go
+++ b/workspaces/controller/internal/webhook/workspacekind_webhook_test.go
@@ -54,6 +54,16 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 				shouldSucceed: true,
 			},
 			{
+				description:   "should reject creation with invalid podMetadata label key",
+				workspaceKind: NewExampleWorkspaceKindWithInvalidPodMetadataLabelKey("wsk-webhook-create--invalid-pod-metadata--label-key"),
+				shouldSucceed: false,
+			},
+			{
+				description:   "should reject creation with invalid podMetadata annotation key",
+				workspaceKind: NewExampleWorkspaceKindWithInvalidPodMetadataAnnotationKey("wsk-webhook-create--invalid-pod-metadata--annotation-key"),
+				shouldSucceed: false,
+			},
+			{
 				description:   "should reject creation with cycle in imageConfig redirects",
 				workspaceKind: NewExampleWorkspaceKindWithImageConfigCycle("wsk-webhook-create--image-config-cycle"),
 				shouldSucceed: false,
@@ -496,6 +506,32 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 					}
 					return ContainSubstring("port %d is defined more than once", duplicatePortNumber)
+				},
+			},
+			{
+				description:   "should reject updating a podMetadata.labels key to an invalid value",
+				shouldSucceed: false,
+
+				workspaceKind: NewExampleWorkspaceKind(workspaceKindName),
+				modifyKindFn: func(wsk *kubefloworgv1beta1.WorkspaceKind) gomegaTypes.GomegaMatcher {
+					invalidKey := "!bad-key!"
+					wsk.Spec.PodTemplate.PodMetadata.Labels = map[string]string{
+						invalidKey: "some-value",
+					}
+					return ContainSubstring("Invalid value: %q", invalidKey)
+				},
+			},
+			{
+				description:   "should reject updating a podMetadata.annotations key to an invalid value",
+				shouldSucceed: false,
+
+				workspaceKind: NewExampleWorkspaceKind(workspaceKindName),
+				modifyKindFn: func(wsk *kubefloworgv1beta1.WorkspaceKind) gomegaTypes.GomegaMatcher {
+					invalidAnnotationKey := "!bad-key!"
+					wsk.Spec.PodTemplate.PodMetadata.Annotations = map[string]string{
+						invalidAnnotationKey: "some-value",
+					}
+					return ContainSubstring("Invalid value: %q", invalidAnnotationKey)
 				},
 			},
 			{


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the controller's validating webhook to validate the following fields:

- Workspace:
     - `spec.podTemplate.podMetadata.labels`
     - `spec.podTemplate.podMetadata.annotations`
- WorkspaceKind:
     - `spec.podTemplate.podMetadata.labels`
     - `spec.podTemplate.podMetadata.annotations`

We do this by calling the upstream [`apimachinery`](https://pkg.go.dev/k8s.io/apimachinery) implementation so we validate exactly the same as upstream:
- Labels: [`v1validation.ValidateLabels()`](https://github.com/kubernetes/apimachinery/blob/v0.33.2/pkg/apis/meta/v1/validation/validation.go#L62-L72)
- Annotations: [`apivalidation.ValidateAnnotations()`](https://github.com/kubernetes/apimachinery/blob/v0.33.2/pkg/api/validation/objectmeta.go#L44-L56)


This is important because it's quite complex to correctly validate a [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) or [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) metadata map, because some seemingly invalid label keys are valid, e.g. `example.com/my-label-key`. 