### PR TITLE
chore: add area labels in owners files

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/ci


### PR DESCRIPTION
Adds automatic area labels using the OWNERS files to the `main` branch, similar to https://github.com/kubeflow/notebooks/pull/450 for `notebooks-v2` and https://github.com/kubeflow/notebooks/pull/594 for the `notebooks-v1` branch.