### PR TITLE
chore: add paulovmr as approver for frontend

### DIFF
--- a/workspaces/frontend/OWNERS
+++ b/workspaces/frontend/OWNERS
@@ -3,5 +3,4 @@ labels:
   - area/v2
 approvers:
   - ederign
-reviewers:
   - paulovmr


### PR DESCRIPTION
Paulo has been doing excellent work on the frontend for Notebooks 2.0, as shown by his extensive [contributions](https://github.com/kubeflow/notebooks/commits/notebooks-v2?author=paulovmr). 

His consistent, high-quality contributions and deep understanding of the frontend make him a strong candidate to become a maintainer/approver for the Notebooks 2.0 frontend. I’m happy to propose him for this role formally.