### PR TITLE
feat: Implement DELETE endpoint for WorkspaceKind

### DIFF
--- a/workspaces/backend/README.md
+++ b/workspaces/backend/README.md
@@ -50,7 +50,7 @@ make run PORT=8000
 | GET /api/v1/workspacekinds/{name}                         | workspacekinds_handler    | Get a WorkspaceKind entity              |
 | PATCH /api/v1/workspacekinds/{name}                       | TBD                       | Patch a WorkspaceKind entity            |
 | PUT /api/v1/workspacekinds/{name}                         | TBD                       | Update a WorkspaceKind entity           |
-| DELETE /api/v1/workspacekinds/{name}                      | TBD                       | Delete a WorkspaceKind entity           |
+| DELETE /api/v1/workspacekinds/{name}                      | workspacekinds_handler    | Delete a WorkspaceKind entity           |
 
 ### Sample local calls
 
@@ -173,4 +173,11 @@ Get a WorkspaceKind:
 ```shell
 # GET /api/v1/workspacekinds/{name}
 curl -i localhost:4000/api/v1/workspacekinds/jupyterlab
+```
+
+Delete a WorkspaceKind:
+
+```shell
+# DELETE /api/v1/workspacekinds/{name}
+curl -X DELETE localhost:4000/api/v1/workspacekinds/jupyterlab
 ```

--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -144,6 +144,7 @@ func (a *App) Routes() http.Handler {
 	router.GET(AllWorkspaceKindsPath, a.GetWorkspaceKindsHandler)
 	router.GET(WorkspaceKindsByNamePath, a.GetWorkspaceKindHandler)
 	router.POST(AllWorkspaceKindsPath, a.CreateWorkspaceKindHandler)
+	router.DELETE(WorkspaceKindsByNamePath, a.DeleteWorkspaceKindHandler)
 	router.POST(PodTemplateOptionsListValuesPath, a.PodTemplateOptionsListValuesHandler)
 
 	// storageclasses

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -150,6 +150,59 @@ func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _
 	a.dataResponse(w, r, responseEnvelope)
 }
 
+// DeleteWorkspaceKindHandler deletes a specific workspace kind by name.
+//
+//	@Summary		Delete workspace kind
+//	@Description	Deletes a specific workspace kind identified by its name.
+//	@Tags			workspacekinds
+//	@ID				deleteWorkspaceKind
+//	@Accept			json
+//	@Param			name	path		string			true	"Name of the workspace kind"	extensions(x-example=jupyterlab)
+//	@Success		204		{object}	nil				"Workspace kind deleted successfully"
+//	@Failure		401		{object}	ErrorEnvelope	"Unauthorized. Authentication is required."
+//	@Failure		403		{object}	ErrorEnvelope	"Forbidden. User does not have permission to delete the workspace kind."
+//	@Failure		404		{object}	ErrorEnvelope	"Not Found. Workspace kind does not exist."
+//	@Failure		409		{object}	ErrorEnvelope	"Conflict. Workspace kind is in use by one or more workspaces."
+//	@Failure		422		{object}	ErrorEnvelope	"Unprocessable Entity. Validation error."
+//	@Failure		500		{object}	ErrorEnvelope	"Internal server error. An unexpected error occurred on the server."
+//	@Router			/workspacekinds/{name} [delete]
+func (a *App) DeleteWorkspaceKindHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	name := ps.ByName(ResourceNamePathParam)
+
+	// validate path parameters
+	var valErrs field.ErrorList
+	valErrs = append(valErrs, helper.ValidateWorkspaceKindName(field.NewPath(ResourceNamePathParam), name)...)
+	if len(valErrs) > 0 {
+		a.failedValidationResponse(w, r, errMsgPathParamsInvalid, valErrs, nil)
+		return
+	}
+
+	// =========================== AUTH ===========================
+	authPolicies := []*auth.ResourcePolicy{
+		auth.NewResourcePolicy(auth.VerbDelete, auth.WorkspaceKinds, auth.ResourcePolicyResourceMeta{Name: name}),
+	}
+	if success := a.requireAuth(w, r, authPolicies); !success {
+		return
+	}
+	// ============================================================
+
+	err := a.repositories.WorkspaceKind.DeleteWorkspaceKind(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, repository.ErrWorkspaceKindNotFound) {
+			a.notFoundResponse(w, r)
+			return
+		} else if apierrors.IsConflict(err) {
+			causes := helper.StatusCausesFromAPIStatus(err)
+			a.conflictResponse(w, r, err, causes)
+			return
+		}
+		a.serverErrorResponse(w, r, fmt.Errorf("error deleting workspace kind: %w", err))
+		return
+	}
+
+	a.deletedResponse(w, r)
+}
+
 // CreateWorkspaceKindHandler creates a new workspace kind.
 //
 //	@Summary		Create workspace kind

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -591,6 +592,176 @@ metadata:
 					},
 				},
 			))
