### PR TITLE
feat: Add support to run notebooks on its own subdomains in Istio

### DIFF
--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -34,7 +34,17 @@ All other fields will be filled in with default value if not specified.
 | --- | --- |
 |ADD_FSGROUP| If the value is true or unset, fsGroup: 100 will be included in the pod's security context. If this value is present and set to false, it will suppress the automatic addition of fsGroup: 100 to the security context of the pod.|
 |DEV| If the value is false or unset, then the default implementation of the Notebook Controller will be used. If the admins want to use a custom implementation from their local machine, they should set this value to true.|
-
+|USE_ISTIO| If the value is set to true, Istio will be used to route traffic. If set to false, Istio routing will be disabled.|
+|ISTIO_GATEWAY|Name of the Istio Gateway resource used to route traffic to notebook servers. Only used if ``USE_ISTIO`` is enabled.|
+|ISTIO_HOST|Specifies the host to use in the Istio VirtualService. Default is ``*``. Only used if ``USE_ISTIO`` is enabled.|
+|ISTIO_USE_NOTEBOOK_SUBDOMAINS| If the value is true, notebooks hosted on a subdomain. This is recommended for security reasons but has some technical dependencies. If the value is set to false, secure subdomain feature is not enabled. Disabled by default.|
+|ISTIO_HOST_NOTEBOOK| Domain template used by Istio to host notebooks (e.g., `${NAMESPACE}-notebook.kubeflow.example.com`). Required if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ISTIO_HOST_AUTH| Host used by Istio for handling authentication callbacks or login flows (e.g., `kubeflow.example.com`). Required if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ISTIO_AUTH_PATH|Specifies the path used for authentication callbacks or redirection when integrating with an identity provider through Istio. Default is ``/oauth2/``. Only used if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ENABLE_CULLING|If the value is true, the controller will do culling on idle notebooks. Not enabled by default.|
+|CULL_IDLE_TIME|Specifies minutes until an idle notebook will be stopped. Default is 1 day.|
+|IDLENESS_CHECK_PERIOD|Specifies minutes for the idleness check period. Default is 1 minute.|
+|CLUSTER_DOMAIN| Specifies the Kubernetes internal cluster domain. Default is ``cluster.local``|
 
 
 ## Commandline parameters

--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -41,6 +41,7 @@ All other fields will be filled in with default value if not specified.
 |ISTIO_HOST_NOTEBOOK| Domain template used by Istio to host notebooks (e.g., `${NAMESPACE}-notebook.kubeflow.example.com`). Required if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
 |ISTIO_HOST_AUTH| Host used by Istio for handling authentication callbacks or login flows (e.g., `kubeflow.example.com`). Required if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
 |ISTIO_AUTH_PATH|Specifies the path used for authentication callbacks or redirection when integrating with an identity provider through Istio. Default is ``/oauth2/``. Only used if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION|If the value is true, [envoy's substitution commands syntax in headers](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers). This should be enabled for security reasons because this prevents access token leakage to user-controlled notebooks. Not enabled by default.|
 |ENABLE_CULLING|If the value is true, the controller will do culling on idle notebooks. Not enabled by default.|
 |CULL_IDLE_TIME|Specifies minutes until an idle notebook will be stopped. Default is 1 day.|
 |IDLENESS_CHECK_PERIOD|Specifies minutes for the idleness check period. Default is 1 minute.|

--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -40,6 +40,26 @@ spec:
               configMapKeyRef:
                 name: config
                 key: ISTIO_HOST
+          - name: ISTIO_USE_NOTEBOOK_SUBDOMAINS
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: ISTIO_USE_NOTEBOOK_SUBDOMAINS
+          - name: ISTIO_HOST_NOTEBOOK
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: ISTIO_HOST_NOTEBOOK
+          - name: ISTIO_HOST_AUTH
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: ISTIO_HOST_AUTH
+          - name: ISTIO_AUTH_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: ISTIO_AUTH_PATH
           - name: CLUSTER_DOMAIN
             valueFrom:
               configMapKeyRef:

--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -60,6 +60,11 @@ spec:
               configMapKeyRef:
                 name: config
                 key: ISTIO_AUTH_PATH
+          - name: ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION
           - name: CLUSTER_DOMAIN
             valueFrom:
               configMapKeyRef:

--- a/components/notebook-controller/config/manager/params.env
+++ b/components/notebook-controller/config/manager/params.env
@@ -5,3 +5,8 @@ CLUSTER_DOMAIN=cluster.local
 ENABLE_CULLING=false
 CULL_IDLE_TIME=1440
 IDLENESS_CHECK_PERIOD=1
+# Notebook multi-domain setup is disabled by default. Change the following variables to enable it:
+ISTIO_USE_NOTEBOOK_SUBDOMAINS=false
+ISTIO_HOST_NOTEBOOK=
+ISTIO_HOST_AUTH=
+ISTIO_AUTH_PATH=

--- a/components/notebook-controller/config/manager/params.env
+++ b/components/notebook-controller/config/manager/params.env
@@ -5,6 +5,7 @@ CLUSTER_DOMAIN=cluster.local
 ENABLE_CULLING=false
 CULL_IDLE_TIME=1440
 IDLENESS_CHECK_PERIOD=1
+ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION=false # Set this value to true to prevent access token leakage
 # Notebook multi-domain setup is disabled by default. Change the following variables to enable it:
 ISTIO_USE_NOTEBOOK_SUBDOMAINS=false
 ISTIO_HOST_NOTEBOOK=

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -706,11 +706,15 @@ func (r *NotebookReconciler) reconcileVirtualService(instance *v1beta1.Notebook)
 		return err
 	}
 
