### PR TITLE
fix: correct Angular CLI argument naming in build:watch scripts

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/package.json
+++ b/components/crud-web-apps/jupyter/frontend/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write './**/*.{ts,html,css}'",
     "build": "npm run copyLibAssets && ng build --base-href /jupyter/ --deploy-url static/",
     "build:fr": "npm run copyLibAssets && ng build --base-href /jupyter/ --deploy-url static/ --configuration=fr",
-    "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
+    "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --output-path ../backend/apps/default/static/ --output-hashing all",
     "serve": "npm run copyLibAssets && ng serve --proxy-config=src/proxy.conf.json",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "format:check": "prettier --check 'src/**/*.{js,ts,html,scss,css}' || node scripts/check-format-error.js",

--- a/components/crud-web-apps/tensorboards/frontend/package.json
+++ b/components/crud-web-apps/tensorboards/frontend/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "build": "npm run copyLibAssets && ng build --base-href /tensorboards/ --deploy-url static/",
     "build:fr": "npm run copyLibAssets && ng build --base-href /tensorboards/ --deploy-url /static/ --configuration=fr",
-    "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/app/static/ --outputHashing all",
+    "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --output-path ../backend/app/static/ --output-hashing all",
     "serve": "npm run copyLibAssets && ng serve --proxy-config=src/proxy.conf.json",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "format:check": "prettier --check 'src/**/*.{js,ts,html,scss,css}' || node scripts/check-format-error.js",

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "build": "npm run copyLibAssets && ng build --base-href /volumes/ --deploy-url static/",
     "build:fr": "npm run copyLibAssets && ng build --base-href /volumes/ --deploy-url /static/ --configuration=fr",
-    "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
+    "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --output-path ../backend/apps/default/static/ --output-hashing all",
     "serve": "npm run copyLibAssets && ng serve --proxy-config=src/proxy.conf.json",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "format:check": "prettier --check 'src/**/*.{js,ts,html,scss,css}' || node scripts/check-format-error.js",


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR fixes incorrect Angular CLI argument naming in the `build:watch` npm scripts across all frontend components.
The Angular CLI was throwing "Unknown arguments" errors:

```shell
npm run build:watch

> frontend@0.0.0 build:watch
> npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all


> frontend@0.0.0 copyLibAssets
> cp -r ./node_modules/kubeflow/assets/* ./src/assets/

Error: Unknown arguments: outputPath, outputHashing
```

