### PR TITLE
feat(ws): Make Workspace Kind drawer resizable and add table view to WS kind details

### DIFF
--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetails.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetails.tsx
@@ -45,7 +45,7 @@ export const WorkspaceKindDetails: React.FunctionComponent<WorkspaceKindDetailsP
   };
 
   return (
-    <DrawerPanelContent data-testid="workspaceDetails">
+    <DrawerPanelContent minSize="45%" isResizable data-testid="workspaceDetails">
       <DrawerHead>
         <Title headingLevel="h6">{workspaceKind.name}</Title>
         <DrawerActions>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsImages.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsImages.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Button, List, ListItem } from '@patternfly/react-core';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import { WorkspaceCountPerKind } from '~/app/hooks/useWorkspaceCountPerKind';
-import { useTypedNavigate } from '~/app/routerHelper';
+import { WorkspaceKindDetailsTable } from './WorkspaceKindDetailsTable';
 
 type WorkspaceDetailsImagesProps = {
   workspaceKind: WorkspaceKind;
@@ -12,37 +11,21 @@ type WorkspaceDetailsImagesProps = {
 export const WorkspaceKindDetailsImages: React.FunctionComponent<WorkspaceDetailsImagesProps> = ({
   workspaceKind,
   workspaceCountPerKind,
-}) => {
-  const navigate = useTypedNavigate();
-
-  return (
-    <List isPlain>
-      {workspaceKind.podTemplate.options.imageConfig.values.map((image, rowIndex) => (
-        <ListItem key={rowIndex}>
-          {image.displayName}:{' '}
-          <Button
-            variant="link"
-            isInline
-            className="workspace-kind-summary-button"
-            onClick={() =>
-              navigate('workspaceKindSummary', {
-                params: { kind: workspaceKind.name },
-                state: {
-                  imageId: image.id,
-                },
-              })
-            }
-          >
-            {
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              workspaceCountPerKind[workspaceKind.name]
-                ? workspaceCountPerKind[workspaceKind.name].countByImage[image.id] ?? 0
-                : 0
-            }
-            {' Workspaces'}
-          </Button>
-        </ListItem>
-      ))}
-    </List>
-  );
-};
+}) => (
+  <WorkspaceKindDetailsTable
+    rows={workspaceKind.podTemplate.options.imageConfig.values.map((image) => ({
+      id: image.id,
+      displayName: image.displayName,
+      kindName: workspaceKind.name,
+      workspaceCountRouteState: {
+        imageId: image.id,
+      },
+      workspaceCount:
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        workspaceCountPerKind[workspaceKind.name]
+          ? workspaceCountPerKind[workspaceKind.name].countByImage[image.id] ?? 0
+          : 0,
+    }))}
+    tableKind="image"
+  />
+);

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsNamespaces.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsNamespaces.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Button, List, ListItem } from '@patternfly/react-core';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import { WorkspaceCountPerKind } from '~/app/hooks/useWorkspaceCountPerKind';
-import { useTypedNavigate } from '~/app/routerHelper';
+import { WorkspaceKindDetailsTable } from './WorkspaceKindDetailsTable';
 
 type WorkspaceDetailsNamespacesProps = {
   workspaceKind: WorkspaceKind;
@@ -11,42 +10,25 @@ type WorkspaceDetailsNamespacesProps = {
 
 export const WorkspaceKindDetailsNamespaces: React.FunctionComponent<
   WorkspaceDetailsNamespacesProps
-> = ({ workspaceKind, workspaceCountPerKind }) => {
-  const navigate = useTypedNavigate();
-
-  return (
-    <List isPlain>
-      {Object.keys(
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        workspaceCountPerKind[workspaceKind.name]
-          ? workspaceCountPerKind[workspaceKind.name].countByNamespace
-          : [],
-      ).map((namespace, rowIndex) => (
-        <ListItem key={rowIndex}>
-          {namespace}:{' '}
-          <Button
-            variant="link"
-            className="workspace-kind-summary-button"
-            isInline
-            onClick={() =>
-              navigate('workspaceKindSummary', {
-                params: { kind: workspaceKind.name },
-                state: {
-                  namespace,
-                },
-              })
-            }
-          >
-            {
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              workspaceCountPerKind[workspaceKind.name]
-                ? workspaceCountPerKind[workspaceKind.name].countByNamespace[namespace]
-                : 0
-            }
-            {' Workspaces'}
-          </Button>
-        </ListItem>
-      ))}
-    </List>
-  );
-};
+> = ({ workspaceKind, workspaceCountPerKind }) => (
+  <WorkspaceKindDetailsTable
+    rows={Object.keys(
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      workspaceCountPerKind[workspaceKind.name]
+        ? workspaceCountPerKind[workspaceKind.name].countByNamespace
+        : [],
+    ).map((namespace, rowIndex) => ({
+      id: String(rowIndex),
+      displayName: namespace,
+      kindName: workspaceKind.name,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      workspaceCount: workspaceCountPerKind[workspaceKind.name]
+        ? workspaceCountPerKind[workspaceKind.name].countByNamespace[namespace]
+        : 0,
+      workspaceCountRouteState: {
+        namespace,
+      },
+    }))}
+    tableKind="namespace"
+  />
+);

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsPodConfigs.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsPodConfigs.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Button, List, ListItem } from '@patternfly/react-core';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import { WorkspaceCountPerKind } from '~/app/hooks/useWorkspaceCountPerKind';
-import { useTypedNavigate } from '~/app/routerHelper';
+import { WorkspaceKindDetailsTable } from './WorkspaceKindDetailsTable';
 
 type WorkspaceDetailsPodConfigsProps = {
   workspaceKind: WorkspaceKind;
@@ -11,37 +10,20 @@ type WorkspaceDetailsPodConfigsProps = {
 
 export const WorkspaceKindDetailsPodConfigs: React.FunctionComponent<
   WorkspaceDetailsPodConfigsProps
-> = ({ workspaceKind, workspaceCountPerKind }) => {
-  const navigate = useTypedNavigate();
-
-  return (
-    <List isPlain>
-      {workspaceKind.podTemplate.options.podConfig.values.map((podConfig, rowIndex) => (
-        <ListItem key={rowIndex}>
-          {podConfig.displayName}:{' '}
-          <Button
-            variant="link"
-            className="workspace-kind-summary-button"
-            isInline
-            onClick={() =>
-              navigate('workspaceKindSummary', {
-                params: { kind: workspaceKind.name },
-                state: {
-                  podConfigId: podConfig.id,
-                },
-              })
-            }
-          >
-            {
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              workspaceCountPerKind[workspaceKind.name]
-                ? workspaceCountPerKind[workspaceKind.name].countByPodConfig[podConfig.id] ?? 0
-                : 0
-            }
-            {' Workspaces'}
-          </Button>
-        </ListItem>
-      ))}
-    </List>
-  );
-};
+> = ({ workspaceKind, workspaceCountPerKind }) => (
+  <WorkspaceKindDetailsTable
+    rows={workspaceKind.podTemplate.options.podConfig.values.map((podConfig) => ({
+      id: podConfig.id,
+      displayName: podConfig.displayName,
+      kindName: workspaceKind.name,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      workspaceCount: workspaceCountPerKind[workspaceKind.name]
+        ? workspaceCountPerKind[workspaceKind.name].countByPodConfig[podConfig.id] ?? 0
+        : 0,
+      workspaceCountRouteState: {
+        podConfigId: podConfig.id,
+      },
+    }))}
+    tableKind="podConfig"
+  />
+);

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsTable.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsTable.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo, useState } from 'react';
+import { Table, Thead, Tr, Td, Tbody, Th } from '@patternfly/react-table';
+import { Button, Content, Pagination, PaginationVariant } from '@patternfly/react-core';
+import { useTypedNavigate } from '~/app/routerHelper';
+import { RouteStateMap } from '~/app/routes';
+
+export interface WorkspaceKindDetailsTableRow {
+  id: string;
+  displayName: string;
+  kindName: string;
+  workspaceCount: number;
+  workspaceCountRouteState: RouteStateMap['workspaceKindSummary'];
+}
+
+interface WorkspaceKindDetailsTableProps {
+  rows: WorkspaceKindDetailsTableRow[];
+  tableKind: 'image' | 'podConfig' | 'namespace';
+}
+
+export const WorkspaceKindDetailsTable: React.FC<WorkspaceKindDetailsTableProps> = ({
+  rows,
+  tableKind,
+}) => {
+  const navigate = useTypedNavigate();
+
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+  const rowPages = useMemo(() => {
+    const pages = [];
+    for (let i = 0; i < rows.length; i += perPage) {
+      pages.push(rows.slice(i, i + perPage));
+    }
+    return pages;
+  }, [perPage, rows]);
+
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+  ) => {
+    setPage(newPage);
+  };
+
+  const onPerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number,
+  ) => {
+    setPerPage(newPerPage);
+    setPage(newPage);
+  };
+  return (
+    <Content>
+      <Table aria-label={`workspace-kind-details-${tableKind}`}>
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Workspaces</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {rowPages[page - 1].map((row) => (
+            <Tr key={row.id}>
+              <Td>{row.displayName}</Td>
+              <Td>
+                <Button
+                  variant="link"
+                  isInline
+                  className="workspace-kind-summary-button"
+                  onClick={() =>
+                    navigate('workspaceKindSummary', {
+                      params: { kind: row.kindName },
+                      state: row.workspaceCountRouteState,
+                    })
+                  }
+                >
+                  {row.workspaceCount} Workspaces
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <Pagination
+        itemCount={rows.length}
+        widgetId="pagination-bottom"
+        perPage={perPage}
+        page={page}
+        variant={PaginationVariant.bottom}
+        isCompact
+        onSetPage={onSetPage}
+        onPerPageSelect={onPerPageSelect}
+      />
+    </Content>
+  );
+};


### PR DESCRIPTION
**Description**

The current implementation of Workspace Kinds details is a list of items with plain texts, which should be reorganized. 
In this PR, we aim to improve the UX by:

- Make the Details drawer resizable so that users can easily 
- Set the minimum with of the drawer panel to 40% of the entire drawer so that all the tabs are visible on most screens
- Refactor Images, Pod Configs and Namespaces to a table view for better viewing

closes: #479 

Before
<img width="1248" height="743" alt="Screenshot 2025-07-15 at 2 40 27 PM" src="https://github.com/user-attachments/assets/9fb3ad2e-a055-453b-9497-6b555482b182" />
<img width="1228" height="737" alt="Screenshot 2025-07-15 at 2 40 20 PM" src="https://github.com/user-attachments/assets/ede53862-bca4-43ed-9e67-fab9306f99a1" />

After


<video src="https://github.com/user-attachments/assets/3a1d2eff-9e11-4000-a2b3-d30bee197c72" />

