### PR TITLE
feat: Add update-manifests-images script for automated release preparation

### DIFF
--- a/releasing/README.md
+++ b/releasing/README.md
@@ -1,0 +1,122 @@
+# Releasing
+
+This folder contains scripts and instructions for releasing images and manifests
+for the components of this repository.
+
+## Release Process
+
+The Notebooks Working Group release process follows the Kubeflow [release timeline](https://github.com/kubeflow/community/blob/master/releases/handbook.md#timeline) 
+and the [release versioning policy](https://github.com/kubeflow/community/blob/master/releases/handbook.md#versioning-policy),
+as defined in the [Kubeflow release handbook](https://github.com/kubeflow/community/blob/master/releases/handbook.md).
+
+## Steps for releasing
+
+### Prepare (MINOR RELEASE)
+
+1. Create a new release branch from `notebooks-v1`:
+
+```sh
+RELEASE_BRANCH="v1.10-branch"
+git checkout -b $RELEASE_BRANCH origin/notebooks-v1
+# OR: git checkout -b $RELEASE_BRANCH upstream/notebooks-v1
+
+# push the release branch to the upstream repository
+git push origin $RELEASE_BRANCH
+# OR: git push upstream $RELEASE_BRANCH
+```
+
+### Prepare (PATCH RELEASE)
+
+1. Check out the release branch for the version you are releasing:
+
+```sh
+RELEASE_BRANCH="v1.10-branch"
+git checkout $RELEASE_BRANCH
+```
+
+2. Cherry-pick the changes you want to include in the patch release (if they have not been added via a PR):
+
+```sh
+# cherry-pick the commit
+# NOTE: you could also use an IDE to make this easier
+git cherry-pick HASH_OF_COMMIT
+
+# push the changes to the release branch
+git push origin $RELEASE_BRANCH
+# OR: git push upstream $RELEASE_BRANCH
+```
+
+### Create Release (ALL RELEASES)
+
+1. Update the image tags in the manifests to the new version:
+
+```sh
+VERSION="v1.10.0-rc.0" # for a release candidate
+# VERSION="v1.10.0" # for a final release
+
+# Ensure required Python dependency is installed
+pip install ruamel.yaml
+
+# Run the release script
+python3 releasing/update-manifests-images.py $VERSION
+```
+
+2. Bump version in `releasing/version/VERSION` file:
+
+```sh
+echo "$VERSION" > releasing/version/VERSION
+```
+
+3. Create a PR into the release branch with the changes from steps 1 and 2:
+
+    - The PR should be titled `chore: Release vX.X.X-rc.X` or `chore: Release vX.X.X`.
+    - This is to trigger the GitHub Actions tests, and ensure a release is possible.
+    - The only changes should be the image tags in the manifests and the VERSION bump.
+    - __WARNING:__ the "example notebook servers" builds are not triggered on PRs (they need to push to a registry as they `FROM` each other).
+      Check the last commit which updated `components/example-notebook-servers/**` and ensure that its build succeeded.
+      If not, STOP, and fix the build for the "example notebook servers" before merging the release PR.
+    - Once the tests pass, merge the PR (this will trigger the release builds).
+
+4. Create a tag in the release branch:
+
+```sh
+# check out the release branch at the commit that was merged
+git checkout $RELEASE_BRANCH
+# NOTE: make sure you are at the current HEAD of the release branch
+#       which should be the commit from the PR merged in the previous step
+
+# create the tag
+# NOTE: this is a signed tag, so you must have set up your GPG key
+git tag -s "$VERSION" -m "$VERSION"
+
+# verify the tag signature
+git verify-tag "$VERSION"
+
+# push the tag
+git push origin "$VERSION"
+# OR: git push upstream "$VERSION"
+```
+
+5. Create a new release on GitHub:
+
+    - Go to the [releases page](https://github.com/kubeflow/notebooks/releases).
+    - Click `"Draft a new release"`.
+    - Enter the tag you just created in the `"Choose a tag"` box.
+    - If this is an RC release:
+       - check the `"This is a pre-release"` box
+       - make a basic description of the release but don't include the full release notes.
+    - If this is a final release:
+       - Set the `"Previous tag"` to the previous non-RC release and click `"Generate release notes"`.
+       - Try and format the release notes like the previous releases.
+    - Click `"Publish release"`.
+
+## Components Updated by Script
+
+The `update-manifests-images.py` script updates image tags for the following Notebooks v1 components:
+
+- **Jupyter Web App** - `components/crud-web-apps/jupyter/manifests/base/kustomization.yaml`
+- **Tensorboards Web App** - `components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml`
+- **Volumes Web App** - `components/crud-web-apps/volumes/manifests/base/kustomization.yaml`
+- **Notebook Controller** - `components/notebook-controller/config/base/kustomization.yaml`
+- **PVC Viewer Controller** - `components/pvcviewer-controller/config/base/kustomization.yaml`
+- **Tensorboard Controller** - `components/tensorboard-controller/config/base/kustomization.yaml`

--- a/releasing/update-manifests-images.py
+++ b/releasing/update-manifests-images.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import sys
+import ruamel.yaml
+
+log = logging.getLogger(__name__)
+
+
+class YAMLEmitterNoVersionDirective(ruamel.yaml.emitter.Emitter):
+    def write_version_directive(self, version_text):
+        pass
+
+    def expect_document_start(self, first=False):
+        if not isinstance(self.event, ruamel.yaml.events.DocumentStartEvent):
+            return super().expect_document_start(first=first)
+        version = self.event.version
+        self.event.version = None
+        ret = super().expect_document_start(first=first)
+        self.event.version = version
+        return ret
+
+
+class YAML(ruamel.yaml.YAML):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.version = (1, 1)
+        self.Emitter = YAMLEmitterNoVersionDirective
+        self.preserve_quotes = True
+
+
+yaml = YAML()
+
+applications = [
+    {
+        "name": "Jupyter Web App",
+        "kustomization": (
+            "components/crud-web-apps/jupyter/"
+            "manifests/base/kustomization.yaml"
+        ),
+        "images": [
+            {
+                "name": "ghcr.io/kubeflow/notebooks/jupyter-web-app",
+                "newName": "ghcr.io/kubeflow/notebooks/jupyter-web-app",
+            },
+        ],
+    },
+    {
+        "name": "Tensorboards Web App",
+        "kustomization": (
+            "components/crud-web-apps/tensorboards/"
+            "manifests/base/kustomization.yaml"
+        ),
+        "images": [
+            {
+                "name": "ghcr.io/kubeflow/kubeflow/tensorboards-web-app",
+                "newName": "ghcr.io/kubeflow/kubeflow/tensorboards-web-app",
+            },
+        ],
+    },
+    {
+        "name": "Volumes Web App",
+        "kustomization": (
+            "components/crud-web-apps/volumes/"
+            "manifests/base/kustomization.yaml"
+        ),
+        "images": [
+            {
+                "name": "ghcr.io/kubeflow/kubeflow/volumes-web-app",
+                "newName": "ghcr.io/kubeflow/kubeflow/volumes-web-app",
+            },
+        ],
+    },
+    {
+        "name": "Notebook Controller",
+        "kustomization": (
+            "components/notebook-controller/"
+            "config/base/kustomization.yaml"
+        ),
+        "images": [
+            {
+                "name": "ghcr.io/kubeflow/kubeflow/notebook-controller",
+                "newName": "ghcr.io/kubeflow/kubeflow/notebook-controller",
+            },
+        ],
+    },
+    {
+        "name": "PVC Viewer Controller",
+        "kustomization": (
+            "components/pvcviewer-controller/"
+            "config/base/kustomization.yaml"
+        ),
+        "images": [
+            {
+                "name": "ghcr.io/kubeflow/kubeflow/pvcviewer-controller",
+                "newName": "ghcr.io/kubeflow/kubeflow/pvcviewer-controller",
+            },
+        ],
+    },
+    {
+        "name": "Tensorboard Controller",
+        "kustomization": (
+            "components/tensorboard-controller/"
+            "config/base/kustomization.yaml"
+        ),
+        "images": [
+            {
+                "name": "ghcr.io/kubeflow/kubeflow/tensorboard-controller",
+                "newName": "ghcr.io/kubeflow/kubeflow/tensorboard-controller",
+            },
+        ],
+    },
+]
+
+
+def update_manifests_images(applications, tag):
+    for application in applications:
+        log.info("Updating manifests for app %s", application["name"])
+        with open(application["kustomization"], "r") as file:
+            kustomize = yaml.load(file)
+
+        images = kustomize.get("images", [])
+        for target_image in application["images"]:
+            found = False
+            for image in images:
+                if image["name"] == target_image["name"]:
+                    image["newName"] = target_image["newName"]
+                    image["newTag"] = tag
+                    found = True
+                    break
+            if not found:
+                images.append({
+                    "name": target_image["name"],
+                    "newName": target_image["newName"],
+                    "newTag": tag})
+        kustomize["images"] = images
+
+        with open(application["kustomization"], "w") as file:
+            yaml.dump(kustomize, file)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser("Update image tags in manifests.")
+    parser.add_argument("tag", type=str, help="Image tag to use.")
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args()
+    update_manifests_images(applications, args.tag)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR adds automation for updating image tags in manifest files during the release process for Notebooks v1 components.

Closes #657

## Changes

- Added `releasing/update-manifests-images.py` - Python script to update image tags
- Added `releasing/README.md` - Complete release process documentation

## Components Updated by Script

The script updates `newTag` fields for these 6 Notebooks v1 components:

1. **Jupyter Web App** - `components/crud-web-apps/jupyter/manifests/base/kustomization.yaml`
2. **Tensorboards Web App** - `components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml`
3. **Volumes Web App** - `components/crud-web-apps/volumes/manifests/base/kustomization.yaml`
4. **Notebook Controller** - `components/notebook-controller/config/base/kustomization.yaml`
5. **PVC Viewer Controller** - `components/pvcviewer-controller/config/base/kustomization.yaml`
6. **Tensorboard Controller** - `components/tensorboard-controller/config/base/kustomization.yaml`

## Usage Example

```bash
# Install dependency
pip install ruamel.yaml

# Update all manifests to a specific version
python3 releasing/update-manifests-images.py v1.9.0

# Update VERSION file
echo "v1.9.0" > releasing/version/VERSION
```

## Testing

Tested locally with test tags - script successfully updates all 6 component manifests while preserving YAML formatting.