### PR TITLE
feat: workspace labels

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionListDescription,
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
+import { Label, LabelGroup } from '@patternfly/react-core/dist/esm/components/Label';
 import { WorkspacesWorkspace } from '~/generated/data-contracts';
 
 type WorkspaceDetailsOverviewProps = {
@@ -29,9 +30,13 @@ export const WorkspaceDetailsOverview: React.FunctionComponent<WorkspaceDetailsO
     <DescriptionListGroup>
       <DescriptionListTerm>Labels</DescriptionListTerm>
       <DescriptionListDescription>
-        {Object.entries(workspace.podTemplate.podMetadata.labels)
-          .map(([key, value]) => `${key}=${value}`)
-          .join(', ')}
+        <LabelGroup>
+          {Object.entries(workspace.podTemplate.podMetadata.labels).map(([key, value]) => (
+            <Label key={key} isCompact>
+              {key}={value}
+            </Label>
+          ))}
+        </LabelGroup>
       </DescriptionListDescription>
     </DescriptionListGroup>
     <Divider />


### PR DESCRIPTION
 closes: #232 

Before
<img width="392" height="321" alt="Screenshot 2025-10-14 at 10 20 30 AM" src="https://github.com/user-attachments/assets/acc91d0c-9485-4f16-8492-3e3ca589362f" />

After
<img width="407" height="282" alt="Screenshot 2025-10-24 at 6 03 51 PM" src="https://github.com/user-attachments/assets/22477b99-76e0-47d8-947d-1c8a118b280d" />
