### PR TITLE
feat: add labels to notebook statefulset

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -366,6 +366,10 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"statefulset":   instance.Name,
+				"notebook-name": instance.Name,
+			},
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

What:

* Add labels to statefulset created by notebook controller
* Same labels as for the pods are used

Why:

* It's best practice to have labels on all resources
* Be able to exclude statefulset from certain cluster policies (kyverno, opa) by label 