### PR TITLE
Migrate shared test/quality related workflows from kubeflow/kubeflow to notebooks-v1 branch

### DIFF
--- a/.github/workflows/common_frontend_tests.yaml
+++ b/.github/workflows/common_frontend_tests.yaml
@@ -1,0 +1,53 @@
+name: Common Frontend Tests
+on:
+  pull_request:
+    paths:
+      - components/crud-web-apps/common/frontend/kubeflow-common-lib/**
+      - releasing/version/VERSION
+    branches:
+      - v*-branch
+      - migrate_test/common
+
+jobs:
+  frontend-format-lint-check:
+    name: Check code format and lint
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+
+      - name: Check frontend code formatting
+        run: |
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run format:check
+
+      - name: Check frontend code linting
+        run: |
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run lint-check
+
+  frontend-unit-tests:
+    runs-on: ubuntu-22.04
+    name: Unit tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node version to 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+
+      - name: Install Kubeflow common library dependecies
+        run: |
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run test:prod

--- a/.github/workflows/python_lint.yaml
+++ b/.github/workflows/python_lint.yaml
@@ -1,0 +1,27 @@
+name: Python Linting
+
+on:
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - "**.py"
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-22.04
+    name: Check
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python environment 3.8
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+        with:
+          exclude: "docs"


### PR DESCRIPTION
feat: migrate shared test/quality related workflows from kubeflow/kubeflow to notebooks-v1 branch

Enables python_lint.yaml and common_frontend_tests.yaml tests to run in kubeflow/notebooks repository.

Solves issue: #593 