### PR TITLE
chore: add area labels in owners files

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/ci

--- a/components/common/OWNERS
+++ b/components/common/OWNERS
@@ -1,0 +1,3 @@
+labels:
+  - area/controller
+  - area/v1

--- a/components/crud-web-apps/OWNERS
+++ b/components/crud-web-apps/OWNERS
@@ -1,3 +1,7 @@
+labels:
+  - area/frontend
+  - area/backend
+  - area/v1
 approvers:
   - kimwnasptd
   - thesuperzapper

--- a/components/example-notebook-servers/OWNERS
+++ b/components/example-notebook-servers/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/server-images
+  - area/v1
 approvers:
   - kimwnasptd
   - thesuperzapper

--- a/components/notebook-controller/OWNERS
+++ b/components/notebook-controller/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/controller
+  - area/v1
 approvers:
   - kimwnasptd
   - thesuperzapper

--- a/components/pvcviewer-controller/OWNERS
+++ b/components/pvcviewer-controller/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/controller
+  - area/v1
 approvers:
   - apo-ger
   - kimwnasptd

--- a/components/tensorboard-controller/OWNERS
+++ b/components/tensorboard-controller/OWNERS
@@ -1,0 +1,3 @@
+labels:
+  - area/controller
+  - area/v1


### PR DESCRIPTION
Adds automatic area labels using the OWNERS files to the `notebooks-v1` branch, similar to https://github.com/kubeflow/notebooks/pull/450 for `notebooks-v2`