+	desiredVirtualServices := make(map[string]struct{}, len(virtualServices))
+
 	for _, virtualService := range virtualServices {
 
 		if err := ctrl.SetControllerReference(instance, virtualService, r.Scheme); err != nil {
 			return err
 		}
+		desiredVirtualServices[virtualService.GetName()] = struct{}{}
+
 		// Check if the virtual service already exists.
 		foundVirtual := &unstructured.Unstructured{}
 		justCreated := false
@@ -738,6 +742,41 @@ func (r *NotebookReconciler) reconcileVirtualService(instance *v1beta1.Notebook)
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	// Delete redirect VirtualServices that are no longer part of the desired
+	// state, for example after ISTIO_USE_NOTEBOOK_SUBDOMAINS is disabled.
+	for _, suffix := range []string{"auth-redirect", "notebook-redirect"} {
+		name := virtualServiceNameWithSuffix(instance.Name, instance.Namespace, suffix)
+		if _, desired := desiredVirtualServices[name]; desired {
+			continue
+		}
+
+		staleVirtualService := &unstructured.Unstructured{}
+		staleVirtualService.SetAPIVersion("networking.istio.io/v1alpha3")
+		staleVirtualService.SetKind("VirtualService")
+
+		err := r.Get(context.TODO(), types.NamespacedName{
+			Name:      name,
+			Namespace: instance.Namespace,
+		}, staleVirtualService)
+		if apierrs.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		// Never delete a resource with the expected name unless this Notebook is
+		// still its controller owner.
+		if !metav1.IsControlledBy(staleVirtualService, instance) {
+			continue
+		}
+
+		log.Info("Deleting stale virtual service", "namespace", instance.Namespace, "name", name)
+		if err := r.Delete(context.TODO(), staleVirtualService); err != nil && !apierrs.IsNotFound(err) {
+			return err
 		}
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -658,9 +658,9 @@ func generateVirtualServices(instance *v1beta1.Notebook) ([]*unstructured.Unstru
 			"headers": map[string]interface{}{
 				"request": map[string]interface{}{
 					"set": headersRequestSetInterface,
-					// remove the authorization cookie to prevent token stealing
-					// otherwise, the bearer token would be leaked to the notebook's container
-					// thus, a contributor could get access to another contributor's token
+					// remove the Authorization header to prevent token stealing.
+					// otherwise, the bearer token would be forwarded to the notebook container,
+					// allowing notebook code to capture a visitor's token.
 					"remove": []interface{}{
 						"Authorization",
 					},

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -468,7 +469,108 @@ func virtualServiceName(kfName string, namespace string) string {
 	return fmt.Sprintf("notebook-%s-%s", namespace, kfName)
 }
 
-func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructured, error) {
+func virtualServiceNameWithSuffix(kfName string, namespace string, suffix string) string {
+	return fmt.Sprintf("notebook-%s-%s-%s", namespace, kfName, suffix)
+}
+
+func generateVirtualServiceForNotebookRedirect(name string, namespace string, prefix string, istioHostNotebook string, istioGateway string) (*unstructured.Unstructured, error) {
+	vsvc := &unstructured.Unstructured{}
+	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")
+	vsvc.SetKind("VirtualService")
+	vsvc.SetName(virtualServiceNameWithSuffix(name, namespace, "notebook-redirect"))
+	vsvc.SetNamespace(namespace)
+
+	istioHost := os.Getenv("ISTIO_HOST")
+	if len(istioHost) == 0 {
+		istioHost = "*"
+	}
+	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioHost}, "spec", "hosts"); err != nil {
+		return nil, fmt.Errorf("Set .spec.hosts error: %v", err)
+
+	}
+
+	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioGateway},
+		"spec", "gateways"); err != nil {
+		return nil, fmt.Errorf("set .spec.gateways error: %v", err)
+	}
+
+	// the http section of the istio VirtualService spec
+	http := []interface{}{
+		map[string]interface{}{
+			"match": []interface{}{
+				map[string]interface{}{
+					"uri": map[string]interface{}{
+						"prefix": prefix,
+					},
+				},
+			},
+			"redirect": map[string]interface{}{
+				"authority":    istioHostNotebook,
+				"redirectCode": int64(307),
+			},
+		},
+	}
+
+	// add http section to istio VirtualService spec
+	if err := unstructured.SetNestedSlice(vsvc.Object, http, "spec", "http"); err != nil {
+		return nil, fmt.Errorf("set .spec.http error: %v", err)
+	}
+
+	return vsvc, nil
+}
+
+func generateVirtualServiceForAuthRedirect(name string, namespace string, prefix string, istioHostNotebook string, istioGateway string) (*unstructured.Unstructured, error) {
+	vsvc := &unstructured.Unstructured{}
+	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")
+	vsvc.SetKind("VirtualService")
+	vsvc.SetName(virtualServiceNameWithSuffix(name, namespace, "auth-redirect"))
+	vsvc.SetNamespace(namespace)
+
+	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioHostNotebook}, "spec", "hosts"); err != nil {
+		return nil, fmt.Errorf("set .spec.hosts error: %v", err)
+	}
+
+	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioGateway},
+		"spec", "gateways"); err != nil {
+		return nil, fmt.Errorf("set .spec.gateways error: %v", err)
+	}
+
+	istioHostAuth := os.Getenv("ISTIO_HOST_AUTH")
+	if len(istioHostAuth) == 0 {
+		return nil, fmt.Errorf("invalid ISTIO_HOST_AUTH: When ISTIO_USE_NOTEBOOK_SUBDOMAINS is set, the ISTIO_HOST_AUTH environment variable must be defined.")
+	}
+
+	istioAuthPath := os.Getenv("ISTIO_AUTH_PATH")
+	if len(istioAuthPath) == 0 {
+		istioAuthPath = "/oauth2/"
+	}
+
+	// the http section of the istio VirtualService spec
+	http := []interface{}{
+		map[string]interface{}{
+			"match": []interface{}{
+				map[string]interface{}{
+					"uri": map[string]interface{}{
+						"prefix": istioAuthPath,
+					},
+				},
+			},
+			"redirect": map[string]interface{}{
+				"authority":    istioHostAuth,
+				"redirectCode": int64(307),
+			},
+		},
+	}
+
+	// add http section to istio VirtualService spec
+	if err := unstructured.SetNestedSlice(vsvc.Object, http, "spec", "http"); err != nil {
+		return nil, fmt.Errorf("set .spec.http error: %v", err)
+	}
+
+	return vsvc, nil
+}
+
+func generateVirtualServices(instance *v1beta1.Notebook) ([]*unstructured.Unstructured, error) {
 	name := instance.Name
 	namespace := instance.Namespace
 	clusterDomain := "cluster.local"
@@ -492,19 +594,12 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	service := fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain)
 
 	vsvc := &unstructured.Unstructured{}
