### PR TITLE
chore(ws): enforce CI failure on uncommitted generated code changes

### DIFF
--- a/.github/workflows/ws-frontend-test.yml
+++ b/.github/workflows/ws-frontend-test.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -35,6 +37,10 @@ jobs:
       - name: Clean
         working-directory: workspaces/frontend
         run: npm run build:clean
+
+      - name: Regenerate API layer code
+        working-directory: workspaces/frontend
+        run: npm run generate:api
 
       - name: Build
         working-directory: workspaces/frontend


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

related: https://github.com/kubeflow/notebooks/issues/499

This PR updates the CI pipeline for the frontend workspace to fail if there are uncommitted changes in generated code. This helps ensure that all generated files are properly committed and that CI reflects the actual state of the codebase.

**Note**: The `fetch-depth: 0` argument is required to fetch the full Git history, since the code lives in `notebooks-v2` branch, allowing us to retrieve the specific Swagger version referenced by the commit hash in the [swagger.version](https://github.com/kubeflow/notebooks/blob/notebooks-v2/workspaces/frontend/scripts/swagger.version) file.