### PR TITLE
chore(ws): enforce component specific imports

### DIFF
--- a/workspaces/frontend/.eslintrc.js
+++ b/workspaces/frontend/.eslintrc.js
@@ -208,6 +208,28 @@ module.exports = {
             name: 'react-router',
             message: 'Use react-router-dom instead.',
           },
+          {
+            name: '@patternfly/react-core',
+            message:
+              'Use specific component imports: @patternfly/react-core/dist/esm/components/ComponentName',
+          },
+          {
+            name: '@patternfly/react-table',
+            message:
+              'Use specific component imports: @patternfly/react-table/dist/esm/components/ComponentName',
+          },
+          {
+            name: '@patternfly/react-icons',
+            message: 'Use specific icon imports: @patternfly/react-icons/dist/esm/icons/IconName',
+          },
+          {
+            name: 'date-fns',
+            message: 'Use specific function imports: date-fns/functionName',
+          },
+          {
+            name: 'lodash',
+            message: 'Use specific function imports: lodash/functionName',
+          },
         ],
       },
     ],

--- a/workspaces/frontend/src/app/App.tsx
+++ b/workspaces/frontend/src/app/App.tsx
@@ -2,20 +2,19 @@ import React, { useEffect } from 'react';
 import '@patternfly/patternfly/patternfly-addons.css';
 import '@patternfly/react-core/dist/styles/base.css';
 import './app.css';
