### PR TITLE
fix(metrics): reset running notebooks metrics before scraping statefulsets

### DIFF
--- a/components/notebook-controller/pkg/metrics/metrics.go
+++ b/components/notebook-controller/pkg/metrics/metrics.go
@@ -80,6 +80,9 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 
 // scrape gets current running notebook statefulsets.
 func (m *Metrics) scrape() {
+	// Reset the current metrics to clear previous data
+	m.runningNotebooks.Reset()
+
 	stsList := &appsv1.StatefulSetList{}
 	err := m.cli.List(context.TODO(), stsList)
 	if err != nil {


### PR DESCRIPTION
It might be better to clear the historical records each time the `notebook_running` metric is calculated. 

For example, if I create a notebook in the `test` namespace and then delete it, never using the `test` namespace again, the `notebook_running` metric will still contain the record `notebook_running{namespace="test"} 1`. 

This is because the `stsCache` will no longer track data related to the `test` namespace, and `m.runningKernels.WithLabelValues(ns).Set(v)` will never update the data for the `test` namespace.
