### PR TITLE
ci: Migrate kubeflow/kubeflow tb_controller_docker_publish.yaml GitHub Action to kubeflow/notebooks - notebooks-v1 branch

### DIFF
--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -1,0 +1,64 @@
+name: Build & Publish Tensorboard Controller Docker image
+on:
+  push:
+    branches:
+      - main
+      - notebooks-v1
+      - v*-branch
+    paths:
+      - components/tensorboard-controller/**
+      - releasing/version/VERSION
+
+env:
+  IMG: ghcr.io/kubeflow/notebooks/tensorboard-controller
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
+
+jobs:
+  push_to_registry:
+    name: Build & Push image to GHCR
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: components/tensorboard-controller
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          version:
+            - 'releasing/version/VERSION'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push multi-arch docker image
+      run: |
+        make docker-build-push-multi-arch
+
+    - name: Build and push latest multi-arch docker image
+      if: github.ref == 'refs/heads/notebooks-v1'
+      run: |
+        export TAG=latest
+        make docker-build-push-multi-arch
+
+    - name: Build and push multi-arch docker image on Version change
+      id: version
+      if: steps.filter.outputs.version == 'true'
+      run: |
+        export TAG=$(cat ../../releasing/version/VERSION)
+        make docker-build-push-multi-arch

--- a/components/tensorboard-controller/Makefile
+++ b/components/tensorboard-controller/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/kubeflow/kubeflow/tensorboard-controller
+IMG ?= ghcr.io/kubeflow/notebooks/tensorboard-controller
 TAG ?= $(shell git describe --tags --always --dirty)
 ARCH ?= linux/amd64
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)


### PR DESCRIPTION
Summary
This PR migrates the GitHub Actions workflow responsible for building and publishing notebooks/tensorboard-controller images from the kubeflow/kubeflow repository to the kubeflow/notebooks repository.

Related: #620 

Verification
Successful job action:
<img width="2504" height="1168" alt="image" src="https://github.com/user-attachments/assets/53d5e8e4-82f6-46a4-9ad7-023c3ed40c2e" />

Successfully built and published notebooks/tensorboard-controller images
<img width="1702" height="940" alt="image" src="https://github.com/user-attachments/assets/80829227-f736-4017-b2f1-18a0e36ac934" />

** The test was on my ghcr.io registry `ghcr.io/liavweiss/notebooks/tensorboard-controller/`
