### PR TITLE
chore: add `area/v2` label to OWNERS in workflows folder

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,4 +1,5 @@
 labels:
   - area/ci
+  - area/v2
 approvers:
   - andyatmiami


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

chore: add `area/v2` label to OWNERS in workflows folder
This sets up the label to be assigned to notebook-v2 work.