### PR TITLE
feat(ws): prepare frontend for validation errors during WorkspaceKind creation

### DIFF
--- a/workspaces/frontend/src/app/NavSidebar.tsx
+++ b/workspaces/frontend/src/app/NavSidebar.tsx
@@ -17,7 +17,7 @@ const NavHref: React.FC<{ item: NavDataHref }> = ({ item }) => {
   const location = useTypedLocation();
 
   // With the redirect in place, we can now use a simple path comparison.
-  const isActive = location.pathname === item.path;
+  const isActive = location.pathname === item.path || location.pathname.startsWith(`${item.path}/`);
 
   return (
     <NavItem isActive={isActive} key={item.label} data-id={item.label} itemId={item.label}>

--- a/workspaces/frontend/src/app/components/ValidationErrorAlert.tsx
+++ b/workspaces/frontend/src/app/components/ValidationErrorAlert.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Alert, List, ListItem } from '@patternfly/react-core';
+import { ValidationError } from '~/shared/api/backendApiTypes';
+
+interface ValidationErrorAlertProps {
+  title: string;
+  errors: ValidationError[];
+}
+
+export const ValidationErrorAlert: React.FC<ValidationErrorAlertProps> = ({ title, errors }) => {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert variant="danger" title={title} isInline>
+      <List>
+        {errors.map((error, index) => (
+          <ListItem key={index}>{error.message}</ListItem>
+        ))}
+      </List>
+    </Alert>
+  );
+};

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -1,19 +1,26 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
+  Alert,
   Button,
   Content,
   ContentVariants,
   Flex,
   FlexItem,
+  List,
+  ListItem,
   PageGroup,
   PageSection,
   Stack,
+  StackItem,
 } from '@patternfly/react-core';
+import { t_global_spacer_sm as SmallPadding } from '@patternfly/react-tokens';
 import { useTypedNavigate } from '~/app/routerHelper';
 import { useCurrentRouteKey } from '~/app/hooks/useCurrentRouteKey';
 import useGenericObjectState from '~/app/hooks/useGenericObjectState';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { WorkspaceKindFormData } from '~/app/types';
+import { ErrorEnvelopeException } from '~/shared/api/apiUtils';
+import { ValidationError } from '~/shared/api/backendApiTypes';
 import { WorkspaceKindFileUpload } from './fileUpload/WorkspaceKindFileUpload';
 import { WorkspaceKindFormProperties } from './properties/WorkspaceKindFormProperties';
 import { WorkspaceKindFormImage } from './image/WorkspaceKindFormImage';
@@ -34,6 +41,8 @@ export const WorkspaceKindForm: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [validated, setValidated] = useState<ValidationStatus>('default');
   const mode = useCurrentRouteKey() === 'workspaceKindCreate' ? 'create' : 'edit';
