### PR TITLE
chore(ws): update swaggo dependency to v1.16.5 and add required fields in OpenAPI definitions

### DIFF
--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -74,7 +74,7 @@ SWAG_DIRS := cmd,$(ALL_GO_DIRS_NO_CMD)
 .PHONY: swag
 swag: SWAGGER
 	$(SWAGGER) fmt -g main.go -d $(SWAG_DIRS)
-	$(SWAGGER) init --parseDependency -q -g main.go -d $(SWAG_DIRS) --output openapi --outputTypes go,json
+	$(SWAGGER) init --parseDependency -q -g main.go -d $(SWAG_DIRS) --output openapi --outputTypes go,json --requiredByDefault
 
 ##@ Build
 
@@ -82,7 +82,7 @@ swag: SWAGGER
 build: fmt vet swag ## Build backend binary.
 	go build -o bin/backend cmd/main.go
 
-.PHONY: run 
+.PHONY: run
 run: fmt vet swag ## Run a backend from your host.
 	go run ./cmd/main.go --port=$(PORT)
 
@@ -131,7 +131,7 @@ SWAGGER = $(LOCALBIN)/swag
 ## Tool Versions
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.61.0
-SWAGGER_VERSION ?= v1.16.4
+SWAGGER_VERSION ?= v1.16.5
 
 .PHONY: SWAGGER
 SWAGGER: $(SWAGGER)

--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/swaggo/http-swagger/v2 v2.0.2
-	github.com/swaggo/swag v1.16.4
+	github.com/swaggo/swag v1.16.5
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/apiserver v0.31.0
@@ -80,6 +80,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
+	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect

--- a/workspaces/backend/go.sum
+++ b/workspaces/backend/go.sum
@@ -128,8 +128,8 @@ github.com/swaggo/files/v2 v2.0.2 h1:Bq4tgS/yxLB/3nwOMcul5oLEUKa877Ykgz3CJMVbQKU
 github.com/swaggo/files/v2 v2.0.2/go.mod h1:TVqetIzZsO9OhHX1Am9sRf9LdrFZqoK49N37KON/jr0=
 github.com/swaggo/http-swagger/v2 v2.0.2 h1:FKCdLsl+sFCx60KFsyM0rDarwiUSZ8DqbfSyIKC9OBg=
 github.com/swaggo/http-swagger/v2 v2.0.2/go.mod h1:r7/GBkAWIfK6E/OLnE8fXnviHiDeAHmgIyooa4xm3AQ=
