### PR TITLE
chore: add OWNERS files with reviewers and labels

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,4 @@
+labels:
+  - area/ci
+reviewers:
+  - andyatmiami

--- a/workspaces/backend/OWNERS
+++ b/workspaces/backend/OWNERS
@@ -1,0 +1,5 @@
+labels:
+  - area/backend
+  - area/v2
+reviewers:
+  - andyatmiami

--- a/workspaces/controller/OWNERS
+++ b/workspaces/controller/OWNERS
@@ -1,0 +1,5 @@
+labels:
+  - area/controller
+  - area/v2
+reviewers:
+  - andyatmiami

--- a/workspaces/frontend/OWNERS
+++ b/workspaces/frontend/OWNERS
@@ -1,2 +1,7 @@
+labels:
+  - area/frontend
+  - area/v2
 approvers:
   - ederign
+reviewers:
+  - paulovmr


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR makes it so that our up-and-coming approvers (@andyatmiami - controller, backend /// @paulovmr - frontend) are automatically assigned as a reviewer in their respective areas.

This is in line with the [code review process](https://www.kubeflow.org/docs/about/contributing/#the-code-review-process) that should enable people to get to approver once they consistently lgtm PRs in a state which the approvers would have merged.

Additionally, it seems like we can set `labels` in the `OWNERS` files which should automatically apply those labels to PRs which change code under those paths. Hopefully this works, but we will see after we merge.