+  const [specErrors, setSpecErrors] = useState<ValidationError[]>([]);
+
   const [data, setData, resetData] = useGenericObjectState<WorkspaceKindFormData>({
     properties: {
       displayName: '',
@@ -60,14 +69,24 @@ export const WorkspaceKindForm: React.FC = () => {
     try {
       if (mode === 'create') {
         const newWorkspaceKind = await api.createWorkspaceKind({}, yamlValue);
+        // TODO: alert user about success
         console.info('New workspace kind created:', JSON.stringify(newWorkspaceKind));
+        navigate('workspaceKinds');
       }
     } catch (err) {
+      if (err instanceof ErrorEnvelopeException) {
+        const validationErrors = err.envelope.error?.cause?.validation_errors;
+        if (validationErrors && validationErrors.length > 0) {
+          setSpecErrors(validationErrors);
+          setValidated('error');
+          return;
+        }
+      }
+      // TODO: alert user about error
       console.error(`Error ${mode === 'edit' ? 'editing' : 'creating'} workspace kind: ${err}`);
     } finally {
       setIsSubmitting(false);
     }
-    navigate('workspaceKinds');
   }, [navigate, mode, api, yamlValue]);
 
   const canSubmit = useMemo(
@@ -102,13 +121,31 @@ export const WorkspaceKindForm: React.FC = () => {
       </PageGroup>
       <PageSection isFilled>
         {mode === 'create' && (
-          <WorkspaceKindFileUpload
-            resetData={resetData}
-            value={yamlValue}
-            setValue={setYamlValue}
-            validated={validated}
-            setValidated={setValidated}
-          />
+          <Stack>
+            <StackItem style={{ padding: SmallPadding.value }}>
+              {specErrors.length > 0 && (
+                <Alert variant="danger" title="Error creating workspace kind" isInline>
+                  <List>
+                    {specErrors.map((error, index) => (
+                      <ListItem key={index}>{error.message}</ListItem>
+                    ))}
+                  </List>
+                </Alert>
+              )}
+            </StackItem>
+            <StackItem style={{ height: '100%' }}>
+              <WorkspaceKindFileUpload
+                resetData={resetData}
+                value={yamlValue}
+                setValue={setYamlValue}
+                validated={validated}
+                setValidated={setValidated}
+                onClear={() => {
+                  setSpecErrors([]);
+                }}
+              />
+            </StackItem>
+          </Stack>
         )}
         {mode === 'edit' && (
           <>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -1,19 +1,17 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
-  Alert,
   Button,
   Content,
   ContentVariants,
   Flex,
   FlexItem,
-  List,
-  ListItem,
   PageGroup,
   PageSection,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
 import { t_global_spacer_sm as SmallPadding } from '@patternfly/react-tokens';
+import { ValidationErrorAlert } from '~/app/components/ValidationErrorAlert';
 import { useTypedNavigate } from '~/app/routerHelper';
 import { useCurrentRouteKey } from '~/app/hooks/useCurrentRouteKey';
 import useGenericObjectState from '~/app/hooks/useGenericObjectState';
@@ -122,17 +120,11 @@ export const WorkspaceKindForm: React.FC = () => {
       <PageSection isFilled>
         {mode === 'create' && (
           <Stack>
-            <StackItem style={{ padding: SmallPadding.value }}>
-              {specErrors.length > 0 && (
-                <Alert variant="danger" title="Error creating workspace kind" isInline>
-                  <List>
-                    {specErrors.map((error, index) => (
-                      <ListItem key={index}>{error.message}</ListItem>
-                    ))}
-                  </List>
-                </Alert>
-              )}
-            </StackItem>
+            {specErrors.length > 0 && (
+              <StackItem style={{ padding: SmallPadding.value }}>
+                <ValidationErrorAlert title="Error creating workspace kind" errors={specErrors} />
+              </StackItem>
+            )}
             <StackItem style={{ height: '100%' }}>
               <WorkspaceKindFileUpload
                 resetData={resetData}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
@@ -119,7 +119,7 @@ export const WorkspaceKindFileUpload: React.FC<WorkspaceKindFileUploadProps> = (
         {fileUploadHelperText && (
           <FileUploadHelperText>
             <HelperText>
-              <HelperTextItem id="helper-text-example-helpText" variant="warning">
+              <HelperTextItem id="helper-text-example-helpText" variant="error">
                 {fileUploadHelperText}
               </HelperTextItem>
             </HelperText>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import yaml, { YAMLException } from 'js-yaml';
 import {
   FileUpload,
@@ -7,6 +7,7 @@ import {
   HelperText,
   HelperTextItem,
   Content,
+  DropzoneErrorCode,
 } from '@patternfly/react-core';
 import { isValidWorkspaceKindYaml } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import { ValidationStatus } from '~/app/pages/WorkspaceKinds/Form/WorkspaceKindForm';
@@ -17,7 +18,11 @@ interface WorkspaceKindFileUploadProps {
   resetData: () => void;
   validated: ValidationStatus;
   setValidated: (type: ValidationStatus) => void;
+  onClear: () => void;
 }
+
+const YAML_MIME_TYPE = 'application/x-yaml';
+const YAML_EXTENSIONS = ['.yml', '.yaml'];
 
 export const WorkspaceKindFileUpload: React.FC<WorkspaceKindFileUploadProps> = ({
   resetData,
@@ -25,52 +30,40 @@ export const WorkspaceKindFileUpload: React.FC<WorkspaceKindFileUploadProps> = (
   setValue,
   validated,
   setValidated,
+  onClear,
 }) => {
-  const isYamlFileRef = useRef(false);
   const [filename, setFilename] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [fileUploadHelperText, setFileUploadHelperText] = useState<string>('');
+  const [fileUploadHelperText, setFileUploadHelperText] = useState<string | undefined>();
 
   const handleFileInputChange = useCallback(
     (_: unknown, file: File) => {
-      const fileName = file.name;
+      onClear();
       setFilename(file.name);
-      // if extension is not yaml or yml, raise a flag
-      const ext = fileName.split('.').pop();
-      const isYaml = ext === 'yml' || ext === 'yaml';
-      isYamlFileRef.current = isYaml;
-      if (!isYaml) {
-        setFileUploadHelperText('Invalid file. Only YAML files are allowed.');
-        resetData();
-        setValidated('error');
-      } else {
-        setFileUploadHelperText('');
-        setValidated('success');
-      }
+      setFileUploadHelperText(undefined);
+      setValidated('success');
     },
-    [resetData, setValidated],
+    [setValidated, onClear],
   );
 
   // TODO: Use zod or another TS type coercion/schema for file upload
   const handleDataChange = useCallback(
     (_: DropEvent, v: string) => {
       setValue(v);
-      if (isYamlFileRef.current) {
-        try {
-          const parsed = yaml.load(v);
-          if (!isValidWorkspaceKindYaml(parsed)) {
-            setFileUploadHelperText('YAML is invalid: must follow WorkspaceKind format.');
-            setValidated('error');
-            resetData();
-          } else {
-            setValidated('success');
-            setFileUploadHelperText('');
-          }
-        } catch (e) {
-          console.error('Error parsing YAML:', e);
-          setFileUploadHelperText(`Error parsing YAML: ${e as YAMLException['reason']}`);
+      try {
+        const parsed = yaml.load(v);
+        if (!isValidWorkspaceKindYaml(parsed)) {
+          setFileUploadHelperText('YAML is invalid: must follow WorkspaceKind format.');
           setValidated('error');
+          resetData();
+        } else {
+          setValidated('success');
+          setFileUploadHelperText('');
         }
+      } catch (e) {
+        console.error('Error parsing YAML:', e);
+        setFileUploadHelperText(`Error parsing YAML: ${e as YAMLException['reason']}`);
+        setValidated('error');
       }
     },
     [setValue, setValidated, resetData],
@@ -82,7 +75,8 @@ export const WorkspaceKindFileUpload: React.FC<WorkspaceKindFileUploadProps> = (
     setFileUploadHelperText('');
     setValidated('default');
     resetData();
-  }, [resetData, setValidated, setValue]);
+    onClear();
+  }, [resetData, setValidated, setValue, onClear]);
 
   const handleFileReadStarted = useCallback(() => {
     setIsLoading(true);
@@ -110,14 +104,27 @@ export const WorkspaceKindFileUpload: React.FC<WorkspaceKindFileUploadProps> = (
         validated={validated}
         allowEditingUploadedText={false}
         browseButtonText="Choose File"
+        dropzoneProps={{
+          accept: { [YAML_MIME_TYPE]: YAML_EXTENSIONS },
+          onDropRejected: (rejections) => {
+            const error = rejections[0]?.errors?.[0] ?? {};
+            setFileUploadHelperText(
+              error.code === DropzoneErrorCode.FileInvalidType
+                ? 'Invalid file. Only YAML files are allowed.'
+                : error.message,
+            );
+          },
+        }}
       >
-        <FileUploadHelperText>
-          <HelperText>
-            <HelperTextItem id="helper-text-example-helpText">
-              {fileUploadHelperText}
-            </HelperTextItem>
-          </HelperText>
-        </FileUploadHelperText>
+        {fileUploadHelperText && (
+          <FileUploadHelperText>
+            <HelperText>
+              <HelperTextItem id="helper-text-example-helpText" variant="warning">
+                {fileUploadHelperText}
+              </HelperTextItem>
+            </HelperText>
+          </FileUploadHelperText>
+        )}
       </FileUpload>
     </Content>
   );

--- a/workspaces/frontend/src/shared/api/__tests__/errorUtils.spec.ts
+++ b/workspaces/frontend/src/shared/api/__tests__/errorUtils.spec.ts
@@ -1,8 +1,9 @@
-import { NotReadyError } from '~/shared/utilities/useFetchState';
-import { APIError } from '~/shared/api/types';
-import { handleRestFailures } from '~/shared/api/errorUtils';
 import { mockNamespaces } from '~/__mocks__/mockNamespaces';
 import { mockBFFResponse } from '~/__mocks__/utils';
+import { ErrorEnvelopeException } from '~/shared/api/apiUtils';
+import { ErrorEnvelope } from '~/shared/api/backendApiTypes';
+import { handleRestFailures } from '~/shared/api/errorUtils';
+import { NotReadyError } from '~/shared/utilities/useFetchState';
 
 describe('handleRestFailures', () => {
   it('should successfully return namespaces', async () => {
@@ -11,14 +12,14 @@ describe('handleRestFailures', () => {
   });
 
   it('should handle and throw notebook errors', async () => {
-    const statusMock: APIError = {
+    const errorEnvelope: ErrorEnvelope = {
       error: {
-        code: '',
-        message: 'error',
+        code: '<error_code>',
+        message: '<error_message>',
       },
     };
-
-    await expect(handleRestFailures(Promise.resolve(statusMock))).rejects.toThrow('error');
+    const expectedError = new ErrorEnvelopeException(errorEnvelope);
+    await expect(handleRestFailures(Promise.reject(errorEnvelope))).rejects.toThrow(expectedError);
   });
 
   it('should handle common state errors ', async () => {

--- a/workspaces/frontend/src/shared/api/__tests__/notebookService.spec.ts
+++ b/workspaces/frontend/src/shared/api/__tests__/notebookService.spec.ts
@@ -1,10 +1,9 @@
 import { BFF_API_VERSION } from '~/app/const';
-import { restGET } from '~/shared/api/apiUtils';
-import { handleRestFailures } from '~/shared/api/errorUtils';
+import { restGET, wrapRequest } from '~/shared/api/apiUtils';
 import { listNamespaces } from '~/shared/api/notebookService';
 
-const mockRestPromise = Promise.resolve({ data: {} });
-const mockRestResponse = {};
+const mockRestResponse = { data: {} };
+const mockRestPromise = Promise.resolve(mockRestResponse);
 
 jest.mock('~/shared/api/apiUtils', () => ({
   restCREATE: jest.fn(() => mockRestPromise),
@@ -12,13 +11,10 @@ jest.mock('~/shared/api/apiUtils', () => ({
   restPATCH: jest.fn(() => mockRestPromise),
   isNotebookResponse: jest.fn(() => true),
   extractNotebookResponse: jest.fn(() => mockRestResponse),
+  wrapRequest: jest.fn(() => mockRestPromise),
 }));
 
-jest.mock('~/shared/api/errorUtils', () => ({
-  handleRestFailures: jest.fn(() => mockRestPromise),
-}));
-
-const handleRestFailuresMock = jest.mocked(handleRestFailures);
+const wrapRequestMock = jest.mocked(wrapRequest);
 const restGETMock = jest.mocked(restGET);
 const APIOptionsMock = {};
 
@@ -33,7 +29,7 @@ describe('getNamespaces', () => {
       {},
       APIOptionsMock,
     );
-    expect(handleRestFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleRestFailuresMock).toHaveBeenCalledWith(mockRestPromise);
+    expect(wrapRequestMock).toHaveBeenCalledTimes(1);
+    expect(wrapRequestMock).toHaveBeenCalledWith(mockRestPromise);
   });
 });

--- a/workspaces/frontend/src/shared/api/backendApiTypes.ts
+++ b/workspaces/frontend/src/shared/api/backendApiTypes.ts
@@ -282,3 +282,36 @@ export interface WorkspacePauseState {
   workspaceName: string;
   paused: boolean;
 }
+
+export enum FieldErrorType {
+  FieldValueRequired = 'FieldValueRequired',
+  FieldValueInvalid = 'FieldValueInvalid',
+  FieldValueNotSupported = 'FieldValueNotSupported',
+  FieldValueDuplicate = 'FieldValueDuplicate',
+  FieldValueTooLong = 'FieldValueTooLong',
+  FieldValueForbidden = 'FieldValueForbidden',
+  FieldValueNotFound = 'FieldValueNotFound',
+  FieldValueConflict = 'FieldValueConflict',
+  FieldValueTooShort = 'FieldValueTooShort',
+  FieldValueUnknown = 'FieldValueUnknown',
+}
+
+export interface ValidationError {
+  type: FieldErrorType;
+  field: string;
+  message: string;
+}
+
+export interface ErrorCause {
+  validation_errors?: ValidationError[]; // TODO: backend is not using camelCase for this field
+}
+
+export type HTTPError = {
+  code: string;
+  message: string;
+  cause?: ErrorCause;
+};
+
+export type ErrorEnvelope = {
+  error: HTTPError | null;
+};

--- a/workspaces/frontend/src/shared/api/errorUtils.ts
+++ b/workspaces/frontend/src/shared/api/errorUtils.ts
@@ -1,25 +1,16 @@
-import { APIError } from '~/shared/api/types';
+import { ErrorEnvelopeException, isErrorEnvelope } from '~/shared/api//apiUtils';
 import { isCommonStateError } from '~/shared/utilities/useFetchState';
 
-const isError = (e: unknown): e is APIError => typeof e === 'object' && e !== null && 'error' in e;
-
 export const handleRestFailures = <T>(promise: Promise<T>): Promise<T> =>
-  promise
-    .then((result) => {
-      if (isError(result)) {
-        throw result;
-      }
-      return result;
-    })
-    .catch((e) => {
-      if (isError(e)) {
-        throw new Error(e.error.message);
-      }
-      if (isCommonStateError(e)) {
-        // Common state errors are handled by useFetchState at storage level, let them deal with it
-        throw e;
-      }
-      // eslint-disable-next-line no-console
-      console.error('Unknown API error', e);
-      throw new Error('Error communicating with server');
-    });
+  promise.catch((e) => {
+    if (isErrorEnvelope(e)) {
+      throw new ErrorEnvelopeException(e);
+    }
+    if (isCommonStateError(e)) {
+      // Common state errors are handled by useFetchState at storage level, let them deal with it
+      throw e;
+    }
+    // eslint-disable-next-line no-console
+    console.error('Unknown API error', e);
+    throw new Error('Error communicating with server');
+  });

--- a/workspaces/frontend/src/shared/api/notebookService.ts
+++ b/workspaces/frontend/src/shared/api/notebookService.ts
@@ -1,19 +1,12 @@
 import {
-  extractNotebookResponse,
   restCREATE,
   restDELETE,
   restGET,
   restPATCH,
   restUPDATE,
   restYAML,
+  wrapRequest,
 } from '~/shared/api/apiUtils';
-import { handleRestFailures } from '~/shared/api/errorUtils';
-import {
-  Namespace,
-  Workspace,
-  WorkspaceKind,
-  WorkspacePauseState,
-} from '~/shared/api/backendApiTypes';
 import {
   CreateWorkspaceAPI,
   CreateWorkspaceKindAPI,
@@ -32,86 +25,60 @@ import {
   StartWorkspaceAPI,
   UpdateWorkspaceAPI,
   UpdateWorkspaceKindAPI,
-} from './callTypes';
+} from '~/shared/api/callTypes';
 
 export const getHealthCheck: GetHealthCheckAPI = (hostPath) => (opts) =>
-  handleRestFailures(restGET(hostPath, `/healthcheck`, {}, opts));
+  wrapRequest(restGET(hostPath, `/healthcheck`, {}, opts), false);
 
 export const listNamespaces: ListNamespacesAPI = (hostPath) => (opts) =>
-  handleRestFailures(restGET(hostPath, `/namespaces`, {}, opts)).then((response) =>
-    extractNotebookResponse<Namespace[]>(response),
-  );
+  wrapRequest(restGET(hostPath, `/namespaces`, {}, opts));
 
 export const listAllWorkspaces: ListAllWorkspacesAPI = (hostPath) => (opts) =>
-  handleRestFailures(restGET(hostPath, `/workspaces`, {}, opts)).then((response) =>
-    extractNotebookResponse<Workspace[]>(response),
-  );
+  wrapRequest(restGET(hostPath, `/workspaces`, {}, opts));
 
 export const listWorkspaces: ListWorkspacesAPI = (hostPath) => (opts, namespace) =>
-  handleRestFailures(restGET(hostPath, `/workspaces/${namespace}`, {}, opts)).then((response) =>
-    extractNotebookResponse<Workspace[]>(response),
-  );
+  wrapRequest(restGET(hostPath, `/workspaces/${namespace}`, {}, opts));
 
 export const getWorkspace: GetWorkspaceAPI = (hostPath) => (opts, namespace, workspace) =>
-  handleRestFailures(restGET(hostPath, `/workspaces/${namespace}/${workspace}`, {}, opts)).then(
-    (response) => extractNotebookResponse<Workspace>(response),
-  );
+  wrapRequest(restGET(hostPath, `/workspaces/${namespace}/${workspace}`, {}, opts));
 
 export const createWorkspace: CreateWorkspaceAPI = (hostPath) => (opts, namespace, data) =>
-  handleRestFailures(restCREATE(hostPath, `/workspaces/${namespace}`, data, {}, opts)).then(
-    (response) => extractNotebookResponse<Workspace>(response),
-  );
+  wrapRequest(restCREATE(hostPath, `/workspaces/${namespace}`, data, {}, opts));
 
 export const updateWorkspace: UpdateWorkspaceAPI =
   (hostPath) => (opts, namespace, workspace, data) =>
-    handleRestFailures(
-      restUPDATE(hostPath, `/workspaces/${namespace}/${workspace}`, data, {}, opts),
-    ).then((response) => extractNotebookResponse<Workspace>(response));
+    wrapRequest(restUPDATE(hostPath, `/workspaces/${namespace}/${workspace}`, data, {}, opts));
 
 export const patchWorkspace: PatchWorkspaceAPI = (hostPath) => (opts, namespace, workspace, data) =>
-  handleRestFailures(restPATCH(hostPath, `/workspaces/${namespace}/${workspace}`, data, opts)).then(
-    (response) => extractNotebookResponse<Workspace>(response),
-  );
+  wrapRequest(restPATCH(hostPath, `/workspaces/${namespace}/${workspace}`, data, opts));
 
 export const deleteWorkspace: DeleteWorkspaceAPI = (hostPath) => (opts, namespace, workspace) =>
-  handleRestFailures(restDELETE(hostPath, `/workspaces/${namespace}/${workspace}`, {}, {}, opts));
+  wrapRequest(restDELETE(hostPath, `/workspaces/${namespace}/${workspace}`, {}, {}, opts), false);
 
 export const pauseWorkspace: PauseWorkspaceAPI = (hostPath) => (opts, namespace, workspace) =>
-  handleRestFailures(
+  wrapRequest(
     restCREATE(hostPath, `/workspaces/${namespace}/${workspace}/actions/pause`, {}, opts),
-  ).then((response) => extractNotebookResponse<WorkspacePauseState>(response));
+  );
 
 export const startWorkspace: StartWorkspaceAPI = (hostPath) => (opts, namespace, workspace) =>
-  handleRestFailures(
+  wrapRequest(
     restCREATE(hostPath, `/workspaces/${namespace}/${workspace}/actions/start`, {}, opts),
-  ).then((response) => extractNotebookResponse<WorkspacePauseState>(response));
+  );
 
 export const listWorkspaceKinds: ListWorkspaceKindsAPI = (hostPath) => (opts) =>
-  handleRestFailures(restGET(hostPath, `/workspacekinds`, {}, opts)).then((response) =>
-    extractNotebookResponse<WorkspaceKind[]>(response),
-  );
+  wrapRequest(restGET(hostPath, `/workspacekinds`, {}, opts));
 
 export const getWorkspaceKind: GetWorkspaceKindAPI = (hostPath) => (opts, kind) =>
-  handleRestFailures(restGET(hostPath, `/workspacekinds/${kind}`, {}, opts)).then((response) =>
-    extractNotebookResponse<WorkspaceKind>(response),
-  );
+  wrapRequest(restGET(hostPath, `/workspacekinds/${kind}`, {}, opts));
 
 export const createWorkspaceKind: CreateWorkspaceKindAPI = (hostPath) => (opts, data) =>
-  handleRestFailures(restYAML(hostPath, `/workspacekinds`, data, {}, opts)).then((response) =>
-    extractNotebookResponse<WorkspaceKind>(response),
-  );
+  wrapRequest(restYAML(hostPath, `/workspacekinds`, data, {}, opts));
 
 export const updateWorkspaceKind: UpdateWorkspaceKindAPI = (hostPath) => (opts, kind, data) =>
-  handleRestFailures(restUPDATE(hostPath, `/workspacekinds/${kind}`, data, {}, opts)).then(
-    (response) => extractNotebookResponse<WorkspaceKind>(response),
-  );
+  wrapRequest(restUPDATE(hostPath, `/workspacekinds/${kind}`, data, {}, opts));
 
 export const patchWorkspaceKind: PatchWorkspaceKindAPI = (hostPath) => (opts, kind, data) =>
-  handleRestFailures(restPATCH(hostPath, `/workspacekinds/${kind}`, data, opts)).then((response) =>
-    extractNotebookResponse<WorkspaceKind>(response),
-  );
+  wrapRequest(restPATCH(hostPath, `/workspacekinds/${kind}`, data, opts));
 
 export const deleteWorkspaceKind: DeleteWorkspaceKindAPI = (hostPath) => (opts, kind) =>
-  handleRestFailures(restDELETE(hostPath, `/workspacekinds/${kind}`, {}, {}, opts)).then(
-    (response) => extractNotebookResponse<void>(response),
-  );
+  wrapRequest(restDELETE(hostPath, `/workspacekinds/${kind}`, {}, {}, opts), false);

--- a/workspaces/frontend/src/shared/api/types.ts
+++ b/workspaces/frontend/src/shared/api/types.ts
@@ -5,13 +5,6 @@ export type APIOptions = {
   headers?: Record<string, string>;
 };
 
-export type APIError = {
-  error: {
-    code: string;
-    message: string;
-  };
-};
-
 export type APIState<T> = {
   /** If API will successfully call */
   apiAvailable: boolean;

--- a/workspaces/frontend/src/shared/mock/mockUtils.ts
+++ b/workspaces/frontend/src/shared/mock/mockUtils.ts
@@ -1,0 +1,7 @@
+import yaml from 'js-yaml';
+
+// For testing purposes, a YAML string is considered invalid if it contains a specific pattern in the metadata name.
+export function isInvalidYaml(yamlString: string): boolean {
+  const parsed = yaml.load(yamlString) as { metadata?: { name?: string } };
+  return parsed.metadata?.name?.includes('-invalid') ?? false;
+}

--- a/workspaces/frontend/src/shared/style/MUI-theme.scss
+++ b/workspaces/frontend/src/shared/style/MUI-theme.scss
@@ -124,7 +124,6 @@
 .mui-theme .pf-v6-c-alert {
   --pf-v6-c-alert--m-warning__title--Color: var(--pf-t--global--text--color--status--warning--default);
   --pf-v6-c-alert__icon--MarginInlineEnd: var(--mui-alert__icon--MarginInlineEnd);
-  --pf-v6-c-alert__title--FontWeight: var(--mui-alert-warning-font-weight);
   --pf-v6-c-alert__icon--MarginBlockStart: var(--mui-alert__icon--MarginBlockStart);
   --pf-v6-c-alert__icon--FontSize: var(--mui-alert__icon--FontSize);
   --pf-v6-c-alert--BoxShadow: var(--mui-alert--BoxShadow);


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

closes https://github.com/kubeflow/notebooks/issues/454

Also in this PR:
- Subpaths also activate their parent item in the nav bar
- Use builtin `<FileUpload>.dropzoneProps` to block invalid file extensions in `WorkspaceKindForm` upload
- Wrap requests to extract ErrorEnvelopes
- Make `<Alert>` title bold again

Demo:
- Trying to drop an unsupported file
- Trying to drop an unexpected WorkspaceKind format
- Trying to drop an invalid WorkspaceKind to simulate validation errors (calls create endpoint and shows the errors)
- Dropping a valid file and successfully call create endpoint

https://github.com/user-attachments/assets/12ac1720-9944-44bf-8a85-81e06d91aa42

