### PR TITLE
fix: enable secret support in backend

### DIFF
--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -769,9 +769,7 @@ var _ = Describe("Workspaces Handler", func() {
 				},
 			}
 			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Data).To(Equal(expected))
-
-			// TODO: Verify secrets once #240 merged
-			// Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(BeEmpty())
+			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(BeEmpty())
 
 			By("creating an HTTP request to delete the Workspace")
 			path = strings.Replace(WorkspacesByNamePath, ":"+NamespacePathParam, namespaceNameCrud, 1)
@@ -808,8 +806,7 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		// TODO: Change to It when #240 merged
-		XIt("should create a workspace with secrets", func() {
+		It("should create a workspace with secrets", func() {
 			// Create a workspace with secrets
 			workspace := &models.WorkspaceCreate{
 				Name: "test-workspace",
@@ -865,11 +862,14 @@ var _ = Describe("Workspaces Handler", func() {
 			createdWorkspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: workspace.Name, Namespace: namespaceNameCrud}, createdWorkspace)).To(Succeed())
 
-			// TODO: Verify the secrets are properly set once #240 merged
-			// Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(HaveLen(1))
-			// Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets[0].SecretName).To(Equal("test-secret"))
-			// Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets[0].MountPath).To(Equal("/secrets"))
-			// Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets[0].DefaultMode).To(Equal(int32(0o644)))
+			expected := []kubefloworgv1beta1.PodSecretMount{
+				{
+					SecretName:  workspace.PodTemplate.Volumes.Secrets[0].SecretName,
+					MountPath:   workspace.PodTemplate.Volumes.Secrets[0].MountPath,
+					DefaultMode: workspace.PodTemplate.Volumes.Secrets[0].DefaultMode,
+				},
+			}
+			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(Equal(expected))
 		})
 
 		// TODO: test when fail to create a Workspace when:

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -144,15 +144,14 @@ func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, workspaceCrea
 	}
 
 	// get secrets from workspace model
-	// TODO: uncomment this once #240 is merged
-	// secretMounts := make([]kubefloworgv1beta1.PodSecretMount, len(workspaceCreate.PodTemplate.Volumes.Secrets))
-	// for i, secret := range workspaceCreate.PodTemplate.Volumes.Secrets {
-	// 	secretMounts[i] = kubefloworgv1beta1.PodSecretMount{
-	// 		SecretName:  secret.SecretName,
-	// 		MountPath:   secret.MountPath,
-	// 		DefaultMode: secret.DefaultMode,
-	// 	}
-	// }
+	secretMounts := make([]kubefloworgv1beta1.PodSecretMount, len(workspaceCreate.PodTemplate.Volumes.Secrets))
+	for i, secret := range workspaceCreate.PodTemplate.Volumes.Secrets {
+		secretMounts[i] = kubefloworgv1beta1.PodSecretMount{
+			SecretName:  secret.SecretName,
+			MountPath:   secret.MountPath,
+			DefaultMode: secret.DefaultMode,
+		}
+	}
 
 	// define workspace object from model
 	workspaceName := workspaceCreate.Name
@@ -172,9 +171,9 @@ func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, workspaceCrea
 					Annotations: workspaceCreate.PodTemplate.PodMetadata.Annotations,
 				},
 				Volumes: kubefloworgv1beta1.WorkspacePodVolumes{
-					Home: workspaceCreate.PodTemplate.Volumes.Home,
-					Data: dataVolumeMounts,
-					// Secrets: secretMounts,
+					Home:    workspaceCreate.PodTemplate.Volumes.Home,
+					Data:    dataVolumeMounts,
+					Secrets: secretMounts,
 				},
 				Options: kubefloworgv1beta1.WorkspacePodOptions{
 					ImageConfig: workspaceCreate.PodTemplate.Options.ImageConfig,


### PR DESCRIPTION
closes: #239 

Originally, PR #240 was not merged and we wanted to at least enable the frontend to have successful API interactions with secrets - so PR #331 was raised and merged that handled the API request but did **NOT** pass the `Secrets` data into the controller.

Now that #240 has merged - this commit uncomments all the code to enable full end to end behavior.