+		})
+	})
+
+	// NOTE: these tests create and delete resources on the cluster, so cannot be run in parallel.
+	//       therefore, we run them using the `Serial` Ginkgo decorator.
+	Context("when deleting a WorkspaceKind", Serial, func() {
+
+		var (
+			workspaceKindName string
+			workspaceKindKey  types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			uniqueName := fmt.Sprintf("wsk-delete-test-%d", GinkgoRandomSeed())
+			workspaceKindName = fmt.Sprintf("workspacekind-%s", uniqueName)
+			workspaceKindKey = types.NamespacedName{Name: workspaceKindName}
+
+			By("creating the WorkspaceKind to delete")
+			workspaceKindToDelete := NewExampleWorkspaceKind(workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspaceKindToDelete)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up the WorkspaceKind")
+			workspaceKind := &kubefloworgv1beta1.WorkspaceKind{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workspaceKindName,
+				},
+			}
+			_ = k8sClient.Delete(ctx, workspaceKind)
+		})
+
+		It("should successfully delete an existing WorkspaceKind", func() {
+			By("creating the HTTP request to delete the WorkspaceKind")
+			path := strings.Replace(WorkspaceKindsByNamePath, ":"+ResourceNamePathParam, workspaceKindName, 1)
+			req, err := http.NewRequest(http.MethodDelete, path, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing DeleteWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{
+					Key:   ResourceNamePathParam,
+					Value: workspaceKindName,
+				},
+			}
+			a.DeleteWorkspaceKindHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusNoContent), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("ensuring the WorkspaceKind has been deleted")
+			deletedWorkspaceKind := &kubefloworgv1beta1.WorkspaceKind{}
+			err = k8sClient.Get(ctx, workspaceKindKey, deletedWorkspaceKind)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should return 404 when trying to delete a non-existent WorkspaceKind", func() {
+			nonExistentName := "non-existent-workspacekind"
+
+			By("creating the HTTP request to delete a non-existent WorkspaceKind")
+			path := strings.Replace(WorkspaceKindsByNamePath, ":"+ResourceNamePathParam, nonExistentName, 1)
+			req, err := http.NewRequest(http.MethodDelete, path, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing DeleteWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{
+					Key:   ResourceNamePathParam,
+					Value: nonExistentName,
+				},
+			}
+			a.DeleteWorkspaceKindHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound), descUnexpectedHTTPStatus, rr.Body.String())
+		})
+
+		It("should return 422 when workspace kind name has invalid format", func() {
+			invalidName := "InvalidNameWithUppercase"
+
+			By("creating the HTTP request with invalid workspace kind name")
+			path := strings.Replace(WorkspaceKindsByNamePath, ":"+ResourceNamePathParam, invalidName, 1)
+			req, err := http.NewRequest(http.MethodDelete, path, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing DeleteWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{
+					Key:   ResourceNamePathParam,
+					Value: invalidName,
+				},
+			}
+			a.DeleteWorkspaceKindHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("decoding the error response")
+			var response ErrorEnvelope
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error message indicates validation failure")
+			Expect(response.Error.Message).To(ContainSubstring("path parameters were invalid"))
+		})
+
+		It("should return 401 when no authentication is provided", func() {
+			By("creating the HTTP request without auth headers")
+			path := strings.Replace(WorkspaceKindsByNamePath, ":"+ResourceNamePathParam, workspaceKindName, 1)
+			req, err := http.NewRequest(http.MethodDelete, path, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("executing DeleteWorkspaceKindHandler without auth")
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{
+					Key:   ResourceNamePathParam,
+					Value: workspaceKindName,
+				},
+			}
+			a.DeleteWorkspaceKindHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnauthorized), descUnexpectedHTTPStatus, rr.Body.String())
+		})
+
+		It("should return 403 when user lacks permission to delete workspace kind", func() {
+			By("creating the HTTP request with non-admin user")
+			path := strings.Replace(WorkspaceKindsByNamePath, ":"+ResourceNamePathParam, workspaceKindName, 1)
+			req, err := http.NewRequest(http.MethodDelete, path, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers with non-admin user")
+			req.Header.Set(userIdHeader, "non-admin-user")
+
+			By("executing DeleteWorkspaceKindHandler")
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{
+					Key:   ResourceNamePathParam,
+					Value: workspaceKindName,
+				},
+			}
+			a.DeleteWorkspaceKindHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden), descUnexpectedHTTPStatus, rr.Body.String())
 		})
 	})
 })

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -22,6 +22,7 @@ import (
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds"
@@ -92,6 +93,23 @@ func (r *WorkspaceKindRepository) Create(ctx context.Context, workspaceKind *kub
 	createdWorkspaceKindModel := models.NewWorkspaceKindModelFromWorkspaceKind(workspaceKind)
 
 	return &createdWorkspaceKindModel, nil
+}
+
+func (r *WorkspaceKindRepository) DeleteWorkspaceKind(ctx context.Context, name string) error {
+	workspaceKind := &kubefloworgv1beta1.WorkspaceKind{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := r.client.Delete(ctx, workspaceKind); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrWorkspaceKindNotFound
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Context, name string, listValuesRequest *modelsPodTemplateOptions.ListValuesRequest) (*modelsPodTemplateOptions.PodTemplateOptions, error) {

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -899,6 +899,68 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Deletes a specific workspace kind identified by its name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspacekinds"
+                ],
+                "summary": "Delete workspace kind",
+                "operationId": "deleteWorkspaceKind",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "jupyterlab",
+                        "description": "Name of the workspace kind",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Workspace kind deleted successfully"
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to delete the workspace kind.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found. Workspace kind does not exist.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict. Workspace kind is in use by one or more workspaces.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error. An unexpected error occurred on the server.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
             }
         },
         "/workspacekinds/{name}/podtemplate/options/listvalues": {

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -897,6 +897,68 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Deletes a specific workspace kind identified by its name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspacekinds"
+                ],
+                "summary": "Delete workspace kind",
+                "operationId": "deleteWorkspaceKind",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "jupyterlab",
+                        "description": "Name of the workspace kind",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Workspace kind deleted successfully"
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to delete the workspace kind.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found. Workspace kind does not exist.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict. Workspace kind is in use by one or more workspaces.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error. An unexpected error occurred on the server.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
             }
         },
         "/workspacekinds/{name}/podtemplate/options/listvalues": {


### PR DESCRIPTION
⚠️ _No GH Issue_ ⚠️ 

- Added the ability to delete a specific WorkspaceKind via a new DELETE API endpoint.
    - `DELETE /workspacekinds/{name}`
- Updated the README to include the new endpoint details and added corresponding tests to ensure proper functionality and error handling for various scenarios, including validation and authorization checks.
- Swagger files regenerated

The implementation is more or less a "carbon copy" of how it is implemented for Workspaces _with the exception_ of the need to handle the `Conflict` that can be returned by the admission webhook.

Example error response during a Conflict:
```
curl -X 'DELETE'   'http://localhost:4001/api/v1/workspacekinds/jupyterlab'   -H 'accept: application/json'
{
  "error": {
    "code": "409",
    "message": "kubernetes conflict error (see .cause.conflict_cause[] for details)",
    "cause": {
      "conflict_cause": [
        {
          "origin": "KUBERNETES",
          "message": "WorkspaceKind is used by 1 workspace(s)"
        }
      ]
    }
  }
}
```

Our testing framework does not currently run with webhooks - so I have deliberately **NOT** added a test case for this behavior.