### PR TITLE
fix: Replace border with box-shadow to avoid layout shifts

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.scss
@@ -12,7 +12,7 @@
   }
 
   .mat-button-toggle-checked {
-    border: 2px solid $kubeflow-blue-primary-hue;
+    box-shadow: inset 0 0 0 2px $kubeflow-blue-primary-hue;
     background-color: white;
   }
 


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Reopen https://github.com/kubeflow/kubeflow/pull/7659

There was an issue where, upon pressing the "Create Notebook" button and then selecting the notebook environment, the layout of the remaining buttons shifted due to the border.

I consider this unintended shift negatively impacts the user experience.

So I replaced border with box-shadow to avoid unintended layout shifts and improve user experience.


## AS-IS
https://github.com/user-attachments/assets/2dcfac4d-681e-4f91-8182-f712dc4ce73f

## TO-BE
https://github.com/user-attachments/assets/5aa01790-a64a-4c7b-b385-02821de40136