+import { Brand } from '@patternfly/react-core/dist/esm/components/Brand';
+import { Flex } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import {
-  Brand,
-  Flex,
   Masthead,
   MastheadBrand,
   MastheadContent,
   MastheadLogo,
   MastheadMain,
   MastheadToggle,
-  Page,
-  PageToggleButton,
-  Title,
-} from '@patternfly/react-core';
-import { BarsIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/Masthead';
+import { Page, PageToggleButton } from '@patternfly/react-core/dist/esm/components/Page';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
+import { BarsIcon } from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import ErrorBoundary from '~/app/error/ErrorBoundary';
 import NamespaceSelector from '~/shared/components/NamespaceSelector';
 import logoDarkTheme from '~/images/logo-dark-theme.svg';

--- a/workspaces/frontend/src/app/EnsureAPIAvailability.tsx
+++ b/workspaces/frontend/src/app/EnsureAPIAvailability.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 import { useNotebookAPI } from './hooks/useNotebookAPI';
 
 interface EnsureAPIAvailabilityProps {

--- a/workspaces/frontend/src/app/NavSidebar.tsx
+++ b/workspaces/frontend/src/app/NavSidebar.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { Brand } from '@patternfly/react-core/dist/esm/components/Brand';
 import {
-  Brand,
   Nav,
   NavExpandable,
   NavItem,
   NavList,
-  PageSidebar,
-  PageSidebarBody,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Nav';
+import { PageSidebar, PageSidebarBody } from '@patternfly/react-core/dist/esm/components/Page';
 import { useTypedLocation } from '~/app/routerHelper';
 import { useNavData, isNavDataGroup, NavDataHref, NavDataGroup } from './AppRoutes';
 import { isMUITheme, LOGO_LIGHT } from './const';

--- a/workspaces/frontend/src/app/components/LoadError.tsx
+++ b/workspaces/frontend/src/app/components/LoadError.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Alert, Bullseye } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core/dist/esm/components/Alert';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
 
 interface LoadErrorProps {
   error: Error;

--- a/workspaces/frontend/src/app/components/LoadingSpinner.tsx
+++ b/workspaces/frontend/src/app/components/LoadingSpinner.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 
 // TODO: simple LoadingSpinner component -- we should improve this later
 

--- a/workspaces/frontend/src/app/components/ThemeAwareSearchInput.tsx
+++ b/workspaces/frontend/src/app/components/ThemeAwareSearchInput.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { SearchInput, SearchInputProps, TextInput } from '@patternfly/react-core';
+import {
+  SearchInput,
+  SearchInputProps,
+} from '@patternfly/react-core/dist/esm/components/SearchInput';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import FormFieldset from 'app/components/FormFieldset';
 import { isMUITheme } from 'app/const';
 

--- a/workspaces/frontend/src/app/components/ValidationErrorAlert.tsx
+++ b/workspaces/frontend/src/app/components/ValidationErrorAlert.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Alert, List, ListItem } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core/dist/esm/components/Alert';
+import { List, ListItem } from '@patternfly/react-core/dist/esm/components/List';
 import { ValidationError } from '~/shared/api/backendApiTypes';
 import { ErrorEnvelopeException } from '~/shared/api/apiUtils';
 

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -1,17 +1,19 @@
 import React, { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import {
-  PageSection,
   TimestampTooltipVariant,
   Timestamp,
-  Label,
+} from '@patternfly/react-core/dist/esm/components/Timestamp';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import {
   PaginationVariant,
   Pagination,
-  Content,
-  Tooltip,
-  Bullseye,
-  Button,
-  Icon,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Pagination';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Icon } from '@patternfly/react-core/dist/esm/components/Icon';
 import {
   Table,
   Thead,
@@ -22,14 +24,12 @@ import {
   ThProps,
   ActionsColumn,
   IActions,
-} from '@patternfly/react-table';
-import {
-  InfoCircleIcon,
-  ExclamationTriangleIcon,
-  TimesCircleIcon,
-  QuestionCircleIcon,
-} from '@patternfly/react-icons';
-import { formatDistanceToNow } from 'date-fns';
+} from '@patternfly/react-table/dist/esm/components/Table';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import { TimesCircleIcon } from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+import { QuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import { Workspace, WorkspaceState } from '~/shared/api/backendApiTypes';
 import {
   DataFieldKey,

--- a/workspaces/frontend/src/app/context/WorkspaceActionsContext.tsx
+++ b/workspaces/frontend/src/app/context/WorkspaceActionsContext.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
+} from '@patternfly/react-core/dist/esm/components/Drawer';
 import { useNamespaceContext } from '~/app/context/NamespaceContextProvider';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { WorkspaceDetails } from '~/app/pages/Workspaces/Details/WorkspaceDetails';

--- a/workspaces/frontend/src/app/error/ErrorBoundary.tsx
+++ b/workspaces/frontend/src/app/error/ErrorBoundary.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Button, Split, SplitItem, Title } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
+import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import { AppRoutePaths } from '~/app/routes';
 import ErrorDetails from '~/app/error/ErrorDetails';
 import UpdateState from '~/app/error/UpdateState';

--- a/workspaces/frontend/src/app/error/ErrorDetails.tsx
+++ b/workspaces/frontend/src/app/error/ErrorDetails.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import {
   ClipboardCopy,
   ClipboardCopyVariant,
+} from '@patternfly/react-core/dist/esm/components/ClipboardCopy';
+import {
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  Title,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 
 type ErrorDetailsProps = {
   title: string;

--- a/workspaces/frontend/src/app/error/UpdateState.tsx
+++ b/workspaces/frontend/src/app/error/UpdateState.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
-  Button,
   EmptyState,
-  EmptyStateActions,
   EmptyStateBody,
-  EmptyStateFooter,
   EmptyStateVariant,
-  PageSection,
-} from '@patternfly/react-core';
-import { PathMissingIcon } from '@patternfly/react-icons';
+  EmptyStateActions,
+  EmptyStateFooter,
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { PathMissingIcon } from '@patternfly/react-icons/dist/esm/icons/path-missing-icon';
 
 type Props = {
   onClose: () => void;

--- a/workspaces/frontend/src/app/hooks/useWorkspaceRowActions.ts
+++ b/workspaces/frontend/src/app/hooks/useWorkspaceRowActions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { IActions } from '@patternfly/react-table';
+import { IActions } from '@patternfly/react-table/dist/esm/components/Table';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { useWorkspaceActionsContext, WorkspaceAction } from '~/app/context/WorkspaceActionsContext';
 

--- a/workspaces/frontend/src/app/pages/Debug/Debug.tsx
+++ b/workspaces/frontend/src/app/pages/Debug/Debug.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
-  Button,
   EmptyState,
   EmptyStateBody,
-  EmptyStateFooter,
   EmptyStateVariant,
-  PageSection,
-} from '@patternfly/react-core';
+  EmptyStateFooter,
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 
 const Debug: React.FunctionComponent = () => (
   <PageSection>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/EditableLabels.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/EditableLabels.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import React, { useRef } from 'react';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table/dist/esm/components/Table';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
-  Button,
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
-  TextInput,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Form';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import inlineEditStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import { css } from '@patternfly/react-styles';
-import { PlusCircleIcon, TrashAltIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import { TrashAltIcon } from '@patternfly/react-icons/dist/esm/icons/trash-alt-icon';
 import { WorkspaceOptionLabel } from '~/shared/api/backendApiTypes';
 
 interface EditableRowInterface {

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -1,19 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  Button,
-  Content,
-  ContentVariants,
-  EmptyState,
-  EmptyStateBody,
-  Flex,
-  FlexItem,
-  PageGroup,
-  PageSection,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { PageGroup, PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
 import { t_global_spacer_sm as SmallPadding } from '@patternfly/react-tokens';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState';
 import { ValidationErrorAlert } from '~/app/components/ValidationErrorAlert';
 import useWorkspaceKindByName from '~/app/hooks/useWorkspaceKindByName';
 import { WorkspaceKind, ValidationError } from '~/shared/api/backendApiTypes';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
@@ -1,17 +1,16 @@
 import React, { useMemo, useState } from 'react';
-import { Table, Thead, Tr, Td, Tbody, Th } from '@patternfly/react-table';
+import { Table, Thead, Tr, Td, Tbody, Th } from '@patternfly/react-table/dist/esm/components/Table';
+import { getUniqueId } from '@patternfly/react-core/helpers';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import {
-  Dropdown,
-  DropdownItem,
-  getUniqueId,
-  Label,
-  MenuToggle,
-  PageSection,
   Pagination,
   PaginationVariant,
-  Radio,
-} from '@patternfly/react-core';
-import { EllipsisVIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/Pagination';
+import { Radio } from '@patternfly/react-core/dist/esm/components/Radio';
+import { Dropdown, DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { EllipsisVIcon } from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 import { WorkspaceKindImageConfigValue } from '~/app/types';
 import { WorkspacePodConfigValue } from '~/shared/api/backendApiTypes';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
@@ -2,13 +2,12 @@ import React, { useCallback, useState } from 'react';
 import yaml, { YAMLException } from 'js-yaml';
 import {
   FileUpload,
-  DropEvent,
-  FileUploadHelperText,
-  HelperText,
-  HelperTextItem,
-  Content,
   DropzoneErrorCode,
-} from '@patternfly/react-core';
+  FileUploadHelperText,
+} from '@patternfly/react-core/dist/esm/components/FileUpload';
+import { DropEvent } from '@patternfly/react-core/dist/esm/helpers/typeUtils';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { isValidWorkspaceKindYaml } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import { ValidationStatus } from '~/app/pages/WorkspaceKinds/Form/WorkspaceKindForm';
 

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImage.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImage.tsx
@@ -1,22 +1,24 @@
 import React, { useCallback, useState } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import {
-  Button,
-  Content,
   Modal,
   ModalHeader,
   ModalFooter,
   ModalVariant,
-  EmptyState,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import {
   EmptyStateFooter,
   EmptyStateActions,
+  EmptyState,
   EmptyStateBody,
-  ExpandableSection,
-} from '@patternfly/react-core';
-import { PlusCircleIcon, CubesIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import { WorkspaceKindImageConfigData, WorkspaceKindImageConfigValue } from '~/app/types';
 import { emptyImage } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import { WorkspaceKindFormPaginatedTable } from '~/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable';
-
 import { WorkspaceKindFormImageModal } from './WorkspaceKindFormImageModal';
 
 interface WorkspaceKindFormImageProps {

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImageModal.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImageModal.tsx
@@ -4,15 +4,16 @@ import {
   ModalHeader,
   ModalBody,
   ModalFooter,
-  Button,
-  Form,
-  FormGroup,
-  TextInput,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import {
   FormSelect,
   FormSelectOption,
-  Switch,
-  HelperText,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/FormSelect';
+import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
+import { HelperText } from '@patternfly/react-core/dist/esm/components/HelperText';
 import { WorkspaceKindImageConfigValue, ImagePullPolicy } from '~/app/types';
 import { EditableLabels } from '~/app/pages/WorkspaceKinds/Form/EditableLabels';
 import { emptyImage } from '~/app/pages/WorkspaceKinds/Form/helpers';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImagePort.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImagePort.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
+  FormGroup,
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
-  FormGroup,
-  Grid,
-  GridItem,
-  TextInput,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Form';
+import { Grid, GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { WorkspaceKindImagePort } from '~/app/types';
 
 interface WorkspaceKindFormImagePortProps {

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImageRedirect.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImageRedirect.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import {
+  FormGroup,
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
-  FormGroup,
+} from '@patternfly/react-core/dist/esm/components/Form';
+import {
   FormSelect,
   FormSelectOption,
-  TextInput,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/FormSelect';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import {
   WorkspaceOptionRedirect,
   WorkspaceRedirectMessageLevel,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/ResourceInputWrapper.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/ResourceInputWrapper.tsx
@@ -2,10 +2,9 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import {
   FormSelect,
   FormSelectOption,
-  NumberInput,
-  Split,
-  SplitItem,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/FormSelect';
+import { NumberInput } from '@patternfly/react-core/dist/esm/components/NumberInput';
+import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import {
   CPU_UNITS,
   MEMORY_UNITS_FOR_SELECTION,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
@@ -1,18 +1,21 @@
 import React, { useCallback, useState } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import {
-  Button,
-  Content,
   Modal,
   ModalHeader,
   ModalFooter,
   ModalVariant,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import {
   EmptyState,
+  EmptyStateBody,
   EmptyStateFooter,
   EmptyStateActions,
-  ExpandableSection,
-  EmptyStateBody,
-} from '@patternfly/react-core';
-import { PlusCircleIcon, CubesIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import { emptyPodConfig } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import { WorkspaceKindPodConfigValue, WorkspaceKindPodConfigData } from '~/app/types';
 import { WorkspaceKindFormPaginatedTable } from '~/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfigModal.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfigModal.tsx
@@ -4,13 +4,12 @@ import {
   ModalHeader,
   ModalBody,
   ModalFooter,
-  Button,
-  Form,
-  FormGroup,
-  TextInput,
-  Switch,
-  HelperText,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
+import { HelperText } from '@patternfly/react-core/dist/esm/components/HelperText';
 import { WorkspaceKindPodConfigValue } from '~/app/types';
 import { WorkspaceOptionLabel } from '~/shared/api/backendApiTypes';
 import { EditableLabels } from '~/app/pages/WorkspaceKinds/Form/EditableLabels';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormResource.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormResource.tsx
@@ -1,17 +1,16 @@
 import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Grid, GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import {
-  Button,
-  Grid,
-  GridItem,
-  Title,
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
-  TextInput,
-  Checkbox,
-  HelperText,
-  HelperTextItem,
-} from '@patternfly/react-core';
-import { PlusCircleIcon, TrashAltIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/Form';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Checkbox } from '@patternfly/react-core/dist/esm/components/Checkbox';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import { TrashAltIcon } from '@patternfly/react-icons/dist/esm/icons/trash-alt-icon';
 import { generateUniqueId } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import { isMemoryLimitLarger } from '~/shared/utilities/valueUnits';
 import { ResourceInputWrapper } from './ResourceInputWrapper';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
@@ -1,14 +1,13 @@
+import React, { useCallback, useState } from 'react';
 import {
-  ExpandableSection,
   Form,
   FormFieldGroup,
   FormFieldGroupHeader,
   FormGroup,
-  HelperText,
-  HelperTextItem,
-  Switch,
-} from '@patternfly/react-core';
-import React, { useCallback, useState } from 'react';
+} from '@patternfly/react-core/dist/esm/components/Form';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
 import { WorkspaceKindPodTemplateData } from '~/app/types';
 import { EditableLabels } from '~/app/pages/WorkspaceKinds/Form/EditableLabels';
 import { WorkspacePodVolumeMount } from '~/shared/api/backendApiTypes';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindFormProperties.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindFormProperties.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
-import {
-  Content,
-  ExpandableSection,
-  Form,
-  FormGroup,
-  HelperText,
-  Switch,
-  TextInput,
-} from '@patternfly/react-core';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { HelperText } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { WorkspaceKindProperties } from '~/app/types';
 
 interface WorkspaceKindFormPropertiesProps {

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/WorkspaceKinds.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/WorkspaceKinds.tsx
@@ -3,25 +3,29 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
-  PageSection,
-  Content,
-  Tooltip,
-  Label,
+} from '@patternfly/react-core/dist/esm/components/Drawer';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  ToolbarGroup,
+  ToolbarFilter,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core/dist/esm/components/Toolbar';
+import {
   Menu,
   MenuContent,
   MenuList,
   MenuItem,
-  MenuToggle,
-  Popper,
-  ToolbarGroup,
-  ToolbarFilter,
-  ToolbarToggleGroup,
-  Bullseye,
-  Button,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Menu';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Popper } from '@patternfly/react-core/helpers';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
   Table,
   Thead,
@@ -32,8 +36,8 @@ import {
   ThProps,
   ActionsColumn,
   IActions,
-} from '@patternfly/react-table';
-import { FilterIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-table/dist/esm/components/Table';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { useWorkspaceCountPerKind } from '~/app/hooks/useWorkspaceCountPerKind';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetails.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetails.tsx
@@ -3,15 +3,17 @@ import {
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
-  DrawerPanelBody,
   DrawerPanelContent,
+  DrawerPanelBody,
+} from '@patternfly/react-core/dist/esm/components/Drawer';
+import {
   Tabs,
   Tab,
   TabTitleText,
-  Title,
   TabContentBody,
   TabContent,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Tabs';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import { WorkspaceCountPerKind } from '~/app/hooks/useWorkspaceCountPerKind';
 import { WorkspaceKindDetailsNamespaces } from '~/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsNamespaces';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx
@@ -4,8 +4,8 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-  Divider,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import ImageFallback from '~/shared/components/ImageFallback';
 import WithValidImage from '~/shared/components/WithValidImage';

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsTable.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsTable.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo, useState } from 'react';
-import { Table, Thead, Tr, Td, Tbody, Th } from '@patternfly/react-table';
-import { Button, Content, Pagination, PaginationVariant } from '@patternfly/react-core';
+import { Table, Thead, Tr, Td, Tbody, Th } from '@patternfly/react-table/dist/esm/components/Table';
+import {
+  Pagination,
+  PaginationVariant,
+} from '@patternfly/react-core/dist/esm/components/Pagination';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { useTypedNavigate } from '~/app/routerHelper';
 import { RouteStateMap } from '~/app/routes';
 

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/summary/WorkspaceKindSummary.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/summary/WorkspaceKindSummary.tsx
@@ -1,13 +1,9 @@
 import React, { useCallback, useRef, useState } from 'react';
-import {
-  Button,
-  Content,
-  ContentVariants,
-  PageSection,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
-import { ArrowLeftIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { ArrowLeftIcon } from '@patternfly/react-icons/dist/esm/icons/arrow-left-icon';
 import { useTypedLocation, useTypedNavigate, useTypedParams } from '~/app/routerHelper';
 import WorkspaceTable, {
   WorkspaceTableFilteredColumn,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/summary/WorkspaceKindSummaryExpandableCard.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/summary/WorkspaceKindSummaryExpandableCard.tsx
@@ -1,20 +1,17 @@
 import React, { useMemo } from 'react';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
-  Bullseye,
-  Button,
   Card,
   CardBody,
-  CardExpandableContent,
   CardHeader,
   CardTitle,
-  Content,
-  ContentVariants,
-  Divider,
-  Flex,
-  FlexItem,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+  CardExpandableContent,
+} from '@patternfly/react-core/dist/esm/components/Card';
+import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
 import {
   t_global_spacer_md as MediumPadding,
   t_global_font_size_4xl as LargeFontSize,

--- a/workspaces/frontend/src/app/pages/Workspaces/DataVolumesList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/DataVolumesList.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 import {
   ClipboardCopy,
   ClipboardCopyVariant,
-  Content,
+} from '@patternfly/react-core/dist/esm/components/ClipboardCopy';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import {
   DescriptionList,
   DescriptionListGroup,
   DescriptionListTerm,
   DescriptionListDescription,
-  Flex,
-  FlexItem,
-  List,
-  ListItem,
-  Tooltip,
-} from '@patternfly/react-core';
-import { DatabaseIcon, LockedIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { List, ListItem } from '@patternfly/react-core/dist/esm/components/List';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { DatabaseIcon } from '@patternfly/react-icons/dist/esm/icons/database-icon';
+import { LockedIcon } from '@patternfly/react-icons/dist/esm/icons/locked-icon';
 import { Workspace } from '~/shared/api/backendApiTypes';
 
 interface DataVolumesListProps {

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
@@ -3,15 +3,17 @@ import {
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
-  DrawerPanelBody,
   DrawerPanelContent,
+  DrawerPanelBody,
+} from '@patternfly/react-core/dist/esm/components/Drawer';
+import {
   Tabs,
   Tab,
   TabTitleText,
-  Title,
   TabContentBody,
   TabContent,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Tabs';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { WorkspaceDetailsOverview } from '~/app/pages/Workspaces/Details/WorkspaceDetailsOverview';
 import { WorkspaceDetailsActions } from '~/app/pages/Workspaces/Details/WorkspaceDetailsActions';

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActions.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActions.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
 import {
   Dropdown,
-  DropdownList,
-  MenuToggle,
   DropdownItem,
-  Flex,
-  FlexItem,
-} from '@patternfly/react-core';
+  DropdownList,
+} from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 
 interface WorkspaceDetailsActionsProps {
   // TODO: Uncomment when edit action is fully supported

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { format } from 'date-fns';
+import { format } from 'date-fns/format';
 import {
   DescriptionList,
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-  Divider,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { Workspace } from '~/shared/api/backendApiTypes';
 
 const DATE_FORMAT = 'PPpp';

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
@@ -4,8 +4,8 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-  Divider,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { Workspace } from '~/shared/api/backendApiTypes';
 
 type WorkspaceDetailsOverviewProps = {

--- a/workspaces/frontend/src/app/pages/Workspaces/ExpandedWorkspaceRow.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/ExpandedWorkspaceRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
+import { Tr, Td, ExpandableRowContent } from '@patternfly/react-table/dist/esm/components/Table';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { WorkspaceTableColumnKeys } from '~/app/components/WorkspaceTable';
 import { WorkspaceStorage } from './WorkspaceStorage';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -1,23 +1,24 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import {
-  Button,
-  Content,
-  Drawer,
-  DrawerContent,
-  DrawerContentBody,
-  DrawerPanelContent,
-  DrawerHead,
-  DrawerActions,
-  DrawerCloseButton,
-  DrawerPanelBody,
-  Flex,
-  FlexItem,
-  PageSection,
   ProgressStep,
   ProgressStepper,
-  Stack,
-  Title,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/ProgressStepper';
+import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import {
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+} from '@patternfly/react-core/dist/esm/components/Drawer';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import useGenericObjectState from '~/app/hooks/useGenericObjectState';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { WorkspaceFormImageSelection } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormDrawer.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormDrawer.tsx
@@ -7,8 +7,8 @@ import {
   DrawerHead,
   DrawerActions,
   DrawerCloseButton,
-  Title,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Drawer';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 
 interface WorkspaceFormDrawerProps {
   children: React.ReactNode;

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails.tsx
@@ -4,8 +4,8 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-  Title,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import { WorkspacePodConfigValue } from '~/shared/api/backendApiTypes';
 import { formatLabelKey } from '~/shared/utilities/WorkspaceUtils';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageList.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   CardTitle,
-  Gallery,
-  PageSection,
-  Toolbar,
-  ToolbarContent,
   Card,
   CardHeader,
   CardBody,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Card';
+import { Gallery } from '@patternfly/react-core/dist/esm/layouts/Gallery';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Toolbar, ToolbarContent } from '@patternfly/react-core/dist/esm/components/Toolbar';
 import Filter, { FilteredColumn, FilterRef } from '~/shared/components/Filter';
 import { WorkspaceImageConfigValue } from '~/shared/api/backendApiTypes';
 import CustomEmptyState from '~/shared/components/CustomEmptyState';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { Content, Split, SplitItem } from '@patternfly/react-core';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import { WorkspaceFormImageList } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageList';
 import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
 import { WorkspaceImageConfigValue } from '~/shared/api/backendApiTypes';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Title } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 
 type WorkspaceFormKindDetailsProps = {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
@@ -2,13 +2,12 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   CardBody,
   CardTitle,
-  Gallery,
-  PageSection,
-  Toolbar,
-  ToolbarContent,
   Card,
   CardHeader,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Card';
+import { Gallery } from '@patternfly/react-core/dist/esm/layouts/Gallery';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Toolbar, ToolbarContent } from '@patternfly/react-core/dist/esm/components/Toolbar';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import Filter, { FilteredColumn, FilterRef } from '~/shared/components/Filter';
 import CustomEmptyState from '~/shared/components/CustomEmptyState';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Content } from '@patternfly/react-core';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { WorkspaceFormKindList } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindList';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigDetails.tsx
@@ -4,9 +4,9 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-  Title,
-  Divider,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { WorkspacePodConfigValue } from '~/shared/api/backendApiTypes';
 import { formatLabelKey } from '~/shared/utilities/WorkspaceUtils';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   CardTitle,
-  Gallery,
-  PageSection,
-  Toolbar,
-  ToolbarContent,
   Card,
   CardHeader,
   CardBody,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Card';
+import { Gallery } from '@patternfly/react-core/dist/esm/layouts/Gallery';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Toolbar, ToolbarContent } from '@patternfly/react-core/dist/esm/components/Toolbar';
 import { WorkspacePodConfigValue } from '~/shared/api/backendApiTypes';
 import Filter, { FilteredColumn, FilterRef } from '~/shared/components/Filter';
 import CustomEmptyState from '~/shared/components/CustomEmptyState';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { Content, Split, SplitItem } from '@patternfly/react-core';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import { WorkspaceFormPodConfigList } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList';
 import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
 import { WorkspacePodConfigValue } from '~/shared/api/backendApiTypes';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSecrets.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSecrets.tsx
@@ -1,23 +1,29 @@
 import React, { useCallback, useState } from 'react';
-import { EllipsisVIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { Table, Thead, Tbody, Tr, Th, Td, TableVariant } from '@patternfly/react-table';
+import { EllipsisVIcon } from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import {
-  Button,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableVariant,
+} from '@patternfly/react-table/dist/esm/components/Table';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import {
   Modal,
-  ModalVariant,
-  TextInput,
-  Dropdown,
-  DropdownItem,
-  MenuToggle,
   ModalBody,
   ModalFooter,
-  Form,
-  FormGroup,
   ModalHeader,
-  ValidatedOptions,
-  HelperText,
-  HelperTextItem,
-} from '@patternfly/react-core';
+  ModalVariant,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { ValidatedOptions } from '@patternfly/react-core/helpers';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Dropdown, DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { WorkspacePodSecretMount } from '~/shared/api/backendApiTypes';
 
 interface WorkspaceFormPropertiesSecretsProps {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSelection.tsx
@@ -1,15 +1,11 @@
 import React, { useMemo, useState } from 'react';
-import {
-  Checkbox,
-  Content,
-  Divider,
-  ExpandableSection,
-  Form,
-  FormGroup,
-  Split,
-  SplitItem,
-  TextInput,
-} from '@patternfly/react-core';
+import { Checkbox } from '@patternfly/react-core/dist/esm/components/Checkbox';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { WorkspaceFormImageDetails } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails';
 import { WorkspaceFormPropertiesVolumes } from '~/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes';
 import { WorkspaceFormProperties } from '~/app/types';

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes.tsx
@@ -1,21 +1,28 @@
 import React, { useCallback, useState } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Dropdown, DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import {
-  Button,
-  Dropdown,
-  DropdownItem,
-  Form,
-  FormGroup,
-  MenuToggle,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
   ModalVariant,
-  Switch,
-  TextInput,
-} from '@patternfly/react-core';
-import { EllipsisVIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { EllipsisVIcon } from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+import {
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table/dist/esm/components/Table';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { WorkspacePodVolumeMount } from '~/shared/api/backendApiTypes';
 
 interface WorkspaceFormPropertiesVolumesProps {

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConfigDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConfigDetails.tsx
@@ -4,7 +4,7 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { formatResourceFromWorkspace } from '~/shared/utilities/WorkspaceUtils';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
@@ -3,10 +3,12 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+} from '@patternfly/react-core/dist/esm/components/Dropdown';
+import {
   MenuToggle,
   MenuToggleElement,
   MenuToggleAction,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import { Workspace, WorkspaceState } from '~/shared/api/backendApiTypes';
 
 type WorkspaceConnectActionProps = {

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspacePackageDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspacePackageDetails.tsx
@@ -3,10 +3,9 @@ import {
   DescriptionList,
   DescriptionListTerm,
   DescriptionListDescription,
-  ListItem,
-  List,
   DescriptionListGroup,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
+import { ListItem, List } from '@patternfly/react-core/dist/esm/components/List';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { extractPackageLabels, formatLabelKey } from '~/shared/utilities/WorkspaceUtils';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceStorage.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceStorage.tsx
@@ -4,7 +4,7 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { DataVolumesList } from '~/app/pages/Workspaces/DataVolumesList';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Content, ContentVariants, PageSection, Stack, StackItem } from '@patternfly/react-core';
+import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
 import WorkspaceTable from '~/app/components/WorkspaceTable';
 import { useNamespaceContext } from '~/app/context/NamespaceContextProvider';
 import { useWorkspacesByNamespace } from '~/app/hooks/useWorkspaces';

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { ExpandableSection, Icon, Tab, Tabs, TabTitleText, Content } from '@patternfly/react-core';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { Icon } from '@patternfly/react-core/dist/esm/components/Icon';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import useWorkspaceKindByName from '~/app/hooks/useWorkspaceKindByName';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRestartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRestartActionModal.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import {
-  Button,
-  Content,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TabTitleText,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
 import { Workspace } from '~/shared/api/backendApiTypes';
 import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
 

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
-  Button,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TabTitleText,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
 import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
 import { Workspace, WorkspacePauseState } from '~/shared/api/backendApiTypes';
 import { ActionButton } from '~/shared/components/ActionButton';

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useState } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import {
-  Button,
-  Content,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TabTitleText,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
 import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
 import { Workspace, WorkspacePauseState } from '~/shared/api/backendApiTypes';
 import { ActionButton } from '~/shared/components/ActionButton';

--- a/workspaces/frontend/src/app/pages/notFound/NotFound.tsx
+++ b/workspaces/frontend/src/app/pages/notFound/NotFound.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
-  Button,
   EmptyState,
   EmptyStateBody,
   EmptyStateFooter,
-  PageSection,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import { useTypedNavigate } from '~/app/routerHelper';
 
 const NotFound: React.FunctionComponent = () => {

--- a/workspaces/frontend/src/shared/components/ActionButton.tsx
+++ b/workspaces/frontend/src/shared/components/ActionButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 
 type ActionButtonProps = {
   action: string;

--- a/workspaces/frontend/src/shared/components/CustomEmptyState.tsx
+++ b/workspaces/frontend/src/shared/components/CustomEmptyState.tsx
@@ -4,9 +4,9 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   EmptyStateActions,
-  Button,
-} from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 interface CustomEmptyStateProps {
   onClearFilters: () => void;

--- a/workspaces/frontend/src/shared/components/DeleteModal.tsx
+++ b/workspaces/frontend/src/shared/components/DeleteModal.tsx
@@ -5,14 +5,12 @@ import {
   ModalFooter,
   ModalHeader,
   ModalVariant,
-  Button,
-  TextInput,
-  Stack,
-  StackItem,
-  FlexItem,
-  HelperText,
-  HelperTextItem,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
 import { default as ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { ActionButton } from '~/shared/components/ActionButton';
 

--- a/workspaces/frontend/src/shared/components/Filter.tsx
+++ b/workspaces/frontend/src/shared/components/Filter.tsx
@@ -11,17 +11,21 @@ import {
   MenuContent,
   MenuItem,
   MenuList,
+} from '@patternfly/react-core/dist/esm/components/Menu';
+import {
   MenuToggle,
   MenuToggleElement,
-  Popper,
+} from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Popper } from '@patternfly/react-core/helpers';
+import {
   Toolbar,
   ToolbarContent,
-  ToolbarFilter,
   ToolbarGroup,
   ToolbarItem,
+  ToolbarFilter,
   ToolbarToggleGroup,
-} from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
+} from '@patternfly/react-core/dist/esm/components/Toolbar';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import ThemeAwareSearchInput from '~/app/components/ThemeAwareSearchInput';
 
 export interface FilterProps {

--- a/workspaces/frontend/src/shared/components/ImageFallback.tsx
+++ b/workspaces/frontend/src/shared/components/ImageFallback.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { Content, ContentVariants, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
 
 type ImageFallbackProps = {
   extended?: boolean;

--- a/workspaces/frontend/src/shared/components/NamespaceSelector.tsx
+++ b/workspaces/frontend/src/shared/components/NamespaceSelector.tsx
@@ -2,18 +2,15 @@ import React, { FC, useEffect, useMemo, useState } from 'react';
 import {
   Dropdown,
   DropdownItem,
-  MenuToggle,
   DropdownList,
   DropdownProps,
-  MenuSearch,
-  MenuSearchInput,
-  InputGroup,
-  InputGroupItem,
-  SearchInput,
-  Button,
-  ButtonVariant,
-  Divider,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { MenuSearch, MenuSearchInput } from '@patternfly/react-core/dist/esm/components/Menu';
+import { InputGroup, InputGroupItem } from '@patternfly/react-core/dist/esm/components/InputGroup';
+import { SearchInput } from '@patternfly/react-core/dist/esm/components/SearchInput';
+import { Button, ButtonVariant } from '@patternfly/react-core/dist/esm/components/Button';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { useNamespaceContext } from '~/app/context/NamespaceContextProvider';
 

--- a/workspaces/frontend/src/shared/components/WithValidImage.tsx
+++ b/workspaces/frontend/src/shared/components/WithValidImage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Skeleton, SkeletonProps } from '@patternfly/react-core';
+import { Skeleton, SkeletonProps } from '@patternfly/react-core/dist/esm/components/Skeleton';
 
 type WithValidImageProps = {
   imageSrc: string | undefined | null;


### PR DESCRIPTION
Enforce component specific imports for `@patternfly`, `date-fns` and `lodash`.

If a general import is made, an error like this will happen:
```
error  '@patternfly/react-core' import is restricted from being used. Use specific component imports: @patternfly/react-core/dist/esm/components/ComponentName  no-restricted-imports
```

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->