### PR TITLE
chore(ws): comment workspace details logs and pod template tabs while they are not supported

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
@@ -68,12 +68,14 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
             aria-label="Activity"
             data-testid="activityTab"
           />
+          {/* TODO: Uncomment when Logs visualization is fully supported
           <Tab
             eventKey={2}
             title={<TabTitleText>Logs</TabTitleText>}
             tabContentId="logsTabContent"
             aria-label="Logs"
           />
+          */}
           <Tab
             eventKey={3}
             title={<TabTitleText>Pod template</TabTitleText>}

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
@@ -76,12 +76,14 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
             aria-label="Logs"
           />
           */}
+          {/* TODO: Uncomment when Pod template visualization is fully supported
           <Tab
             eventKey={3}
             title={<TabTitleText>Pod template</TabTitleText>}
             tabContentId="podTemplateTabContent"
             aria-label="Pod template"
           />
+          */}
         </Tabs>
       </DrawerPanelBody>
 


### PR DESCRIPTION
Logs and Pod Template tabs now are not rendered while they are not fully implemented:

<img width="534" height="428" alt="image" src="https://github.com/user-attachments/assets/b942dfd0-2581-4298-b8a5-0aae40f445a2" />


<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->