### PR TITLE
chore: upgrade to go 1.24 for pvcviewer-controller

### DIFF
--- a/.github/workflows/pvcviewer_controller_unit_test.yaml
+++ b/.github/workflows/pvcviewer_controller_unit_test.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.22.2"
+        go-version-file: 'components/pvcviewer-controller/go.mod'
         check-latest: true
 
     - name: Run unit tests

--- a/components/pvcviewer-controller/Dockerfile
+++ b/components/pvcviewer-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_VERSION=1.22.2
+ARG GOLANG_VERSION=1.24
 FROM golang:${GOLANG_VERSION} as builder
 
 WORKDIR /workspace
@@ -16,7 +16,7 @@ COPY pvcviewer-controller/api/ api/
 COPY pvcviewer-controller/controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/components/pvcviewer-controller/go.mod
+++ b/components/pvcviewer-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/components/pvcviewer-controller
 
-go 1.22.2
+go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
[TASK] Upgrade Go to 1.24 - pvcviewer-controller component #723

- Update CI workflow pvcviewer_controller_unit_test.yaml to use go-version 1.24
- Update go.mod to go 1.24
- Update Dockerfile GOLANG_VERSION to 1.24