### PR TITLE
fix: controller make deploy set image

### DIFF
--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -138,7 +138,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image workspaces-controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy

--- a/workspaces/controller/config/manager/manager.yaml
+++ b/workspaces/controller/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
           - --metrics-bind-address=0
-        image: workspaces-controller:latest
+        image: workspaces-controller
         imagePullPolicy: IfNotPresent
         name: manager
         securityContext:


### PR DESCRIPTION
related: #596

When refactoring the controller manifests - a change was missed to ensure the `make deploy` command - which calls `kustomize edit set image ...` properly replaces the `workspaces-controller` `image` reference.

In line with `backend` and `frontend` - the manifest should initially just specify `workspaces-controller` as the image name - and that _exact value_ should then be used in `kustomize edit set image`.

This commit brings that alignment into place.