### PR TITLE
feat: refactor Form View to Edit only

### DIFF
--- a/workspaces/frontend/src/shared/api/backendApiTypes.ts
+++ b/workspaces/frontend/src/shared/api/backendApiTypes.ts
@@ -90,7 +90,7 @@ export interface WorkspaceKindPodTemplate {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface WorkspaceKindCreate {}
+export type WorkspaceKindCreate = string;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface WorkspaceKindUpdate {}

--- a/workspaces/frontend/src/shared/api/notebookApi.ts
+++ b/workspaces/frontend/src/shared/api/notebookApi.ts
@@ -4,7 +4,6 @@ import {
   Workspace,
   WorkspaceCreate,
   WorkspaceKind,
-  WorkspaceKindCreate,
   WorkspaceKindPatch,
   WorkspaceKindUpdate,
   WorkspacePatch,
@@ -63,10 +62,7 @@ export type StartWorkspace = (
 // WorkspaceKind
 export type ListWorkspaceKinds = (opts: APIOptions) => Promise<WorkspaceKind[]>;
 export type GetWorkspaceKind = (opts: APIOptions, kind: string) => Promise<WorkspaceKind>;
-export type CreateWorkspaceKind = (
-  opts: APIOptions,
-  data: RequestData<WorkspaceKindCreate>,
-) => Promise<WorkspaceKind>;
+export type CreateWorkspaceKind = (opts: APIOptions, data: string) => Promise<WorkspaceKind>;
 export type UpdateWorkspaceKind = (
   opts: APIOptions,
   kind: string,

--- a/workspaces/frontend/src/shared/api/notebookService.ts
+++ b/workspaces/frontend/src/shared/api/notebookService.ts
@@ -5,6 +5,7 @@ import {
   restGET,
   restPATCH,
   restUPDATE,
+  restYAML,
 } from '~/shared/api/apiUtils';
 import { handleRestFailures } from '~/shared/api/errorUtils';
 import {
@@ -96,7 +97,7 @@ export const getWorkspaceKind: GetWorkspaceKindAPI = (hostPath) => (opts, kind) 
   );
 
 export const createWorkspaceKind: CreateWorkspaceKindAPI = (hostPath) => (opts, data) =>
-  handleRestFailures(restCREATE(hostPath, `/workspacekinds`, data, {}, opts)).then((response) =>
+  handleRestFailures(restYAML(hostPath, `/workspacekinds`, data, {}, opts)).then((response) =>
     extractNotebookResponse<WorkspaceKind>(response),
   );
 


### PR DESCRIPTION
 closes: #349
 related: #365

Per the community meeting on June 26th 2025, the team has come to an agreement that the creation flow should allow only a single YAML upload. Configuring pod config, properties and images will only be available when the user wishes to Edit a Workspace Kind