### PR TITLE
chore(ws): Add support for PF utility classes

### DIFF
--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@patternfly/patternfly": "^6.2.3",
         "@patternfly/react-catalog-view-extension": "^6.1.0",
         "@patternfly/react-code-editor": "^6.2.0",
         "@patternfly/react-core": "^6.2.0",
@@ -4727,6 +4728,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/@patternfly/patternfly": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.2.3.tgz",
+      "integrity": "sha512-FR027W7JygcQpvlRU/Iom936Vm0apzfi2o5lvtlcWW6IaeZCCTtTaDxehoYuELHlemzkLziQAgu6LuCJEVayjw=="
     },
     "node_modules/@patternfly/react-catalog-view-extension": {
       "version": "6.1.0",

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -104,6 +104,7 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
+    "@patternfly/patternfly": "^6.2.3",
     "@patternfly/react-catalog-view-extension": "^6.1.0",
     "@patternfly/react-code-editor": "^6.2.0",
     "@patternfly/react-core": "^6.2.0",

--- a/workspaces/frontend/src/app/App.tsx
+++ b/workspaces/frontend/src/app/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import '@patternfly/patternfly/patternfly-addons.css';
 import '@patternfly/react-core/dist/styles/base.css';
 import './app.css';
 import {


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

### Summary
Adds support for PatternFly [utility classes]( https://www.patternfly.org/utility-classes/about-utility-classes/).

### Changes
- Added `@patternfly/patternfly/patternfly-addons.css` import to `App.tsx`
- Enables usage of PatternFly utility classes throughout the application (spacing, display, text, sizing, flex, background, etc.)

### Benefits
- Provides access to PatternFly's comprehensive utility class system
- Prevents inline/custom CSS for common styling patterns

### Testing Instructions
1. Add `className="pf-v6-u-text-color-brand"` to the Title component on line 54 of `workspaces/frontend/src/app/App.tsx`:
   ```tsx
   <Title headingLevel="h2" size="3xl" className="pf-v6-u-text-color-brand">
     Kubeflow Notebooks 2.0
   </Title>
   ```
2. Save the file and verify the application title text appears in blue (PatternFly brand color)
3. Remove the test class when verification is complete

### Related
- Closes: #420
- Related: https://github.com/kubeflow/notebooks/pull/473