### PR TITLE
feat(ws): Define k8s workload manifest for backend component #324

### DIFF
--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -124,11 +124,13 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUBECTL ?= kubectl
+KUSTOMIZE := $(LOCALBIN)/kustomize
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 SWAGGER = $(LOCALBIN)/swag
 
 ## Tool Versions
+KUSTOMIZE_VERSION ?= v5.5.0
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.61.0
 SWAGGER_VERSION ?= v1.16.4
@@ -147,6 +149,26 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+
+##@ deployment
+
+.PHONY: deploy
+deploy: kustomize ## Deploy backend to the K8s cluster specified in ~/.kube/config.
+	cd config/default && $(KUSTOMIZE) edit set image nbv2-backend=${IMG}
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+
+.PHONY: undeploy
+undeploy: kustomize ## Undeploy backend from the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=true -f -
+
+
+##@ Dependencies
+
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/workspaces/backend/config/default/deployment.yaml
+++ b/workspaces/backend/config/default/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nbv2-backend
+  namespace: backend-system
+  labels:
+    app: nbv2-backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: nbv2-backend
+      app.kubernetes.io/component: backend
+      app.kubernetes.io/managed-by: kustomize
+  template:
+    metadata:
+      labels:
+        app: nbv2-backend
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/managed-by: kustomize
+    spec:
+      serviceAccountName: nbv2-backend
+      securityContext:
+        runAsNonRoot: true
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: nbv2-backend
+        image: nbv2-backend
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        ports:
+        - containerPort: 4000
+        env:
+        - name: PORT
+          value: "4000"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        livenessProbe:
+          httpGet:
+            path: /api/v1/healthcheck
+            port: 4000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /api/v1/healthcheck
+            port: 4000
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1

--- a/workspaces/backend/config/default/kustomization.yaml
+++ b/workspaces/backend/config/default/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - service_account.yaml
+  - rbac.yaml
+  - service.yaml
+  - deployment.yaml
+
+images:
+  - name: nbv2-backend

--- a/workspaces/backend/config/default/namespace.yaml
+++ b/workspaces/backend/config/default/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backend-system

--- a/workspaces/backend/config/default/rbac.yaml
+++ b/workspaces/backend/config/default/rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backend-clusterrole
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - workspaces
+  - workspacekinds
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backend-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backend-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: nbv2-backend
+  namespace: backend-system

--- a/workspaces/backend/config/default/service.yaml
+++ b/workspaces/backend/config/default/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nbv2-backend
+  namespace: backend-system
+  labels:
+    app: nbv2-backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    app: nbv2-backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/managed-by: kustomize
+  ports:
+  - port: 4000
+    targetPort: 4000
+  type: NodePort

--- a/workspaces/backend/config/default/service_account.yaml
+++ b/workspaces/backend/config/default/service_account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: nbv2-backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/managed-by: kustomize
+  name: nbv2-backend
+  namespace: backend-system


### PR DESCRIPTION
closes: #324 

In this PR I have created the manifest workload for the backend component.
Add 2 targets to the Makefile `deploy` and `undeploy`.

How to deploy the backed component:

`cd workspaces/backend`
`make docker-build`
`make docker-push`
`make deploy`
`kubectl port-forward svc/nbv2-backend 4000:4000 -n backend-system`

How to undeploy the backed component:

`cd workspaces/backend`
`make undeploy`


@andyatmiami, regarding this PR, I want to consult with you:
1. I used type: `NodePort` in the `service.yaml` mainly because we dont have yet an nginx-ingress 
I can change it to be type: `ClusterIP` if needed
2. Im not sure about the image/container names, do you think we need to chnage it to be just a `backend` or we can leave it as it is `nbv2-backend`?
 


