### PR TITLE
ci: add publish workflow for backend

### DIFF
--- a/.github/workflows/ws-backend-publish.yml
+++ b/.github/workflows/ws-backend-publish.yml
@@ -1,0 +1,55 @@
+name: Build & Publish Backend container image
+on:
+  push:
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
+    paths:
+      - workspaces/**    ## NOTE: we publish changes on any commit to workspaces/ components
+      - releasing/version/VERSION
+
+env:
+  REGISTRY: ghcr.io/kubeflow/notebooks
+  NAME: workspaces-backend
+
+jobs:
+  push_to_registry:
+    name: Build & Push container image to GHCR
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          version:
+            - 'releasing/version/VERSION'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push multi-arch container image
+      run: |
+        cd workspaces/backend
+        make docker-buildx REGISTRY=${REGISTRY} NAME=${NAME}
+
+    - name: Build and push multi-arch container image on Version change
+      if: steps.filter.outputs.version == 'true'
+      run: |
+        VERSION=$(cat releasing/version/VERSION)
+        cd workspaces/backend
+        make docker-buildx REGISTRY=${REGISTRY} NAME=${NAME} TAG=${VERSION}

--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -1,5 +1,11 @@
+GIT_COMMIT     := $(shell git rev-parse HEAD)
+GIT_TREE_STATE := $(shell test -n "`git status --porcelain`" && echo "-dirty" || echo "")
+
 # Image URL to use all building/pushing image targets
-IMG ?= nb-backend:latest
+REGISTRY ?= ghcr.io/kubeflow/notebooks
+NAME ?= workspaces-backend
+TAG ?= sha-$(GIT_COMMIT)$(GIT_TREE_STATE)
+IMG ?= $(REGISTRY)/$(NAME):$(TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 


### PR DESCRIPTION
related: #607 

This commit adds a GHA workflow to support publishing a container image for the `workspaces/backend` component as well as some updates to the `Makefile` to establish reasonable (but overridable) defaults.

Key behavior:
- Publishes backend image on any workspaces/ directory change
- Builds image with commit SHA tags by default
    - "release" images with use the tag as defined by the `VERSION` file
    - a `-dirty` suffix is added to the tag if the codebase is not `porcelain`
    - no `latest` tag is ever produced on images
- Uses  `ghcr.io/kubeflow/notebooks` registry with configurable naming

example image name from "random" commit:
- `ghcr.io/kubeflow/notebooks/workspaces-backend:sha-3fa851ab3173942dbaa1a609468e7f9eadf5f4e4`

example image name from release:
- `ghcr.io/kubeflow/notebooks/workspaces-backend:v2.0.0`
