### PR TITLE
fix(ws): Implement dual scrolling for workspace kind wizard

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails.tsx
@@ -16,7 +16,7 @@ type WorkspaceFormImageDetailsProps = {
 export const WorkspaceFormImageDetails: React.FunctionComponent<WorkspaceFormImageDetailsProps> = ({
   workspaceImage,
 }) => (
-  <div style={{ marginLeft: 'var(--pf-t--global--spacer--md)' }}>
+  <>
     {workspaceImage && (
       <>
         <Title headingLevel="h3">{workspaceImage.displayName}</Title>
@@ -38,5 +38,5 @@ export const WorkspaceFormImageDetails: React.FunctionComponent<WorkspaceFormIma
         ))}
       </>
     )}
-  </div>
+  </>
 );

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
@@ -1,10 +1,8 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Content, Split, SplitItem } from '@patternfly/react-core';
-import { WorkspaceFormImageDetails } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageDetails';
 import { WorkspaceFormImageList } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageList';
 import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
 import { WorkspaceImageConfigValue } from '~/shared/api/backendApiTypes';
-import { WorkspaceFormDrawer } from '~/app/pages/Workspaces/Form/WorkspaceFormDrawer';
 
 interface WorkspaceFormImageSelectionProps {
   images: WorkspaceImageConfigValue[];
@@ -18,26 +16,6 @@ const WorkspaceFormImageSelection: React.FunctionComponent<WorkspaceFormImageSel
   onSelect,
 }) => {
   const [selectedLabels, setSelectedLabels] = useState<Map<string, Set<string>>>(new Map());
-  const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLSpanElement>(undefined);
-
-  const onExpand = useCallback(() => {
-    if (drawerRef.current) {
-      drawerRef.current.focus();
-    }
-  }, []);
-
-  const onClick = useCallback(
-    (image?: WorkspaceImageConfigValue) => {
-      setIsExpanded(true);
-      onSelect(image);
-    },
-    [onSelect],
-  );
-
-  const onCloseClick = useCallback(() => {
-    setIsExpanded(false);
-  }, []);
 
   const imageFilterContent = useMemo(
     () => (
@@ -50,32 +28,19 @@ const WorkspaceFormImageSelection: React.FunctionComponent<WorkspaceFormImageSel
     [images, selectedLabels, setSelectedLabels],
   );
 
-  const imageDetailsContent = useMemo(
-    () => <WorkspaceFormImageDetails workspaceImage={selectedImage} />,
-    [selectedImage],
-  );
-
   return (
     <Content style={{ height: '100%' }}>
-      <WorkspaceFormDrawer
-        title="Image"
-        info={imageDetailsContent}
-        isExpanded={isExpanded}
-        onCloseClick={onCloseClick}
-        onExpand={onExpand}
-      >
-        <Split hasGutter>
-          <SplitItem style={{ minWidth: '200px' }}>{imageFilterContent}</SplitItem>
-          <SplitItem isFilled>
-            <WorkspaceFormImageList
-              images={images}
-              selectedLabels={selectedLabels}
-              selectedImage={selectedImage}
-              onSelect={onClick}
-            />
-          </SplitItem>
-        </Split>
-      </WorkspaceFormDrawer>
+      <Split hasGutter>
+        <SplitItem style={{ minWidth: '200px' }}>{imageFilterContent}</SplitItem>
+        <SplitItem isFilled>
+          <WorkspaceFormImageList
+            images={images}
+            selectedLabels={selectedLabels}
+            selectedImage={selectedImage}
+            onSelect={onSelect}
+          />
+        </SplitItem>
+      </Split>
     </Content>
   );
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindDetails.tsx
@@ -9,12 +9,12 @@ type WorkspaceFormKindDetailsProps = {
 export const WorkspaceFormKindDetails: React.FunctionComponent<WorkspaceFormKindDetailsProps> = ({
   workspaceKind,
 }) => (
-  <div style={{ marginLeft: 'var(--pf-t--global--spacer--md)' }}>
+  <>
     {workspaceKind && (
       <>
         <Title headingLevel="h3">{workspaceKind.displayName}</Title>
         <p>{workspaceKind.description}</p>
       </>
     )}
-  </div>
+  </>
 );

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
@@ -1,10 +1,8 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React from 'react';
 import { Content } from '@patternfly/react-core';
 import { WorkspaceKind } from '~/shared/api/backendApiTypes';
 import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
-import { WorkspaceFormKindDetails } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindDetails';
 import { WorkspaceFormKindList } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindList';
-import { WorkspaceFormDrawer } from '~/app/pages/Workspaces/Form/WorkspaceFormDrawer';
 
 interface WorkspaceFormKindSelectionProps {
   selectedKind: WorkspaceKind | undefined;
@@ -16,31 +14,6 @@ const WorkspaceFormKindSelection: React.FunctionComponent<WorkspaceFormKindSelec
   onSelect,
 }) => {
   const [workspaceKinds, loaded, error] = useWorkspaceKinds();
-  const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLSpanElement>(undefined);
-
-  const onExpand = useCallback(() => {
-    if (drawerRef.current) {
-      drawerRef.current.focus();
-    }
-  }, []);
-
-  const onClick = useCallback(
-    (kind?: WorkspaceKind) => {
-      setIsExpanded(true);
-      onSelect(kind);
-    },
-    [onSelect],
-  );
-
-  const onCloseClick = useCallback(() => {
-    setIsExpanded(false);
-  }, []);
-
-  const kindDetailsContent = useMemo(
-    () => <WorkspaceFormKindDetails workspaceKind={selectedKind} />,
-    [selectedKind],
-  );
 
   if (error) {
     return <p>Error loading workspace kinds: {error.message}</p>; // TODO: UX for error state
@@ -52,19 +25,11 @@ const WorkspaceFormKindSelection: React.FunctionComponent<WorkspaceFormKindSelec
 
   return (
     <Content style={{ height: '100%' }}>
-      <WorkspaceFormDrawer
-        title="Workspace kind"
-        info={kindDetailsContent}
-        isExpanded={isExpanded}
-        onCloseClick={onCloseClick}
-        onExpand={onExpand}
-      >
-        <WorkspaceFormKindList
-          allWorkspaceKinds={workspaceKinds}
-          selectedKind={selectedKind}
-          onSelect={onClick}
-        />
-      </WorkspaceFormDrawer>
+      <WorkspaceFormKindList
+        allWorkspaceKinds={workspaceKinds}
+        selectedKind={selectedKind}
+        onSelect={onSelect}
+      />
     </Content>
   );
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigDetails.tsx
@@ -19,10 +19,12 @@ export const WorkspaceFormPodConfigDetails: React.FunctionComponent<
 > = ({ workspacePodConfig }) => (
   <>
     {workspacePodConfig && (
-      <div style={{ marginLeft: 'var(--pf-t--global--spacer--md)' }}>
+      <>
         <Title headingLevel="h3">{workspacePodConfig.displayName}</Title>{' '}
         <p>{workspacePodConfig.description}</p>
+        <br />
         <Divider />
+        <br />
         {workspacePodConfig.labels.map((label) => (
           <DescriptionList
             key={label.key}
@@ -37,7 +39,7 @@ export const WorkspaceFormPodConfigDetails: React.FunctionComponent<
             </DescriptionListGroup>
           </DescriptionList>
         ))}
-      </div>
+      </>
     )}
   </>
 );

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
@@ -1,9 +1,7 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Content, Split, SplitItem } from '@patternfly/react-core';
-import { WorkspaceFormPodConfigDetails } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigDetails';
 import { WorkspaceFormPodConfigList } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList';
 import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
-import { WorkspaceFormDrawer } from '~/app/pages/Workspaces/Form/WorkspaceFormDrawer';
 import { WorkspacePodConfigValue } from '~/shared/api/backendApiTypes';
 
 interface WorkspaceFormPodConfigSelectionProps {
@@ -16,26 +14,6 @@ const WorkspaceFormPodConfigSelection: React.FunctionComponent<
   WorkspaceFormPodConfigSelectionProps
 > = ({ podConfigs, selectedPodConfig, onSelect }) => {
   const [selectedLabels, setSelectedLabels] = useState<Map<string, Set<string>>>(new Map());
-  const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLSpanElement>(undefined);
-
-  const onExpand = useCallback(() => {
-    if (drawerRef.current) {
-      drawerRef.current.focus();
-    }
-  }, []);
-
-  const onClick = useCallback(
-    (podConfig?: WorkspacePodConfigValue) => {
-      setIsExpanded(true);
-      onSelect(podConfig);
-    },
-    [onSelect],
-  );
-
-  const onCloseClick = useCallback(() => {
-    setIsExpanded(false);
-  }, []);
 
   const podConfigFilterContent = useMemo(
     () => (
@@ -48,32 +26,19 @@ const WorkspaceFormPodConfigSelection: React.FunctionComponent<
     [podConfigs, selectedLabels, setSelectedLabels],
   );
 
-  const podConfigDetailsContent = useMemo(
-    () => <WorkspaceFormPodConfigDetails workspacePodConfig={selectedPodConfig} />,
-    [selectedPodConfig],
-  );
-
   return (
     <Content style={{ height: '100%' }}>
-      <WorkspaceFormDrawer
-        title="Pod config"
-        info={podConfigDetailsContent}
-        isExpanded={isExpanded}
-        onCloseClick={onCloseClick}
-        onExpand={onExpand}
-      >
-        <Split hasGutter>
-          <SplitItem style={{ minWidth: '200px' }}>{podConfigFilterContent}</SplitItem>
-          <SplitItem isFilled>
-            <WorkspaceFormPodConfigList
-              podConfigs={podConfigs}
-              selectedLabels={selectedLabels}
-              selectedPodConfig={selectedPodConfig}
-              onSelect={onClick}
-            />
-          </SplitItem>
-        </Split>
-      </WorkspaceFormDrawer>
+      <Split hasGutter>
+        <SplitItem style={{ minWidth: '200px' }}>{podConfigFilterContent}</SplitItem>
+        <SplitItem isFilled>
+          <WorkspaceFormPodConfigList
+            podConfigs={podConfigs}
+            selectedLabels={selectedLabels}
+            selectedPodConfig={selectedPodConfig}
+            onSelect={onSelect}
+          />
+        </SplitItem>
+      </Split>
     </Content>
   );
 };


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Closes #374 

The workspace creation wizard had inconsistent scrolling behavior and lacked proper drawer component nesting, preventing users from scrolling through workspace options while also viewing information in the drawer panel. Dual scrolling is now supported. 

### Solution
Refactored the workspace form to use PatternFly `Drawer` component with proper nesting structure to support dual scrolling throughout the workspace kind creation wizard.

### Changes
- **Restructured drawer component hierarchy** - moved drawer to parent level with centralized state management
- **Fixed component nesting** - properly nested `DrawerContent`, `DrawerContentBody`, and `DrawerPanelContent` for consistent scrolling
- **Simplified selection components** - removed individual drawer wrappers and consolidated drawer logic

Before:
<img width="1508" height="857" alt="Screenshot 2025-07-14 at 4 30 41 PM" src="https://github.com/user-attachments/assets/3be33dc8-937b-46da-81de-fb9ef2167524" />
<img width="1508" height="857" alt="Screenshot 2025-07-14 at 4 30 41 PM" src="https://github.com/user-attachments/assets/491b4b77-0dbb-4f85-a5a6-785a27c3e5bf" />
<img width="1509" height="851" alt="Screenshot 2025-07-14 at 4 30 53 PM" src="https://github.com/user-attachments/assets/d41b6a15-938c-4638-a8b7-990f3de873f5" />

After:
<img width="1512" height="858" alt="Screenshot 2025-07-14 at 4 37 46 PM" src="https://github.com/user-attachments/assets/4dbc72df-1be2-4405-adf6-a75906d3dc1e" />
<img width="1508" height="856" alt="Screenshot 2025-07-14 at 4 38 11 PM" src="https://github.com/user-attachments/assets/cc8fcbb2-c384-4435-9608-95df4b5a4c2e" />
<img width="767" height="436" alt="Screenshot 2025-07-14 at 4 38 29 PM" src="https://github.com/user-attachments/assets/bc4a6e3b-85d4-464f-9e94-a21c55731c98" />