+	vsvcs := []*unstructured.Unstructured{vsvc}
+
 	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")
 	vsvc.SetKind("VirtualService")
 	vsvc.SetName(virtualServiceName(name, namespace))
 	vsvc.SetNamespace(namespace)
-
-	istioHost := os.Getenv("ISTIO_HOST")
-	if len(istioHost) == 0 {
-		istioHost = "*"
-	}
-	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioHost}, "spec", "hosts"); err != nil {
-		return nil, fmt.Errorf("Set .spec.hosts error: %v", err)
-
-	}
 
 	istioGateway := os.Getenv("ISTIO_GATEWAY")
 	if len(istioGateway) == 0 {
@@ -513,6 +608,33 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioGateway},
 		"spec", "gateways"); err != nil {
 		return nil, fmt.Errorf("set .spec.gateways error: %v", err)
+	}
+
+	istioHost := os.Getenv("ISTIO_HOST")
+	if os.Getenv("ISTIO_USE_NOTEBOOK_SUBDOMAINS") == "true" {
+		istioHost = os.Getenv("ISTIO_HOST_NOTEBOOK")
+		if !strings.Contains(istioHost, "${NAMESPACE}") {
+			return nil, errors.New("invalid ISTIO_HOST_NOTEBOOK: When ISTIO_USE_NOTEBOOK_SUBDOMAINS is set, the placeholder ${NAMESPACE} must be defined in ISTIO_HOST_NOTEBOOK.")
+		}
+		istioHost = strings.ReplaceAll(istioHost, "${NAMESPACE}", namespace)
+
+		vsvcForNotebookRedirect, err := generateVirtualServiceForNotebookRedirect(name, namespace, prefix, istioHost, istioGateway)
+		if err != nil {
+			return nil, fmt.Errorf("generate virtual service for notebook redirect error: %v", err)
+		}
+
+		vsvcForAuthRedirect, err := generateVirtualServiceForAuthRedirect(name, namespace, prefix, istioHost, istioGateway)
+		if err != nil {
+			return nil, fmt.Errorf("generate virtual service for auth redirect error: %v", err)
+		}
+
+		vsvcs = append(vsvcs, vsvcForAuthRedirect, vsvcForNotebookRedirect)
+	} else if len(istioHost) == 0 {
+		istioHost = "*"
+	}
+	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioHost}, "spec", "hosts"); err != nil {
+		return nil, fmt.Errorf("Set .spec.hosts error: %v", err)
+
 	}
 
 	headersRequestSet := make(map[string]string)
@@ -536,6 +658,12 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 			"headers": map[string]interface{}{
 				"request": map[string]interface{}{
 					"set": headersRequestSetInterface,
+					// remove the authorization cookie to prevent token stealing
+					// otherwise, the bearer token would be leaked to the notebook's container
+					// thus, a contributor could get access to another contributor's token
+					"remove": []interface{}{
+						"Authorization",
+					},
 				},
 			},
 			"match": []interface{}{
@@ -566,45 +694,50 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 		return nil, fmt.Errorf("set .spec.http error: %v", err)
 	}
 
