### PR TITLE
ci: add NBC docker publish workflow

### DIFF
--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -1,0 +1,67 @@
+name: Build & Publish Notebook Controller Docker image
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+      - notebooks-v1
+    paths:
+      - components/notebook-controller/**
+      - components/common/**
+      - releasing/version/VERSION
+
+env:
+  IMG: ghcr.io/kubeflow/notebooks/notebook-controller
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
+
+jobs:
+  push_to_registry:
+    name: Build & Push Docker image to GHCR
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          version:
+            - 'releasing/version/VERSION'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push multi-arch docker image
+      run: |
+        cd components/notebook-controller
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
+
+    - name: Build and push latest multi-arch docker image
+      if: github.ref == 'refs/heads/notebooks-v1'
+      run: |
+        export TAG=latest
+        cd components/notebook-controller
+        make docker-build-push-multi-arch
+
+    - name: Build and push multi-arch docker image on Version change
+      id: version
+      if: steps.filter.outputs.version == 'true'
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/notebook-controller
+        make docker-build-push-multi-arch

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/kubeflow/kubeflow/notebook-controller
+IMG ?= ghcr.io/kubeflow/notebooks/notebook-controller
 TAG ?= $(shell git describe --tags --always --dirty)
 ARCH ?= linux/amd64
 


### PR DESCRIPTION
This PR migrates the GitHub Actions workflow responsible for building and publishing the NBC (notebooks conroller) Docker image from the kubeflow/kubeflow repository to the kubeflow/notebooks repository.

related #615 

Successfully built and published a test image:
[GitHub Action Run](https://github.com/noalimoy/notebooks/actions/runs/18555590053)

<img width="1157" height="595" alt="{BB0300E2-7681-4923-8B40-1B1E09D58196}" src="https://github.com/user-attachments/assets/dcab4540-1032-4ef4-b867-8ee0a26a6dac" />