### PR TITLE
chore: update supported platforms for multi-arch builds

### DIFF
--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -104,7 +104,7 @@ docker-push: ## Push docker image with the backend.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64/v8,linux/amd64,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile

--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -114,7 +114,7 @@ docker-push: ## Push docker image with the manager.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64/v8,linux/amd64,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile

--- a/workspaces/frontend/Makefile
+++ b/workspaces/frontend/Makefile
@@ -39,7 +39,7 @@ docker-push: ## Push docker image for the frontend.
 	$(CONTAINER_TOOL) push ${IMG}
 
 # PLATFORMS defines the target platforms for cross-platform support.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64/v8,linux/amd64,linux/ppc64le
 
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for cross-platform support.


### PR DESCRIPTION
ℹ️  _NO GH ISSUE_

After discussion with the Kubeflow WG lead - concerns were raised about including `linux/s390x` support in our multi-arch builds for the following reasons:
- not clear we could in good faith support this system due to lack of hardware / potential emulation issues
- not clear there is enough of a need from community to support `linux/s390x` for Kubeflow Notebooks.

As a result - we are going to remove the `linux/s390x` target from our multi-arch builds logic for all the `workspaces` components.

Additionally, included a minor fix to explicitly specify the `v8` variant of `linux/arm64`.  Today `linux/arm64` and `linux/arm64/v8` are essentially the same - but that could change if there was ever a `v9` variant introduced.  As such - opting to be explicit here.

