### PR TITLE
feat: Migrate kubeflow/kubeflow vwa_docker_publish.yaml

### DIFF
--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -1,0 +1,59 @@
+name: Build & Publish VWA Docker image
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+      - notebooks-v1
+    paths:
+      - components/crud-web-apps/volumes/**
+      - components/crud-web-apps/common/**
+      - releasing/version/VERSION
+
+env:
+  IMG: ghcr.io/kubeflow/notebooks/volumes-web-app
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
+
+jobs:
+  push_to_registry:
+    name: Build & Push image to GHCR
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: components/crud-web-apps/volumes
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          version:
+            - 'releasing/version/VERSION'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push multi-arch docker image
+      run: make docker-build-push-multi-arch
+
+    - name: Build and push latest multi-arch docker image
+      if: github.ref == 'refs/heads/notebooks-v1'
+      run: TAG=latest make docker-build-push-multi-arch
+
+    - name: Build and push multi-arch docker image on Version change
+      id: version
+      if: steps.filter.outputs.version == 'true'
+      run: TAG=$(cat ../../../releasing/version/VERSION) make docker-build-push-multi-arch

--- a/components/crud-web-apps/volumes/Makefile
+++ b/components/crud-web-apps/volumes/Makefile
@@ -1,4 +1,4 @@
-IMG ?= ghcr.io/kubeflow/kubeflow/volumes-web-app
+IMG ?= ghcr.io/kubeflow/notebooks/volumes-web-app
 TAG ?= $(shell git describe --tags --always --dirty)
 ARCH ?= linux/amd64
 


### PR DESCRIPTION
Migrate Volumes Web App Docker publish workflow from kubeflow/kubeflow
to kubeflow/notebooks. 
Address issue #618 
## Key Changes

### Migration
- Move workflow to notebooks repo structure
- Update image registry to ghcr.io/kubeflow/notebooks/jupyter-web-app

Successful build: [https://github.com/yehudit1987/notebooks/actions/runs/18835077691/job/53734120838](url)

<img width="1601" height="752" alt="Screenshot from 2025-10-27 11-51-39" src="https://github.com/user-attachments/assets/81de1b06-9d8d-4692-b51e-0974cd5e24c8" />

