### PR TITLE
test(tb): Migrate TBC test-related workflows from kubeflow/kubeflow to notebooks-v1 branch

### DIFF
--- a/.github/workflows/tb_controller_integration_test.yaml
+++ b/.github/workflows/tb_controller_integration_test.yaml
@@ -1,0 +1,64 @@
+name: Tensorboard Controller Integration Test
+on:
+  pull_request:
+    paths:
+      - components/tensorboard-controller/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
+      - notebooks-v1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: ghcr.io/kubeflow/kubeflow/tensorboard-controller
+  TAG: integration-test
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Tensorboard Controller Image
+        run: |
+          cd components/tensorboard-controller
+          make docker-build 
+
+      - name: Install KinD
+        run: ./components/testing/gh-actions/install_kind.sh
+
+      - name: Create KinD Cluster
+        run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
+
+      - name: Load Images into KinD Cluster
+        run: |
+          kind load docker-image "${IMG}:${TAG}"
+
+      - name: Install kustomize
+        run: ./components/testing/gh-actions/install_kustomize.sh
+
+      - name: Install Istio
+        run: ./components/testing/gh-actions/install_istio.sh
+
+      - name: Build & Apply manifests
+        run: |
+          cd components/tensorboard-controller/config
+          kubectl create ns kubeflow
+          
+          export CURRENT_IMAGE="${IMG}"
+          export PR_IMAGE="${IMG}:${TAG}"
+          
+          # escape "." in the image names, as it is a special characters in sed
+          export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+          export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+          
+          kustomize build overlays/kubeflow \
+            | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+            | kubectl apply -f -
+          
+          kubectl wait pods -n kubeflow -l app=tensorboard-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/tb_controller_multi_arch_test.yaml
+++ b/.github/workflows/tb_controller_multi_arch_test.yaml
@@ -1,0 +1,37 @@
+name: TensorBoard Controller Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/tensorboard-controller/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
+      - notebooks-v1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: ghcr.io/kubeflow/kubeflow/tensorboard-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build multi-arch Image
+        run: |
+          cd components/tensorboard-controller
+          ARCH=linux/amd64 make docker-build-multi-arch
+          ARCH=linux/ppc64le make docker-build-multi-arch
+          ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/components/testing/gh-actions/install_cert_manager.sh
+++ b/components/testing/gh-actions/install_cert_manager.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CERT_MANAGER_VERSION="1.12.10"
+CERT_MANAGER_URL="https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml"
+
+echo "Fetching cert-manager ${CERT_MANAGER_VERSION} manifests..."
+curl -sL -o cert-manager.yaml "$CERT_MANAGER_URL"
+
+echo "Applying cert-manager manifests..."
+kubectl apply -f cert-manager.yaml
+
+echo "Waiting for cert-manager to be ready..."
+kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager

--- a/components/testing/gh-actions/install_istio.sh
+++ b/components/testing/gh-actions/install_istio.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ISTIO_VERSION="1.17.8"
+ISTIO_URL="https://istio.io/downloadIstio"
+
+echo "Installing Istio ${ISTIO_VERSION} ..."
+mkdir istio_tmp
+pushd istio_tmp >/dev/null
+    curl -sL "$ISTIO_URL" | ISTIO_VERSION=${ISTIO_VERSION} sh -
+    cd istio-${ISTIO_VERSION}
+    export PATH=$PWD/bin:$PATH
+    istioctl install -y
+popd

--- a/components/testing/gh-actions/install_kind.sh
+++ b/components/testing/gh-actions/install_kind.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KIND_VERSION="0.22.0"
+KIND_URL="https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64"
+
+echo "Setting up kind environment..."
+sudo swapoff -a
+sudo rm -f /swapfile
+sudo mkdir -p /tmp/etcd
+sudo mount -t tmpfs tmpfs /tmp/etcd
+
+echo "Installing kind ${KIND_VERSION} ..."
+curl -sL -o kind "$KIND_URL"
+chmod +x ./kind
+sudo mv kind /usr/local/bin

--- a/components/testing/gh-actions/install_kustomize.sh
+++ b/components/testing/gh-actions/install_kustomize.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KUSTOMIZE_VERSION="5.4.1"
+KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+
+echo "Installing kustomize ${KUSTOMIZE_VERSION} ..."
+curl -sL -o kustomize.tar.gz "$KUSTOMIZE_URL"
+tar -xzf kustomize.tar.gz
+chmod +x kustomize
+sudo mv kustomize /usr/local/bin

--- a/components/testing/gh-actions/kind-1-22.yaml
+++ b/components/testing/gh-actions/kind-1-22.yaml
@@ -1,0 +1,24 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+# Configure registry for KinD.
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."$REGISTRY_NAME:$REGISTRY_PORT"]
+      endpoint = ["http://$REGISTRY_NAME:$REGISTRY_PORT"]
+# This is needed in order to support projected volumes with service account tokens.
+# See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+nodes:
+  - role: control-plane
+    image: kindest/node:1.22.9@sha256:ad5b8404c4052781365a4e70bb7d17c5331e4177bd4a7cd214339316cd6193b6
+  - role: worker
+    image: kindest/node:1.22.9@sha256:ad5b8404c4052781365a4e70bb7d17c5331e4177bd4a7cd214339316cd6193b6

--- a/components/testing/gh-actions/kind-1-25.yaml
+++ b/components/testing/gh-actions/kind-1-25.yaml
@@ -1,0 +1,24 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+# Configure registry for KinD.
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."$REGISTRY_NAME:$REGISTRY_PORT"]
+      endpoint = ["http://$REGISTRY_NAME:$REGISTRY_PORT"]
+# This is needed in order to support projected volumes with service account tokens.
+# See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+  - role: worker
+    image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1


### PR DESCRIPTION
resolves #591 

migrate the files below to kubeflow/notebooks-v1 branch: 
 - tb_controller_multi_arch_test.yaml
 - tb_controller_integration_test.yaml

 


added the following needed for the tests:
 - install_cert_manager.sh
 - install_istio.sh
 - install_kind.sh
 - install_kustomize.sh
 - kind-1-22.yaml
 - kind-1-25.yaml