-github.com/swaggo/swag v1.16.4 h1:clWJtd9LStiG3VeijiCfOVODP6VpHtKdQy9ELFG3s1A=
-github.com/swaggo/swag v1.16.4/go.mod h1:VBsHJRsDvfYvqoiMKnsdwhNV9LEMHgEDZcyVYX0sxPg=
+github.com/swaggo/swag v1.16.5 h1:nMf2fEV1TetMTJb4XzD0Lz7jFfKJmJKGTygEey8NSxM=
+github.com/swaggo/swag v1.16.5/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -605,6 +605,9 @@ const docTemplate = `{
         },
         "api.ErrorEnvelope": {
             "type": "object",
+            "required": [
+                "error"
+            ],
             "properties": {
                 "error": {
                     "$ref": "#/definitions/api.HTTPError"
@@ -613,6 +616,10 @@ const docTemplate = `{
         },
         "api.HTTPError": {
             "type": "object",
+            "required": [
+                "code",
+                "message"
+            ],
             "properties": {
                 "cause": {
                     "$ref": "#/definitions/api.ErrorCause"
@@ -627,6 +634,9 @@ const docTemplate = `{
         },
         "api.NamespaceListEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -638,6 +648,11 @@ const docTemplate = `{
         },
         "api.ValidationError": {
             "type": "object",
+            "required": [
+                "field",
+                "message",
+                "type"
+            ],
             "properties": {
                 "field": {
                     "type": "string"
@@ -652,6 +667,9 @@ const docTemplate = `{
         },
         "api.WorkspaceCreateEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "$ref": "#/definitions/workspaces.WorkspaceCreate"
@@ -660,6 +678,9 @@ const docTemplate = `{
         },
         "api.WorkspaceEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "$ref": "#/definitions/workspaces.Workspace"
@@ -668,6 +689,9 @@ const docTemplate = `{
         },
         "api.WorkspaceKindEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "$ref": "#/definitions/workspacekinds.WorkspaceKind"
@@ -676,6 +700,9 @@ const docTemplate = `{
         },
         "api.WorkspaceKindListEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -687,6 +714,9 @@ const docTemplate = `{
         },
         "api.WorkspaceListEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -725,6 +755,10 @@ const docTemplate = `{
         },
         "health_check.HealthCheck": {
             "type": "object",
+            "required": [
+                "status",
+                "systemInfo"
+            ],
             "properties": {
                 "status": {
                     "$ref": "#/definitions/health_check.ServiceStatus"
@@ -747,6 +781,9 @@ const docTemplate = `{
         },
         "health_check.SystemInfo": {
             "type": "object",
+            "required": [
+                "version"
+            ],
             "properties": {
                 "version": {
                     "type": "string"
@@ -755,6 +792,9 @@ const docTemplate = `{
         },
         "namespaces.Namespace": {
             "type": "object",
+            "required": [
+                "name"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -763,6 +803,10 @@ const docTemplate = `{
         },
         "workspacekinds.ImageConfig": {
             "type": "object",
+            "required": [
+                "default",
+                "values"
+            ],
             "properties": {
                 "default": {
                     "type": "string"
@@ -777,6 +821,13 @@ const docTemplate = `{
         },
         "workspacekinds.ImageConfigValue": {
             "type": "object",
+            "required": [
+                "description",
+                "displayName",
+                "hidden",
+                "id",
+                "labels"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -803,6 +854,9 @@ const docTemplate = `{
         },
         "workspacekinds.ImageRef": {
             "type": "object",
+            "required": [
+                "url"
+            ],
             "properties": {
                 "url": {
                     "type": "string"
@@ -811,6 +865,10 @@ const docTemplate = `{
         },
         "workspacekinds.OptionLabel": {
             "type": "object",
+            "required": [
+                "key",
+                "value"
+            ],
             "properties": {
                 "key": {
                     "type": "string"
@@ -822,6 +880,9 @@ const docTemplate = `{
         },
         "workspacekinds.OptionRedirect": {
             "type": "object",
+            "required": [
+                "to"
+            ],
             "properties": {
                 "message": {
                     "$ref": "#/definitions/workspacekinds.RedirectMessage"
@@ -833,6 +894,10 @@ const docTemplate = `{
         },
         "workspacekinds.PodConfig": {
             "type": "object",
+            "required": [
+                "default",
+                "values"
+            ],
             "properties": {
                 "default": {
                     "type": "string"
@@ -847,6 +912,13 @@ const docTemplate = `{
         },
         "workspacekinds.PodConfigValue": {
             "type": "object",
+            "required": [
+                "description",
+                "displayName",
+                "hidden",
+                "id",
+                "labels"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -873,6 +945,10 @@ const docTemplate = `{
         },
         "workspacekinds.PodMetadata": {
             "type": "object",
+            "required": [
+                "annotations",
+                "labels"
+            ],
             "properties": {
                 "annotations": {
                     "type": "object",
@@ -890,6 +966,11 @@ const docTemplate = `{
         },
         "workspacekinds.PodTemplate": {
             "type": "object",
+            "required": [
+                "options",
+                "podMetadata",
+                "volumeMounts"
+            ],
             "properties": {
                 "options": {
                     "$ref": "#/definitions/workspacekinds.PodTemplateOptions"
@@ -904,6 +985,10 @@ const docTemplate = `{
         },
         "workspacekinds.PodTemplateOptions": {
             "type": "object",
+            "required": [
+                "imageConfig",
+                "podConfig"
+            ],
             "properties": {
                 "imageConfig": {
                     "$ref": "#/definitions/workspacekinds.ImageConfig"
@@ -915,6 +1000,9 @@ const docTemplate = `{
         },
         "workspacekinds.PodVolumeMounts": {
             "type": "object",
+            "required": [
+                "home"
+            ],
             "properties": {
                 "home": {
                     "type": "string"
@@ -923,6 +1011,10 @@ const docTemplate = `{
         },
         "workspacekinds.RedirectMessage": {
             "type": "object",
+            "required": [
+                "level",
+                "text"
+            ],
             "properties": {
                 "level": {
                     "$ref": "#/definitions/workspacekinds.RedirectMessageLevel"
@@ -947,6 +1039,17 @@ const docTemplate = `{
         },
         "workspacekinds.WorkspaceKind": {
             "type": "object",
+            "required": [
+                "deprecated",
+                "deprecationMessage",
+                "description",
+                "displayName",
+                "hidden",
+                "icon",
+                "logo",
+                "name",
+                "podTemplate"
+            ],
             "properties": {
                 "deprecated": {
                     "type": "boolean"
@@ -979,6 +1082,10 @@ const docTemplate = `{
         },
         "workspaces.Activity": {
             "type": "object",
+            "required": [
+                "lastActivity",
+                "lastUpdate"
+            ],
             "properties": {
                 "lastActivity": {
                     "description": "Unix Epoch time",
@@ -995,6 +1102,10 @@ const docTemplate = `{
         },
         "workspaces.HttpService": {
             "type": "object",
+            "required": [
+                "displayName",
+                "httpPath"
+            ],
             "properties": {
                 "displayName": {
                     "type": "string"
@@ -1006,6 +1117,9 @@ const docTemplate = `{
         },
         "workspaces.ImageConfig": {
             "type": "object",
+            "required": [
+                "current"
+            ],
             "properties": {
                 "current": {
                     "$ref": "#/definitions/workspaces.OptionInfo"
@@ -1023,6 +1137,9 @@ const docTemplate = `{
         },
         "workspaces.ImageRef": {
             "type": "object",
+            "required": [
+                "url"
+            ],
             "properties": {
                 "url": {
                     "type": "string"
@@ -1031,6 +1148,12 @@ const docTemplate = `{
         },
         "workspaces.LastProbeInfo": {
             "type": "object",
+            "required": [
+                "endTimeMs",
+                "message",
+                "result",
+                "startTimeMs"
+            ],
             "properties": {
                 "endTimeMs": {
                     "description": "Unix Epoch time in milliseconds",
@@ -1050,6 +1173,12 @@ const docTemplate = `{
         },
         "workspaces.OptionInfo": {
             "type": "object",
+            "required": [
+                "description",
+                "displayName",
+                "id",
+                "labels"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -1070,6 +1199,10 @@ const docTemplate = `{
         },
         "workspaces.OptionLabel": {
             "type": "object",
+            "required": [
+                "key",
+                "value"
+            ],
             "properties": {
                 "key": {
                     "type": "string"
@@ -1081,6 +1214,9 @@ const docTemplate = `{
         },
         "workspaces.PodConfig": {
             "type": "object",
+            "required": [
+                "current"
+            ],
             "properties": {
                 "current": {
                     "$ref": "#/definitions/workspaces.OptionInfo"
@@ -1098,6 +1234,10 @@ const docTemplate = `{
         },
         "workspaces.PodMetadata": {
             "type": "object",
+            "required": [
+                "annotations",
+                "labels"
+            ],
             "properties": {
                 "annotations": {
                     "type": "object",
@@ -1115,6 +1255,10 @@ const docTemplate = `{
         },
         "workspaces.PodMetadataMutate": {
             "type": "object",
+            "required": [
+                "annotations",
+                "labels"
+            ],
             "properties": {
                 "annotations": {
                     "type": "object",
@@ -1132,6 +1276,10 @@ const docTemplate = `{
         },
         "workspaces.PodSecretInfo": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "secretName"
+            ],
             "properties": {
                 "defaultMode": {
                     "type": "integer"
@@ -1146,6 +1294,10 @@ const docTemplate = `{
         },
         "workspaces.PodSecretMount": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "secretName"
+            ],
             "properties": {
                 "defaultMode": {
                     "type": "integer"
@@ -1160,6 +1312,11 @@ const docTemplate = `{
         },
         "workspaces.PodTemplate": {
             "type": "object",
+            "required": [
+                "options",
+                "podMetadata",
+                "volumes"
+            ],
             "properties": {
                 "options": {
                     "$ref": "#/definitions/workspaces.PodTemplateOptions"
@@ -1174,6 +1331,11 @@ const docTemplate = `{
         },
         "workspaces.PodTemplateMutate": {
             "type": "object",
+            "required": [
+                "options",
+                "podMetadata",
+                "volumes"
+            ],
             "properties": {
                 "options": {
                     "$ref": "#/definitions/workspaces.PodTemplateOptionsMutate"
@@ -1188,6 +1350,10 @@ const docTemplate = `{
         },
         "workspaces.PodTemplateOptions": {
             "type": "object",
+            "required": [
+                "imageConfig",
+                "podConfig"
+            ],
             "properties": {
                 "imageConfig": {
                     "$ref": "#/definitions/workspaces.ImageConfig"
@@ -1199,6 +1365,10 @@ const docTemplate = `{
         },
         "workspaces.PodTemplateOptionsMutate": {
             "type": "object",
+            "required": [
+                "imageConfig",
+                "podConfig"
+            ],
             "properties": {
                 "imageConfig": {
                     "type": "string"
@@ -1210,6 +1380,11 @@ const docTemplate = `{
         },
         "workspaces.PodVolumeInfo": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "pvcName",
+                "readOnly"
+            ],
             "properties": {
                 "mountPath": {
                     "type": "string"
@@ -1224,6 +1399,10 @@ const docTemplate = `{
         },
         "workspaces.PodVolumeMount": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "pvcName"
+            ],
             "properties": {
                 "mountPath": {
                     "type": "string"
@@ -1238,6 +1417,9 @@ const docTemplate = `{
         },
         "workspaces.PodVolumes": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -1258,6 +1440,9 @@ const docTemplate = `{
         },
         "workspaces.PodVolumesMutate": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -1291,6 +1476,10 @@ const docTemplate = `{
         },
         "workspaces.RedirectMessage": {
             "type": "object",
+            "required": [
+                "level",
+                "text"
+            ],
             "properties": {
                 "level": {
                     "$ref": "#/definitions/workspaces.RedirectMessageLevel"
@@ -1315,6 +1504,10 @@ const docTemplate = `{
         },
         "workspaces.RedirectStep": {
             "type": "object",
+            "required": [
+                "sourceId",
+                "targetId"
+            ],
             "properties": {
                 "message": {
                     "$ref": "#/definitions/workspaces.RedirectMessage"
@@ -1337,6 +1530,20 @@ const docTemplate = `{
         },
         "workspaces.Workspace": {
             "type": "object",
+            "required": [
+                "activity",
+                "deferUpdates",
+                "name",
+                "namespace",
+                "paused",
+                "pausedTime",
+                "pendingRestart",
+                "podTemplate",
+                "services",
+                "state",
+                "stateMessage",
+                "workspaceKind"
+            ],
             "properties": {
                 "activity": {
                     "$ref": "#/definitions/workspaces.Activity"
@@ -1381,6 +1588,13 @@ const docTemplate = `{
         },
         "workspaces.WorkspaceCreate": {
             "type": "object",
+            "required": [
+                "deferUpdates",
+                "kind",
+                "name",
+                "paused",
+                "podTemplate"
+            ],
             "properties": {
                 "deferUpdates": {
                     "type": "boolean"
@@ -1401,6 +1615,12 @@ const docTemplate = `{
         },
         "workspaces.WorkspaceKindInfo": {
             "type": "object",
+            "required": [
+                "icon",
+                "logo",
+                "missing",
+                "name"
+            ],
             "properties": {
                 "icon": {
                     "$ref": "#/definitions/workspaces.ImageRef"

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -603,6 +603,9 @@
         },
         "api.ErrorEnvelope": {
             "type": "object",
+            "required": [
+                "error"
+            ],
             "properties": {
                 "error": {
                     "$ref": "#/definitions/api.HTTPError"
@@ -611,6 +614,10 @@
         },
         "api.HTTPError": {
             "type": "object",
+            "required": [
+                "code",
+                "message"
+            ],
             "properties": {
                 "cause": {
                     "$ref": "#/definitions/api.ErrorCause"
@@ -625,6 +632,9 @@
         },
         "api.NamespaceListEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -636,6 +646,11 @@
         },
         "api.ValidationError": {
             "type": "object",
+            "required": [
+                "field",
+                "message",
+                "type"
+            ],
             "properties": {
                 "field": {
                     "type": "string"
@@ -650,6 +665,9 @@
         },
         "api.WorkspaceCreateEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "$ref": "#/definitions/workspaces.WorkspaceCreate"
@@ -658,6 +676,9 @@
         },
         "api.WorkspaceEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "$ref": "#/definitions/workspaces.Workspace"
@@ -666,6 +687,9 @@
         },
         "api.WorkspaceKindEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "$ref": "#/definitions/workspacekinds.WorkspaceKind"
@@ -674,6 +698,9 @@
         },
         "api.WorkspaceKindListEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -685,6 +712,9 @@
         },
         "api.WorkspaceListEnvelope": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -723,6 +753,10 @@
         },
         "health_check.HealthCheck": {
             "type": "object",
+            "required": [
+                "status",
+                "systemInfo"
+            ],
             "properties": {
                 "status": {
                     "$ref": "#/definitions/health_check.ServiceStatus"
@@ -745,6 +779,9 @@
         },
         "health_check.SystemInfo": {
             "type": "object",
+            "required": [
+                "version"
+            ],
             "properties": {
                 "version": {
                     "type": "string"
@@ -753,6 +790,9 @@
         },
         "namespaces.Namespace": {
             "type": "object",
+            "required": [
+                "name"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -761,6 +801,10 @@
         },
         "workspacekinds.ImageConfig": {
             "type": "object",
+            "required": [
+                "default",
+                "values"
+            ],
             "properties": {
                 "default": {
                     "type": "string"
@@ -775,6 +819,13 @@
         },
         "workspacekinds.ImageConfigValue": {
             "type": "object",
+            "required": [
+                "description",
+                "displayName",
+                "hidden",
+                "id",
+                "labels"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -801,6 +852,9 @@
         },
         "workspacekinds.ImageRef": {
             "type": "object",
+            "required": [
+                "url"
+            ],
             "properties": {
                 "url": {
                     "type": "string"
@@ -809,6 +863,10 @@
         },
         "workspacekinds.OptionLabel": {
             "type": "object",
+            "required": [
+                "key",
+                "value"
+            ],
             "properties": {
                 "key": {
                     "type": "string"
@@ -820,6 +878,9 @@
         },
         "workspacekinds.OptionRedirect": {
             "type": "object",
+            "required": [
+                "to"
+            ],
             "properties": {
                 "message": {
                     "$ref": "#/definitions/workspacekinds.RedirectMessage"
@@ -831,6 +892,10 @@
         },
         "workspacekinds.PodConfig": {
             "type": "object",
+            "required": [
+                "default",
+                "values"
+            ],
             "properties": {
                 "default": {
                     "type": "string"
@@ -845,6 +910,13 @@
         },
         "workspacekinds.PodConfigValue": {
             "type": "object",
+            "required": [
+                "description",
+                "displayName",
+                "hidden",
+                "id",
+                "labels"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -871,6 +943,10 @@
         },
         "workspacekinds.PodMetadata": {
             "type": "object",
+            "required": [
+                "annotations",
+                "labels"
+            ],
             "properties": {
                 "annotations": {
                     "type": "object",
@@ -888,6 +964,11 @@
         },
         "workspacekinds.PodTemplate": {
             "type": "object",
+            "required": [
+                "options",
+                "podMetadata",
+                "volumeMounts"
+            ],
             "properties": {
                 "options": {
                     "$ref": "#/definitions/workspacekinds.PodTemplateOptions"
@@ -902,6 +983,10 @@
         },
         "workspacekinds.PodTemplateOptions": {
             "type": "object",
+            "required": [
+                "imageConfig",
+                "podConfig"
+            ],
             "properties": {
                 "imageConfig": {
                     "$ref": "#/definitions/workspacekinds.ImageConfig"
@@ -913,6 +998,9 @@
         },
         "workspacekinds.PodVolumeMounts": {
             "type": "object",
+            "required": [
+                "home"
+            ],
             "properties": {
                 "home": {
                     "type": "string"
@@ -921,6 +1009,10 @@
         },
         "workspacekinds.RedirectMessage": {
             "type": "object",
+            "required": [
+                "level",
+                "text"
+            ],
             "properties": {
                 "level": {
                     "$ref": "#/definitions/workspacekinds.RedirectMessageLevel"
@@ -945,6 +1037,17 @@
         },
         "workspacekinds.WorkspaceKind": {
             "type": "object",
+            "required": [
+                "deprecated",
+                "deprecationMessage",
+                "description",
+                "displayName",
+                "hidden",
+                "icon",
+                "logo",
+                "name",
+                "podTemplate"
+            ],
             "properties": {
                 "deprecated": {
                     "type": "boolean"
@@ -977,6 +1080,10 @@
         },
         "workspaces.Activity": {
             "type": "object",
+            "required": [
+                "lastActivity",
+                "lastUpdate"
+            ],
             "properties": {
                 "lastActivity": {
                     "description": "Unix Epoch time",
@@ -993,6 +1100,10 @@
         },
         "workspaces.HttpService": {
             "type": "object",
+            "required": [
+                "displayName",
+                "httpPath"
+            ],
             "properties": {
                 "displayName": {
                     "type": "string"
@@ -1004,6 +1115,9 @@
         },
         "workspaces.ImageConfig": {
             "type": "object",
+            "required": [
+                "current"
+            ],
             "properties": {
                 "current": {
                     "$ref": "#/definitions/workspaces.OptionInfo"
@@ -1021,6 +1135,9 @@
         },
         "workspaces.ImageRef": {
             "type": "object",
+            "required": [
+                "url"
+            ],
             "properties": {
                 "url": {
                     "type": "string"
@@ -1029,6 +1146,12 @@
         },
         "workspaces.LastProbeInfo": {
             "type": "object",
+            "required": [
+                "endTimeMs",
+                "message",
+                "result",
+                "startTimeMs"
+            ],
             "properties": {
                 "endTimeMs": {
                     "description": "Unix Epoch time in milliseconds",
@@ -1048,6 +1171,12 @@
         },
         "workspaces.OptionInfo": {
             "type": "object",
+            "required": [
+                "description",
+                "displayName",
+                "id",
+                "labels"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -1068,6 +1197,10 @@
         },
         "workspaces.OptionLabel": {
             "type": "object",
+            "required": [
+                "key",
+                "value"
+            ],
             "properties": {
                 "key": {
                     "type": "string"
@@ -1079,6 +1212,9 @@
         },
         "workspaces.PodConfig": {
             "type": "object",
+            "required": [
+                "current"
+            ],
             "properties": {
                 "current": {
                     "$ref": "#/definitions/workspaces.OptionInfo"
@@ -1096,6 +1232,10 @@
         },
         "workspaces.PodMetadata": {
             "type": "object",
+            "required": [
+                "annotations",
+                "labels"
+            ],
             "properties": {
                 "annotations": {
                     "type": "object",
@@ -1113,6 +1253,10 @@
         },
         "workspaces.PodMetadataMutate": {
             "type": "object",
+            "required": [
+                "annotations",
+                "labels"
+            ],
             "properties": {
                 "annotations": {
                     "type": "object",
@@ -1130,6 +1274,10 @@
         },
         "workspaces.PodSecretInfo": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "secretName"
+            ],
             "properties": {
                 "defaultMode": {
                     "type": "integer"
@@ -1144,6 +1292,10 @@
         },
         "workspaces.PodSecretMount": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "secretName"
+            ],
             "properties": {
                 "defaultMode": {
                     "type": "integer"
@@ -1158,6 +1310,11 @@
         },
         "workspaces.PodTemplate": {
             "type": "object",
+            "required": [
+                "options",
+                "podMetadata",
+                "volumes"
+            ],
             "properties": {
                 "options": {
                     "$ref": "#/definitions/workspaces.PodTemplateOptions"
@@ -1172,6 +1329,11 @@
         },
         "workspaces.PodTemplateMutate": {
             "type": "object",
+            "required": [
+                "options",
+                "podMetadata",
+                "volumes"
+            ],
             "properties": {
                 "options": {
                     "$ref": "#/definitions/workspaces.PodTemplateOptionsMutate"
@@ -1186,6 +1348,10 @@
         },
         "workspaces.PodTemplateOptions": {
             "type": "object",
+            "required": [
+                "imageConfig",
+                "podConfig"
+            ],
             "properties": {
                 "imageConfig": {
                     "$ref": "#/definitions/workspaces.ImageConfig"
@@ -1197,6 +1363,10 @@
         },
         "workspaces.PodTemplateOptionsMutate": {
             "type": "object",
+            "required": [
+                "imageConfig",
+                "podConfig"
+            ],
             "properties": {
                 "imageConfig": {
                     "type": "string"
@@ -1208,6 +1378,11 @@
         },
         "workspaces.PodVolumeInfo": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "pvcName",
+                "readOnly"
+            ],
             "properties": {
                 "mountPath": {
                     "type": "string"
@@ -1222,6 +1397,10 @@
         },
         "workspaces.PodVolumeMount": {
             "type": "object",
+            "required": [
+                "mountPath",
+                "pvcName"
+            ],
             "properties": {
                 "mountPath": {
                     "type": "string"
@@ -1236,6 +1415,9 @@
         },
         "workspaces.PodVolumes": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -1256,6 +1438,9 @@
         },
         "workspaces.PodVolumesMutate": {
             "type": "object",
+            "required": [
+                "data"
+            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -1289,6 +1474,10 @@
         },
         "workspaces.RedirectMessage": {
             "type": "object",
+            "required": [
+                "level",
+                "text"
+            ],
             "properties": {
                 "level": {
                     "$ref": "#/definitions/workspaces.RedirectMessageLevel"
@@ -1313,6 +1502,10 @@
         },
         "workspaces.RedirectStep": {
             "type": "object",
+            "required": [
+                "sourceId",
+                "targetId"
+            ],
             "properties": {
                 "message": {
                     "$ref": "#/definitions/workspaces.RedirectMessage"
@@ -1335,6 +1528,20 @@
         },
         "workspaces.Workspace": {
             "type": "object",
+            "required": [
+                "activity",
+                "deferUpdates",
+                "name",
+                "namespace",
+                "paused",
+                "pausedTime",
+                "pendingRestart",
+                "podTemplate",
+                "services",
+                "state",
+                "stateMessage",
+                "workspaceKind"
+            ],
             "properties": {
                 "activity": {
                     "$ref": "#/definitions/workspaces.Activity"
@@ -1379,6 +1586,13 @@
         },
         "workspaces.WorkspaceCreate": {
             "type": "object",
+            "required": [
+                "deferUpdates",
+                "kind",
+                "name",
+                "paused",
+                "podTemplate"
+            ],
             "properties": {
                 "deferUpdates": {
                     "type": "boolean"
@@ -1399,6 +1613,12 @@
         },
         "workspaces.WorkspaceKindInfo": {
             "type": "object",
+            "required": [
+                "icon",
+                "logo",
+                "missing",
+                "name"
+            ],
             "properties": {
                 "icon": {
                     "$ref": "#/definitions/workspaces.ImageRef"


### PR DESCRIPTION
related: #430 

- Updated swaggo/swag from v1.16.4 to v1.16.5 in go.mod and Makefile.
- Added required fields to various OpenAPI definitions in docs.go and swagger.json for better validation via `--requiredByDefault` flag
    - `swag` `v1.16.5` contains a commit we authored to treat `json:omitempty` as `required: false`.  That, in conjunction with `--requiredByDefault` flag, allows us to generate models with proper _required-ness_