### PR TITLE
ci: improved multi-arch build times

### DIFF
--- a/workspaces/backend/Dockerfile
+++ b/workspaces/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use the golang image to build the application
-FROM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -8,7 +8,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY backend/go.mod backend/go.sum ./
 
-# Copy controller directory 
+# Copy controller directory
 COPY controller /workspace/controller
 
 # Rewrite the go.mod to update the replace directive and download dependencies

--- a/workspaces/controller/Dockerfile
+++ b/workspaces/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/workspaces/frontend/Dockerfile
+++ b/workspaces/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # ---------- Builder stage ----------
-FROM node:20-slim AS builder
+FROM --platform=$BUILDPLATFORM node:20-slim AS builder
 
 # Set working directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
⚠️: _NO GH ISSUE_

Modified the Dockerfiles for `backend`, `controller`, and `frontend` to use the `--platform=$BUILDPLATFORM` directive, enabling better compatibility for multi-platform builds.

This change limits the exposure to emulation required to produce the image - ensuring the "base layer" is always built on the same architecture as the build system.

This is safe:
- for `controller` and `backend` because `go` build already supports cross-compilation
- for `frontend` because the `webpack` config simply outputs HTML/JS files to be including in the final stage of the build.