-	return vsvc, nil
+	return vsvcs, nil
 
 }
 
 func (r *NotebookReconciler) reconcileVirtualService(instance *v1beta1.Notebook) error {
 	log := r.Log.WithValues("notebook", instance.Namespace)
-	virtualService, err := generateVirtualService(instance)
+	virtualServices, err := generateVirtualServices(instance)
 	if err != nil {
 		log.Info("Unable to generate VirtualService...", err)
 		return err
 	}
-	if err := ctrl.SetControllerReference(instance, virtualService, r.Scheme); err != nil {
-		return err
-	}
-	// Check if the virtual service already exists.
-	foundVirtual := &unstructured.Unstructured{}
-	justCreated := false
-	foundVirtual.SetAPIVersion("networking.istio.io/v1alpha3")
-	foundVirtual.SetKind("VirtualService")
-	err = r.Get(context.TODO(), types.NamespacedName{Name: virtualServiceName(instance.Name,
-		instance.Namespace), Namespace: instance.Namespace}, foundVirtual)
-	if err != nil && apierrs.IsNotFound(err) {
-		log.Info("Creating virtual service", "namespace", instance.Namespace, "name",
-			virtualServiceName(instance.Name, instance.Namespace))
-		err = r.Create(context.TODO(), virtualService)
-		justCreated = true
-		if err != nil {
+
+	for _, virtualService := range virtualServices {
+
+		if err := ctrl.SetControllerReference(instance, virtualService, r.Scheme); err != nil {
 			return err
 		}
-	} else if err != nil {
-		return err
-	}
-
-	if !justCreated && reconcilehelper.CopyVirtualService(virtualService, foundVirtual) {
-		log.Info("Updating virtual service", "namespace", instance.Namespace, "name",
-			virtualServiceName(instance.Name, instance.Namespace))
-		err = r.Update(context.TODO(), foundVirtual)
-		if err != nil {
+		// Check if the virtual service already exists.
+		foundVirtual := &unstructured.Unstructured{}
+		justCreated := false
+		foundVirtual.SetAPIVersion("networking.istio.io/v1alpha3")
+		foundVirtual.SetKind("VirtualService")
+		virtualServiceName := virtualService.GetName()
+		virtualServiceNamespace := virtualService.GetNamespace()
+		err = r.Get(context.TODO(), types.NamespacedName{Name: virtualServiceName, Namespace: virtualServiceNamespace}, foundVirtual)
+		if err != nil && apierrs.IsNotFound(err) {
+			log.Info("Creating virtual service", "namespace", virtualServiceNamespace, "name",
+				virtualServiceName)
+			err = r.Create(context.TODO(), virtualService)
+			justCreated = true
+			if err != nil {
+				return err
+			}
+		} else if err != nil {
 			return err
+		}
+
+		if !justCreated && reconcilehelper.CopyVirtualService(virtualService, foundVirtual) {
+			log.Info("Updating virtual service", "namespace", virtualServiceNamespace, "name",
+				virtualServiceName)
+			err = r.Update(context.TODO(), foundVirtual)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -646,12 +646,16 @@ func generateVirtualServices(instance *v1beta1.Notebook) ([]*unstructured.Unstru
 			headersRequestSet = make(map[string]string)
 		}
 	}
+
+	modifyHeader := func(s string) string { return s }
+	if os.Getenv("ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION") == "true" {
+		modifyHeader = escapeDynamicEnvoyValueSymbol
+	}
 	// cast from map[string]string, as SetNestedSlice needs map[string]interface{}
 	headersRequestSetInterface := make(map[string]interface{})
 	for key, element := range headersRequestSet {
-		headersRequestSetInterface[key] = element
+		headersRequestSetInterface[key] = modifyHeader(element)
 	}
-
 	// the http section of the istio VirtualService spec
 	http := []interface{}{
 		map[string]interface{}{
@@ -908,4 +912,13 @@ func (r *NotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return nil
+}
+
+// escapeDynamicEnvoyValueSymbol escapes literal percent symbols
+// of envoy's substitution commands syntax in headers.
+//
+// example: "%REQUEST_HEADER(MY_CUSTOM_HEADER)%" becomes "%%REQUEST_HEADER(MY_CUSTOM_HEADER)%%".
+// reference: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers
+func escapeDynamicEnvoyValueSymbol(value string) string {
+	return strings.ReplaceAll(value, "%", "%%")
 }

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -313,6 +313,7 @@ func TestGenerateVirtualServices(t *testing.T) {
 		"ISTIO_HOST_NOTEBOOK",
 		"ISTIO_HOST_AUTH",
 		"ISTIO_AUTH_PATH",
+		"ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION",
 	}
 	preserveEnvironment(t, cleanEnv)
 
@@ -500,6 +501,40 @@ func TestGenerateVirtualServices(t *testing.T) {
 			},
 			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_rewrite.yaml"),
 			testEnv:                 map[string]string{},
+		},
+		{
+			name: "Notebooks Envoy header manipulation is disabled",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+					Annotations: map[string]string{
+						"notebooks.kubeflow.org/http-headers-request-set": `{"X-Leaked-Token": "Example-Value %REQ(Authorization)% foobar", "X-Leaked-Value": "%PROTOCOL%"}`,
+					},
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_header_manipulation_disabled.yaml"),
+			testEnv: map[string]string{
+				"ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION": "true",
+			},
+		},
+		{
+			name: "Notebooks Envoy header manipulation is enabled",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+					Annotations: map[string]string{
+						"notebooks.kubeflow.org/http-headers-request-set": `{"X-Leaked-Token": "Example-Value %REQ(Authorization)% foobar", "X-Leaked-Value": "%PROTOCOL%"}`,
+					},
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_header_manipulation_enabled.yaml"),
+			testEnv: map[string]string{
+				"ISTIO_DISABLE_ENVOY_HEADER_MANIPULATION": "false",
+			},
 		},
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -1,21 +1,33 @@
 package controllers
 
 import (
+	"bytes"
+	"embed"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
 	"reflect"
 	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	nbv1beta1 "github.com/kubeflow/notebooks/components/notebook-controller/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	_ "embed"
 )
 
 func TestNbNameFromInvolvedObject(t *testing.T) {
@@ -289,10 +301,290 @@ func TestCreateNotebookStatus(t *testing.T) {
 
 }
 
+func TestGenerateVirtualServices(t *testing.T) {
+
+	tests := []struct {
+		name                    string
+		notebook                nbv1beta1.Notebook
+		expectedVirtualServices []*unstructured.Unstructured
+		expectedErrorState      error
+		testEnv                 map[string]string
+	}{
+		{
+			name: "Default config",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_default_config.yaml"),
+			testEnv:                 map[string]string{},
+		},
+		{
+			name: "Istio host set",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_istio_host_set.yaml"),
+			testEnv: map[string]string{
+				"ISTIO_HOST": "kubeflow.example.org",
+			},
+		},
+		{
+			name: "Istio gateway set",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_istio_gateway_set.yaml"),
+			testEnv: map[string]string{
+				"ISTIO_GATEWAY": "test/test-gateway",
+			},
+		},
+		{
+			name: "Cluster domain set",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_cluster_domain_set.yaml"),
+			testEnv: map[string]string{
+				"CLUSTER_DOMAIN": "example.local",
+			},
+		},
+		{
+			name: "Notebooks subdomain configured",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_subdomains.yaml"),
+			testEnv: map[string]string{
+				"ISTIO_USE_NOTEBOOK_SUBDOMAINS": "true",
+				"ISTIO_HOST_NOTEBOOK":           "${NAMESPACE}-notebook.kubeflow.example.org",
+				"ISTIO_HOST_AUTH":               "kubeflow.example.org",
+			},
+		},
+		{
+			name: "Notebooks subdomain configured with different auth path",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_subdomains_different_auth_path.yaml"),
+			testEnv: map[string]string{
+				"ISTIO_USE_NOTEBOOK_SUBDOMAINS": "true",
+				"ISTIO_HOST_NOTEBOOK":           "${NAMESPACE}-notebook.kubeflow.example.org",
+				"ISTIO_HOST_AUTH":               "kubeflow.example.org",
+				"ISTIO_AUTH_PATH":               "/different-auth/",
+			},
+		},
+		{
+			name: "Notebooks invalid subdomain configuration: missing ISTIO_HOST_AUTH",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedErrorState: fmt.Errorf("generate virtual service for auth redirect error: invalid ISTIO_HOST_AUTH: When ISTIO_USE_NOTEBOOK_SUBDOMAINS is set, the ISTIO_HOST_AUTH environment variable must be defined."),
+			testEnv: map[string]string{
+				"ISTIO_USE_NOTEBOOK_SUBDOMAINS": "true",
+				"ISTIO_HOST_NOTEBOOK":           "${NAMESPACE}-notebook.kubeflow.example.org",
+			},
+		},
+		{
+			name: "Notebooks invalid subdomain configuration: missing ISTIO_HOST_NOTEBOOK",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedErrorState: fmt.Errorf("invalid ISTIO_HOST_NOTEBOOK: When ISTIO_USE_NOTEBOOK_SUBDOMAINS is set, the placeholder ${NAMESPACE} must be defined in ISTIO_HOST_NOTEBOOK."),
+			testEnv: map[string]string{
+				"ISTIO_USE_NOTEBOOK_SUBDOMAINS": "true",
+				"ISTIO_HOST_AUTH":               "kubeflow.example.org",
+			},
+		},
+		{
+			name: "Notebooks invalid subdomain configuration: invalid ISTIO_HOST_NOTEBOOK",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedErrorState: fmt.Errorf("invalid ISTIO_HOST_NOTEBOOK: When ISTIO_USE_NOTEBOOK_SUBDOMAINS is set, the placeholder ${NAMESPACE} must be defined in ISTIO_HOST_NOTEBOOK."),
+			testEnv: map[string]string{
+				"ISTIO_USE_NOTEBOOK_SUBDOMAINS": "true",
+				"ISTIO_HOST_NOTEBOOK":           "${NAMESPACE-notebook.kubeflow.example.org",
+				"ISTIO_HOST_AUTH":               "kubeflow.example.org",
+			},
+		},
+		{
+			name: "Notebooks header annotation configured",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+					Annotations: map[string]string{
+						"notebooks.kubeflow.org/http-headers-request-set": `{"ExampleHeader": "Example-Value", "ExampleHeader2": "Example-Value2"}`,
+					},
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_headers.yaml"),
+			testEnv:                 map[string]string{},
+		},
+		{
+			name: "Notebooks invalid header annotation configured",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+					Annotations: map[string]string{
+						"notebooks.kubeflow.org/http-headers-request-set": `{"ExampleHeader": "Example-INVALID_JSON}`,
+					},
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_default_config.yaml"),
+			testEnv:                 map[string]string{},
+		},
+		{
+			name: "Notebooks rewrite annotation configured",
+			notebook: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+					Annotations: map[string]string{
+						"notebooks.kubeflow.org/http-rewrite-uri": `/foo/bar`,
+					},
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			expectedVirtualServices: decodeUnstructuredFixture(t, "notebook_controller_virtualservice_test_rewrite.yaml"),
+			testEnv:                 map[string]string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prepareTestEnvironment(t, test.testEnv)
+
+			actualVirtualServices, actualErrorState := generateVirtualServices(&test.notebook)
+
+			if test.expectedErrorState != nil {
+				if test.expectedErrorState.Error() != actualErrorState.Error() {
+					t.Errorf("Unexpected error: %v\nExpected: %v", actualErrorState, test.expectedErrorState.Error())
+				}
+			} else {
+				if actualErrorState != nil {
+					t.Errorf("Unexpected error: %v", actualErrorState)
+				}
+
+				if len(actualVirtualServices) != len(test.expectedVirtualServices) {
+					t.Errorf("\nExpect: len()=%v; \nOutput: len()=%v", len(test.expectedVirtualServices), len(actualVirtualServices))
+				}
+
+				for i, expected := range test.expectedVirtualServices {
+					var actual *unstructured.Unstructured
+					if len(actualVirtualServices) > i {
+						actual = actualVirtualServices[i]
+					}
+					if !apiequality.Semantic.DeepEqual(expected, actual) {
+						t.Errorf("\nExpect: %v; \nOutput: %v", expected, actual)
+					}
+				}
+			}
+		})
+	}
+
+}
+
 func createMockReconciler() *NotebookReconciler {
 	reconciler := &NotebookReconciler{
 		Scheme: runtime.NewScheme(),
 		Log:    ctrl.Log,
 	}
 	return reconciler
+}
+
+func prepareTestEnvironment(t *testing.T, testEnv map[string]string) {
+	// save old environment & set test environment
+	oldEnv := make(map[string]string)
+	for key, value := range testEnv {
+		oldValue, hadValue := os.LookupEnv(key)
+		if hadValue {
+			oldEnv[key] = oldValue
+			t.Cleanup(func() {
+				os.Setenv(key, oldValue)
+			})
+		} else {
+			t.Cleanup(func() {
+				os.Unsetenv(key)
+			})
+		}
+		os.Setenv(key, value)
+	}
+
+}
+
+//go:embed test_fixtures/*.yaml
+var fixtures embed.FS
+
+func decodeUnstructuredFixture(t *testing.T, name string) []*unstructured.Unstructured {
+	t.Helper()
+
+	data, err := fixtures.ReadFile(path.Join("test_fixtures", name))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	var objects []*unstructured.Unstructured
+
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+	for {
+		var obj unstructured.Unstructured
+
+		err := decoder.Decode(&obj)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to decode YAML fixture: %v", err)
+		}
+
+		// Skip empty YAML documents.
+		if len(obj.Object) == 0 {
+			continue
+		}
+
+		objects = append(objects, &obj)
+	}
+
+	return objects
 }

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -20,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -532,6 +535,93 @@ func TestGenerateVirtualServices(t *testing.T) {
 		})
 	}
 
+}
+
+func TestReconcileVirtualServiceDeletesStaleRedirects(t *testing.T) {
+
+	// remove this set of environment variables to ensure a clean env
+	cleanEnv := []string{
+		"CLUSTER_DOMAIN",
+		"ISTIO_HOST",
+		"ISTIO_GATEWAY",
+		"ISTIO_USE_NOTEBOOK_SUBDOMAINS",
+		"ISTIO_HOST_NOTEBOOK",
+		"ISTIO_HOST_AUTH",
+		"ISTIO_AUTH_PATH",
+	}
+	preserveEnvironment(t, cleanEnv)
+
+	prepareTestEnvironment(cleanEnv, map[string]string{
+		"ISTIO_USE_NOTEBOOK_SUBDOMAINS": "true",
+		"ISTIO_HOST_NOTEBOOK":           "${NAMESPACE}-notebook.kubeflow.example.org",
+		"ISTIO_HOST_AUTH":               "kubeflow.example.org",
+	})
+
+	notebook := &nbv1beta1.Notebook{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "kubeflow-user",
+			UID:       types.UID("test-notebook-uid"),
+		},
+	}
+
+	testScheme := runtime.NewScheme()
+	if err := nbv1beta1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("failed to add Notebook API to scheme: %v", err)
+	}
+
+	virtualServices, err := generateVirtualServices(notebook)
+	if err != nil {
+		t.Fatalf("failed to generate initial VirtualServices: %v", err)
+	}
+
+	objects := make([]runtime.Object, 0, len(virtualServices))
+	for _, virtualService := range virtualServices {
+		if err := ctrl.SetControllerReference(notebook, virtualService, testScheme); err != nil {
+			t.Fatalf("failed to set controller reference: %v", err)
+		}
+		objects = append(objects, virtualService)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithRuntimeObjects(objects...).
+		Build()
+	reconciler := &NotebookReconciler{
+		Client: fakeClient,
+		Scheme: testScheme,
+		Log:    ctrl.Log,
+	}
+
+	if err := os.Unsetenv("ISTIO_USE_NOTEBOOK_SUBDOMAINS"); err != nil {
+		t.Fatalf("failed to disable notebook subdomains: %v", err)
+	}
+	if err := reconciler.reconcileVirtualService(notebook); err != nil {
+		t.Fatalf("failed to reconcile VirtualServices: %v", err)
+	}
+
+	baseVirtualService := &unstructured.Unstructured{}
+	baseVirtualService.SetAPIVersion("networking.istio.io/v1alpha3")
+	baseVirtualService.SetKind("VirtualService")
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      virtualServiceName(notebook.Name, notebook.Namespace),
+		Namespace: notebook.Namespace,
+	}, baseVirtualService); err != nil {
+		t.Fatalf("expected base VirtualService to remain: %v", err)
+	}
+
+	for _, suffix := range []string{"auth-redirect", "notebook-redirect"} {
+		staleVirtualService := &unstructured.Unstructured{}
+		staleVirtualService.SetAPIVersion("networking.istio.io/v1alpha3")
+		staleVirtualService.SetKind("VirtualService")
+		err := fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      virtualServiceNameWithSuffix(notebook.Name, notebook.Namespace, suffix),
+			Namespace: notebook.Namespace,
+		}, staleVirtualService)
+		if !apierrs.IsNotFound(err) {
+			t.Fatalf("expected stale %s VirtualService to be deleted, got: %v", suffix, err)
+		}
+	}
 }
 
 func createMockReconciler() *NotebookReconciler {

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -26,8 +26,6 @@ import (
 
 	nbv1beta1 "github.com/kubeflow/notebooks/components/notebook-controller/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
-
-	_ "embed"
 )
 
 func TestNbNameFromInvolvedObject(t *testing.T) {
@@ -303,6 +301,18 @@ func TestCreateNotebookStatus(t *testing.T) {
 
 func TestGenerateVirtualServices(t *testing.T) {
 
+	// remove this set of environment variables to ensure a clean env
+	cleanEnv := []string{
+		"CLUSTER_DOMAIN",
+		"ISTIO_HOST",
+		"ISTIO_GATEWAY",
+		"ISTIO_USE_NOTEBOOK_SUBDOMAINS",
+		"ISTIO_HOST_NOTEBOOK",
+		"ISTIO_HOST_AUTH",
+		"ISTIO_AUTH_PATH",
+	}
+	preserveEnvironment(t, cleanEnv)
+
 	tests := []struct {
 		name                    string
 		notebook                nbv1beta1.Notebook
@@ -492,7 +502,7 @@ func TestGenerateVirtualServices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			prepareTestEnvironment(t, test.testEnv)
+			prepareTestEnvironment(cleanEnv, test.testEnv)
 
 			actualVirtualServices, actualErrorState := generateVirtualServices(&test.notebook)
 
@@ -532,24 +542,28 @@ func createMockReconciler() *NotebookReconciler {
 	return reconciler
 }
 
-func prepareTestEnvironment(t *testing.T, testEnv map[string]string) {
-	// save old environment & set test environment
-	oldEnv := make(map[string]string)
-	for key, value := range testEnv {
+// backup & restore old environment after test
+func preserveEnvironment(t *testing.T, cleanEnv []string) {
+	for _, key := range cleanEnv {
 		oldValue, hadValue := os.LookupEnv(key)
 		if hadValue {
-			oldEnv[key] = oldValue
 			t.Cleanup(func() {
 				os.Setenv(key, oldValue)
 			})
-		} else {
-			t.Cleanup(func() {
-				os.Unsetenv(key)
-			})
 		}
-		os.Setenv(key, value)
+	}
+}
+
+func prepareTestEnvironment(cleanEnv []string, testEnv map[string]string) {
+	// clean environment
+	for _, key := range cleanEnv {
+		os.Unsetenv(key)
 	}
 
+	// set test environment
+	for key, value := range testEnv {
+		os.Setenv(key, value)
+	}
 }
 
 //go:embed test_fixtures/*.yaml

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -510,7 +510,7 @@ func TestGenerateVirtualServices(t *testing.T) {
 			actualVirtualServices, actualErrorState := generateVirtualServices(&test.notebook)
 
 			if test.expectedErrorState != nil {
-				if test.expectedErrorState.Error() != actualErrorState.Error() {
+				if actualErrorState == nil || test.expectedErrorState.Error() != actualErrorState.Error() {
 					t.Errorf("Unexpected error: %v\nExpected: %v", actualErrorState, test.expectedErrorState.Error())
 				}
 			} else {

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_cluster_domain_set.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_cluster_domain_set.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.example.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_default_config.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_default_config.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_header_manipulation_disabled.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_header_manipulation_disabled.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set:
+          X-Leaked-Token: 'Example-Value %%REQ(Authorization)%% foobar'
+          X-Leaked-Value: '%%PROTOCOL%%'
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_header_manipulation_enabled.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_header_manipulation_enabled.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set:
+          X-Leaked-Token: 'Example-Value %REQ(Authorization)% foobar'
+          X-Leaked-Value: '%PROTOCOL%'
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_headers.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_headers.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set:
+          ExampleHeader: "Example-Value"
+          ExampleHeader2: "Example-Value2"
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_istio_gateway_set.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_istio_gateway_set.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - test/test-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_istio_host_set.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_istio_host_set.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - 'kubeflow.example.org'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_rewrite.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_rewrite.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/foo/bar"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_subdomains.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_subdomains.yaml
@@ -1,0 +1,65 @@
+# Notebook
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - 'kubeflow-user-notebook.kubeflow.example.org'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80
+---
+# Auth redirect
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test-auth-redirect
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - 'kubeflow-user-notebook.kubeflow.example.org'
+  http:
+  - match:
+    - uri:
+        prefix: "/oauth2/"
+    redirect:
+      authority: "kubeflow.example.org"
+      redirectCode: 307
+---
+# Redirect after auth
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test-notebook-redirect
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    redirect:
+      authority: "kubeflow-user-notebook.kubeflow.example.org"
+      redirectCode: 307

--- a/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_subdomains_different_auth_path.yaml
+++ b/components/notebook-controller/controllers/test_fixtures/notebook_controller_virtualservice_test_subdomains_different_auth_path.yaml
@@ -1,0 +1,65 @@
+# Notebook
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - 'kubeflow-user-notebook.kubeflow.example.org'
+  http:
+  - headers:
+      request:
+        remove: 
+        - "Authorization"
+        set: {}
+    match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    rewrite:
+      uri: "/notebook/kubeflow-user/test/"
+    route:
+    - destination:
+        host: "test.kubeflow-user.svc.cluster.local"
+        port: 
+          number: 80
+---
+# Auth redirect
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test-auth-redirect
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - 'kubeflow-user-notebook.kubeflow.example.org'
+  http:
+  - match:
+    - uri:
+        prefix: "/different-auth/"
+    redirect:
+      authority: "kubeflow.example.org"
+      redirectCode: 307
+---
+# Redirect after auth
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: notebook-kubeflow-user-test-notebook-redirect
+  namespace: kubeflow-user
+spec:
+  gateways: 
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: "/notebook/kubeflow-user/test/"
+    redirect:
+      authority: "kubeflow-user-notebook.kubeflow.example.org"
+      redirectCode: 307


### PR DESCRIPTION
This PR makes it possible to host notebooks on their own subdomains when Istio is used by adding this feature to the Kubeflow `notebook-controller`. This isolates the notebook's origin from the dashboard / Kubeflow API origin in the browser and addresses a security problem that allows session hijacking through a malicious notebook.

This pull request addresses the security issue described in [GHSA-qjw6-hpc7-w36h](https://github.com/kubeflow/notebooks/security/advisories/GHSA-qjw6-hpc7-w36h)

The relevant changes to the community-distribution can be found in pull request https://github.com/kubeflow/community-distribution/pull/3550 .

Please note, we will add the feature to v2 once the feature is approved.

(reopend PR from [!7742 in kubeflow/kubeflow](https://github.com/kubeflow/kubeflow/pull/7742/files))

## Motivation / Why this change is needed
This change addresses a security problem that allows session hijacking through a malicious notebook:

An attacker can log session cookies by misusing the Notebook feature: An attacker can create a Notebook with a custom image that logs the cookies / trigger API requests. Afterwards, they must convince the victim to visit the URL of the Notebook (a phishing attack). This is a classic phishing attack scenario.

Disallowing custom images wouldn't be sufficient because you can achieve the same thing with a few extra steps using one of default images.

The problem relies on the fact that the Notebooks and the Kubeflow Dashboard / APIs are in the Browser's [same origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). Thus, any attacker-controlled site would be able to access the Kubeflow API in the context of the victim.

To prevent this attack, the [authenticating cookies need to be removed](https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations) from requests forwarded to Notebook's Pods, and the notebooks need to be hosted on a different domain. This PR accomplishes this.

A proof of concept that demonstrates the problem is available but will not be disclosed until the problem is fixed.

## Request for Feedback

~~At the moment, we are removing all cookie headers for security reasons before the request is forwarded to the notebook container. This breaks the functionality in some notebook images. So the goal is to remove only the authenticating cookie and keep the remaining cookies..~~

~~Our idea is to use a [Istio Wasm Plugin](https://istio.io/latest/docs/reference/config/proxy_extensions/wasm-plugin/) that accomplishes this.~~

As discussed with @thesuperzapper, we will ad a envoy filter to remove the authorizing cookie. This will be part of a pull request in [kubeflow-manifests](https://github.com/kubeflow/community-distribution/tree/master).

## What this PR accomplishes
1. Set individual hosts based on the environment variable `ISTIO_HOST_NOTEBOOK` in the notebook's VirtualServices when `ISTIO_USE_NOTEBOOK_SUBDOMAINS` is set to prevent access to the dashboard / APIs from attacker-controlled notebooks through the browser.
2. Implementing the authentication flow on the subdomains by redirecting unauthenticated requests to the host configured in `ISTIO_HOST_AUTH` for the `ISTIO_AUTH_PATH`.
3. Remove authenticating token from the request before it is forwarded to the notebook container to prevent session token stealing (see [line 664 in ``components/notebook-controller/controllers/notebook_controller.go‎``](https://github.com/kubeflow/notebooks/pull/562/changes/BASE..6bbd74650b9a568514a013c74221f08b03715117#diff-a436986c5e93996f9035eee6798d064ab8659957e8443eb44b3a4d3db289bde4R664)). The cookie header cannot be removed as cookies are required by some notebook images. We remove the authenticating cookie through an ``EnvoyFilter``. This is part of  https://github.com/kubeflow/community-distribution/pull/3550 and not this PR.

This pull request **does not change any default behavior of the notebook's controller**. Unless ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is explicitly set, the notebook controller works as before.

## ~~Open Tasks~~ (done)

~~This PR is a draft at the moment because the following parts are work in progress:~~

1. [x]  At the moment, we are removing all cookie headers for security reasons before the request is forwarded to the notebook container. This breaks the functionality in some notebook images. So the goal is to remove only the authenticating cookie and keep the remaining cookies. See [Request for Feedback](#request-for-feedback)
   - We fixed this problem with an ``EnvoyFilter``. This will not be part of this pull request as it will be part of the Kubeflow [manifests repository](https://github.com/kubeflow/manifests). Thanks to @thesuperzapper for the productive discussion last year.
2. [x]  The subdomain feature requires additional configuration in the Kubeflow installation to make it fully functional (see configuration below). This will be documented and provided in a separate pull request in the [manifests repository](https://github.com/kubeflow/manifests), see https://github.com/kubeflow/community-distribution/pull/3550
3. [x]  Unit test code for the new feature

## Configuration
The subdomain feature is disabled by default as the setup has some prerequisites and is a breaking change. It requires a wildcard domain and wildcard TLS certificate or automated domain and certificate management.

To enable the feature, do the following configuration steps:

1. Configure the following environment variables in the `notebook-controller`:

```shell
ISTIO_USE_NOTEBOOK_SUBDOMAINS: true
ISTIO_HOST_NOTEBOOK: "${NAMESPACE}-notebook.kubeflow.example.com"
ISTIO_HOST_AUTH: "kubeflow.example.com"
ISTIO_HOST_AUTH_PATH: "/oauth2/"
```

2. The `configmap` of `oauth2` must also be adjusted by enabling cookies for subdomains. Edit the `oauth2_proxy.cfg` configuration of the `oauth2-proxy-hk55gm96k4` ConfigMap in the `oauth2-proxy` namespace and add the following setting:

```shell
cookie_domains = "kubeflow.example.com"
```

Detailed instructions are part of the pull request [!3550 in kubeflow-manifests](https://github.com/kubeflow/community-distribution/pull/3550).

## Notes

Setting ``forwardOriginalToken`` to ``false`` is not a solution as this would break existing functionality. We rather remove the token from requests to the notebooks only.