### PR TITLE
ci: add example notebooks server images publish workflows

### DIFF
--- a/.github/workflows/example_notebook_servers_publish.yaml
+++ b/.github/workflows/example_notebook_servers_publish.yaml
@@ -1,0 +1,119 @@
+name: Build & Publish Notebook Servers
+on:
+  push:
+    branches:
+      - main
+      - notebooks-v1
+      - v*-branch
+    paths:
+      - components/example-notebook-servers/**
+      - releasing/version/VERSION
+
+jobs:
+  base_images:
+    name: Build & Push - Base
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        base
+
+  codeserver_images:
+    name: Build & Push - Code Server
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ base_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        codeserver
+        codeserver-python
+
+  rstudio_images:
+    name: Build & Push - RStudio
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ base_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        rstudio
+        rstudio-tidyverse
+
+  jupyter_images:
+    name: Build & Push - Jupyter
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ base_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        jupyter
+
+  jupyter_scipy_images:
+    name: Build & Push - Jupyter (SciPy)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        jupyter-scipy
+
+  jupyter_pytorch_images:
+    name: Build & Push - Jupyter (PyTorch)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        jupyter-pytorch
+        jupyter-pytorch-full
+
+  jupyter_pytorch_cuda_images:
+    name: Build & Push - Jupyter (PyTorch + CUDA)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      # TODO: support 'linux/arm64' for PyTorch CUDA images
+      build_arch: linux/amd64
+      image_folders: |
+        jupyter-pytorch-cuda
+        jupyter-pytorch-cuda-full
+
+  jupyter_pytorch_gaudi_images:
+    name: Build & Push - Jupyter (PyTorch + Gaudi)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64
+      image_folders: |
+        jupyter-pytorch-gaudi
+        jupyter-pytorch-gaudi-full
+
+  jupyter_tensorflow_images:
+    name: Build & Push - Jupyter (TensorFlow)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64,linux/arm64
+      image_folders: |
+        jupyter-tensorflow
+        jupyter-tensorflow-full
+
+  jupyter_tensorflow_cuda_images:
+    name: Build & Push - Jupyter (TensorFlow + CUDA)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      # TODO: support 'linux/arm64' for TensorFlow CUDA images
+      build_arch: linux/amd64
+      image_folders: |
+        jupyter-tensorflow-cuda
+        jupyter-tensorflow-cuda-full

--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -1,0 +1,61 @@
+name: Build & Publish Notebook Servers (TEMPLATE)
+on:
+  workflow_call:
+    inputs:
+      build_arch:
+        required: true
+        description: "architectures to build for, comma separated"
+        type: string
+      image_folders:
+        required: true
+        description: "image folders to build, ordered by dependency, whitespace separated"
+        type: string
+
+env:
+  REGISTRY: ghcr.io/kubeflow/kubeflow/notebook-servers
+  CACHE_IMAGE: ghcr.io/${{ github.repository }}/notebook-servers/build-cache
+
+jobs:
+  build_and_push_images:
+    name: Build & Push Images
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            version:
+              - 'releasing/version/VERSION'
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Notebook Server images
+        env:
+          ARCH: ${{ inputs.build_arch }}
+          IMAGE_FOLDERS: ${{ inputs.image_folders }}
+          SHOULD_TAG_LATEST: ${{ github.ref == 'refs/heads/notebooks-v1' }}
+          SHOULD_TAG_VERSION: ${{ steps.filter.outputs.version == 'true' }}
+        run: |
+          if [[ "$SHOULD_TAG_LATEST" = "true" ]]; then
+            export ALSO_TAG_LATEST=1
+          fi
+          if [[ "$SHOULD_TAG_VERSION" = "true" ]]; then
+              export ALSO_TAG_VERSION=$(cat releasing/version/VERSION)
+          fi
+          cd components/example-notebook-servers/
+          make docker-build-push-multi-arch


### PR DESCRIPTION
**Summary**
This PR migrates the GitHub Actions workflow responsible for building and publishing all notebook server example images from the kubeflow/kubeflow repository to the kubeflow/notebooks repository.

Related: #614 

**Verification**
Successfully built and published all notebook server example images:
https://github.com/liavweiss?tab=packages&repo_name=notebooks
<img width="2507" height="1065" alt="image" src="https://github.com/user-attachments/assets/4fa79fcd-1da8-493c-bce7-69c7690cde2b" />

I kept `ghcr.io/kubeflow/kubeflow/notebook-servers` as it is, after this comment https://github.com/kubeflow/notebooks/issues/585#issuecomment-3362374417


