### PR TITLE
fix: cancel button variant and expandable spacing

### DIFF
--- a/workspaces/frontend/src/app/App.tsx
+++ b/workspaces/frontend/src/app/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
               <NamespaceContextProvider>
                 <Page
                   mainContainerId="primary-app-container"
+                  isContentFilled
                   masthead={
                     isStandalone ? (
                       <NavBar

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -184,32 +184,40 @@ export const WorkspaceKindForm: React.FC = () => {
           </Stack>
         )}
         {mode === 'edit' && (
-          <>
-            <WorkspaceKindFormProperties
-              mode={mode}
-              properties={data.properties}
-              updateField={(properties) => setData('properties', properties)}
-            />
-            <WorkspaceKindFormImage
-              mode={mode}
-              imageConfig={data.imageConfig}
-              updateImageConfig={(imageInput) => {
-                setData('imageConfig', imageInput);
-              }}
-            />
-            <WorkspaceKindFormPodConfig
-              podConfig={data.podConfig}
-              updatePodConfig={(podConfig) => {
-                setData('podConfig', podConfig);
-              }}
-            />
-            <WorkspaceKindFormPodTemplate
-              podTemplate={data.podTemplate}
-              updatePodTemplate={(podTemplate) => {
-                setData('podTemplate', podTemplate);
-              }}
-            />
-          </>
+          <Stack hasGutter>
+            <StackItem>
+              <WorkspaceKindFormProperties
+                mode={mode}
+                properties={data.properties}
+                updateField={(properties) => setData('properties', properties)}
+              />
+            </StackItem>
+            <StackItem>
+              <WorkspaceKindFormImage
+                mode={mode}
+                imageConfig={data.imageConfig}
+                updateImageConfig={(imageInput) => {
+                  setData('imageConfig', imageInput);
+                }}
+              />
+            </StackItem>
+            <StackItem>
+              <WorkspaceKindFormPodConfig
+                podConfig={data.podConfig}
+                updatePodConfig={(podConfig) => {
+                  setData('podConfig', podConfig);
+                }}
+              />
+            </StackItem>
+            <StackItem>
+              <WorkspaceKindFormPodTemplate
+                podTemplate={data.podTemplate}
+                updatePodTemplate={(podTemplate) => {
+                  setData('podTemplate', podTemplate);
+                }}
+              />
+            </StackItem>
+          </Stack>
         )}
       </PageSection>
       <PageSection isFilled={false} stickyOnBreakpoint={{ default: 'bottom' }}>
@@ -226,7 +234,7 @@ export const WorkspaceKindForm: React.FC = () => {
             </Button>
           </FlexItem>
           <FlexItem>
-            <Button variant="link" isInline onClick={cancel}>
+            <Button variant="link" onClick={cancel}>
               Cancel
             </Button>
           </FlexItem>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/fileUpload/WorkspaceKindFileUpload.tsx
@@ -86,7 +86,7 @@ export const WorkspaceKindFileUpload: React.FC<WorkspaceKindFileUploadProps> = (
   }, []);
 
   return (
-    <Content style={{ height: '100%' }}>
+    <Content>
       <FileUpload
         className="workspacekind-file-upload"
         id="text-file-simple"

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImage.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImage.tsx
@@ -105,66 +105,64 @@ export const WorkspaceKindFormImage: React.FC<WorkspaceKindFormImageProps> = ({
 
   return (
     <Content>
-      <div className="pf-u-mb-0">
-        <ExpandableSection
-          toggleText="Workspace Images"
-          onToggle={() => setIsExpanded((prev) => !prev)}
-          isExpanded={isExpanded}
-          isIndented
-        >
-          {imageConfig.values.length === 0 && (
-            <EmptyState titleText="Start by creating an image" headingLevel="h4" icon={CubesIcon}>
-              <EmptyStateBody>Add an image configuration to your Workspace Kind</EmptyStateBody>
-              <EmptyStateFooter>
-                <EmptyStateActions>{addImageBtn}</EmptyStateActions>
-              </EmptyStateFooter>
-            </EmptyState>
-          )}
-          {imageConfig.values.length > 0 && (
-            <div>
-              <WorkspaceKindFormPaginatedTable
-                ariaLabel="Images table"
-                rows={imageConfig.values}
-                defaultId={defaultId}
-                setDefaultId={(id) => {
-                  updateImageConfig({ ...imageConfig, default: id });
-                  setDefaultId(id);
-                }}
-                handleEdit={handleEdit}
-                openDeleteModal={openDeleteModal}
-              />
-              {addImageBtn}
-            </div>
-          )}
-          <WorkspaceKindFormImageModal
-            isOpen={isModalOpen}
-            onClose={clearForm}
-            onSubmit={handleAddOrEditSubmit}
-            editIndex={editIndex}
-            image={image}
-            setImage={setImage}
-            mode={mode}
-          />
-          <Modal
-            isOpen={isDeleteModalOpen}
-            onClose={() => setIsDeleteModalOpen(false)}
-            variant={ModalVariant.small}
-          >
-            <ModalHeader
-              title="Remove Image?"
-              description="This image will be removed from the workspace kind."
+      <ExpandableSection
+        toggleText="Workspace Images"
+        onToggle={() => setIsExpanded((prev) => !prev)}
+        isExpanded={isExpanded}
+        isIndented
+      >
+        {imageConfig.values.length === 0 && (
+          <EmptyState titleText="Start by creating an image" headingLevel="h4" icon={CubesIcon}>
+            <EmptyStateBody>Add an image configuration to your Workspace Kind</EmptyStateBody>
+            <EmptyStateFooter>
+              <EmptyStateActions>{addImageBtn}</EmptyStateActions>
+            </EmptyStateFooter>
+          </EmptyState>
+        )}
+        {imageConfig.values.length > 0 && (
+          <div>
+            <WorkspaceKindFormPaginatedTable
+              ariaLabel="Images table"
+              rows={imageConfig.values}
+              defaultId={defaultId}
+              setDefaultId={(id) => {
+                updateImageConfig({ ...imageConfig, default: id });
+                setDefaultId(id);
+              }}
+              handleEdit={handleEdit}
+              openDeleteModal={openDeleteModal}
             />
-            <ModalFooter>
-              <Button key="remove" variant="danger" onClick={handleDelete}>
-                Remove
-              </Button>
-              <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
-                Cancel
-              </Button>
-            </ModalFooter>
-          </Modal>
-        </ExpandableSection>
-      </div>
+            {addImageBtn}
+          </div>
+        )}
+        <WorkspaceKindFormImageModal
+          isOpen={isModalOpen}
+          onClose={clearForm}
+          onSubmit={handleAddOrEditSubmit}
+          editIndex={editIndex}
+          image={image}
+          setImage={setImage}
+          mode={mode}
+        />
+        <Modal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          variant={ModalVariant.small}
+        >
+          <ModalHeader
+            title="Remove Image?"
+            description="This image will be removed from the workspace kind."
+          />
+          <ModalFooter>
+            <Button key="remove" variant="danger" onClick={handleDelete}>
+              Remove
+            </Button>
+            <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </ExpandableSection>
     </Content>
   );
 };

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
@@ -101,71 +101,69 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
 
   return (
     <Content>
-      <div className="pf-u-mb-0">
-        <ExpandableSection
-          toggleText="Pod Configurations"
-          onToggle={() => setIsExpanded((prev) => !prev)}
-          isExpanded={isExpanded}
-          isIndented
-        >
-          {podConfig.values.length === 0 && (
-            <EmptyState
-              titleText="Start by creating a pod configuration"
-              headingLevel="h4"
-              icon={CubesIcon}
-            >
-              <EmptyStateBody>
-                Configure specifications for pods and containers in your Workspace Kind
-              </EmptyStateBody>
-              <EmptyStateFooter>
-                <EmptyStateActions>{addConfigBtn}</EmptyStateActions>
-              </EmptyStateFooter>
-            </EmptyState>
-          )}
-          {podConfig.values.length > 0 && (
-            <>
-              <WorkspaceKindFormPaginatedTable
-                ariaLabel="Pod Configs Table"
-                rows={podConfig.values}
-                defaultId={defaultId}
-                setDefaultId={(id) => {
-                  updatePodConfig({ ...podConfig, default: id });
-                  setDefaultId(id);
-                }}
-                handleEdit={handleEdit}
-                openDeleteModal={openDeleteModal}
-              />
-              {addConfigBtn}
-            </>
-          )}
-          <WorkspaceKindFormPodConfigModal
-            isOpen={isModalOpen}
-            onClose={clearForm}
-            onSubmit={handleAddOrEditSubmit}
-            editIndex={editIndex}
-            currConfig={currConfig}
-            setCurrConfig={setCurrConfig}
-          />
-          <Modal
-            isOpen={isDeleteModalOpen}
-            onClose={() => setIsDeleteModalOpen(false)}
-            variant={ModalVariant.small}
+      <ExpandableSection
+        toggleText="Pod Configurations"
+        onToggle={() => setIsExpanded((prev) => !prev)}
+        isExpanded={isExpanded}
+        isIndented
+      >
+        {podConfig.values.length === 0 && (
+          <EmptyState
+            titleText="Start by creating a pod configuration"
+            headingLevel="h4"
+            icon={CubesIcon}
           >
-            <ModalHeader
-              title="Remove Pod Config?"
-              description="The pod config will be removed from the workspace kind."
+            <EmptyStateBody>
+              Configure specifications for pods and containers in your Workspace Kind
+            </EmptyStateBody>
+            <EmptyStateFooter>
+              <EmptyStateActions>{addConfigBtn}</EmptyStateActions>
+            </EmptyStateFooter>
+          </EmptyState>
+        )}
+        {podConfig.values.length > 0 && (
+          <>
+            <WorkspaceKindFormPaginatedTable
+              ariaLabel="Pod Configs Table"
+              rows={podConfig.values}
+              defaultId={defaultId}
+              setDefaultId={(id) => {
+                updatePodConfig({ ...podConfig, default: id });
+                setDefaultId(id);
+              }}
+              handleEdit={handleEdit}
+              openDeleteModal={openDeleteModal}
             />
-            <ModalFooter>
-              <Button key="remove" variant="danger" onClick={handleDelete}>
-                Remove
-              </Button>
-              <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
-                Cancel
-              </Button>
-            </ModalFooter>
-          </Modal>
-        </ExpandableSection>
-      </div>
+            {addConfigBtn}
+          </>
+        )}
+        <WorkspaceKindFormPodConfigModal
+          isOpen={isModalOpen}
+          onClose={clearForm}
+          onSubmit={handleAddOrEditSubmit}
+          editIndex={editIndex}
+          currConfig={currConfig}
+          setCurrConfig={setCurrConfig}
+        />
+        <Modal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          variant={ModalVariant.small}
+        >
+          <ModalHeader
+            title="Remove Pod Config?"
+            description="The pod config will be removed from the workspace kind."
+          />
+          <ModalFooter>
+            <Button key="remove" variant="danger" onClick={handleDelete}>
+              Remove
+            </Button>
+            <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </ExpandableSection>
     </Content>
   );
 };

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
@@ -53,144 +53,142 @@ export const WorkspaceKindFormPodTemplate: React.FC<WorkspaceKindFormPodTemplate
   );
 
   return (
-    <div className="pf-u-mb-0">
-      <ExpandableSection
-        toggleText="Pod Lifecycle & Customization"
-        onToggle={() => setIsExpanded((prev) => !prev)}
-        isExpanded={isExpanded}
-        isIndented
-      >
-        <Form>
+    <ExpandableSection
+      toggleText="Pod Lifecycle & Customization"
+      onToggle={() => setIsExpanded((prev) => !prev)}
+      isExpanded={isExpanded}
+      isIndented
+    >
+      <Form>
+        <FormFieldGroup
+          aria-label="Pod Metadata"
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'Pod Metadata',
+                id: 'workspace-kind-pod-metadata',
+              }}
+              titleDescription={
+                <HelperText>
+                  Edit mutable metadata of all pods created with this Workspace Kind.
+                </HelperText>
+              }
+            />
+          }
+        >
+          <EditableLabels
+            rows={Object.entries(podTemplate.podMetadata.labels).map((entry) => ({
+              key: entry[0],
+              value: entry[1],
+            }))}
+            setRows={(newLabels) => {
+              updatePodTemplate({
+                ...podTemplate,
+                podMetadata: {
+                  ...podTemplate.podMetadata,
+                  labels: newLabels.reduce((acc: { [k: string]: string }, { key, value }) => {
+                    acc[key] = value;
+                    return acc;
+                  }, {}),
+                },
+              });
+            }}
+          />
+          <EditableLabels
+            title="Annotations"
+            description="Use annotations to attach arbitrary non-identifying metadata to Kubernetes objects."
+            buttonLabel="Annotation"
+            rows={Object.entries(podTemplate.podMetadata.annotations).map((entry) => ({
+              key: entry[0],
+              value: entry[1],
+            }))}
+            setRows={(newAnnotations) => {
+              updatePodTemplate({
+                ...podTemplate,
+                podMetadata: {
+                  ...podTemplate.podMetadata,
+                  annotations: newAnnotations.reduce(
+                    (acc: { [k: string]: string }, { key, value }) => {
+                      acc[key] = value;
+                      return acc;
+                    },
+                    {},
+                  ),
+                },
+              });
+            }}
+          />
+        </FormFieldGroup>
+        {/* podTemplate.culling is currently not developed in the backend */}
+        {podTemplate.culling && (
           <FormFieldGroup
-            aria-label="Pod Metadata"
+            aria-label="Pod Culling"
             header={
               <FormFieldGroupHeader
                 titleText={{
-                  text: 'Pod Metadata',
-                  id: 'workspace-kind-pod-metadata',
+                  text: 'Pod Culling',
+                  id: 'workspace-kind-pod-culling',
                 }}
                 titleDescription={
                   <HelperText>
-                    Edit mutable metadata of all pods created with this Workspace Kind.
+                    <HelperTextItem variant="warning">
+                      Warning: Only for JupyterLab deployments
+                    </HelperTextItem>
+                    Culling scales the number of pods in a Workspace to zero based on its last
+                    activity by polling Jupyter&apos;s status endpoint.
                   </HelperText>
                 }
               />
             }
           >
-            <EditableLabels
-              rows={Object.entries(podTemplate.podMetadata.labels).map((entry) => ({
-                key: entry[0],
-                value: entry[1],
-              }))}
-              setRows={(newLabels) => {
-                updatePodTemplate({
-                  ...podTemplate,
-                  podMetadata: {
-                    ...podTemplate.podMetadata,
-                    labels: newLabels.reduce((acc: { [k: string]: string }, { key, value }) => {
-                      acc[key] = value;
-                      return acc;
-                    }, {}),
-                  },
-                });
-              }}
-            />
-            <EditableLabels
-              title="Annotations"
-              description="Use annotations to attach arbitrary non-identifying metadata to Kubernetes objects."
-              buttonLabel="Annotation"
-              rows={Object.entries(podTemplate.podMetadata.annotations).map((entry) => ({
-                key: entry[0],
-                value: entry[1],
-              }))}
-              setRows={(newAnnotations) => {
-                updatePodTemplate({
-                  ...podTemplate,
-                  podMetadata: {
-                    ...podTemplate.podMetadata,
-                    annotations: newAnnotations.reduce(
-                      (acc: { [k: string]: string }, { key, value }) => {
-                        acc[key] = value;
-                        return acc;
-                      },
-                      {},
-                    ),
-                  },
-                });
-              }}
-            />
-          </FormFieldGroup>
-          {/* podTemplate.culling is currently not developed in the backend */}
-          {podTemplate.culling && (
-            <FormFieldGroup
-              aria-label="Pod Culling"
-              header={
-                <FormFieldGroupHeader
-                  titleText={{
-                    text: 'Pod Culling',
-                    id: 'workspace-kind-pod-culling',
-                  }}
-                  titleDescription={
-                    <HelperText>
-                      <HelperTextItem variant="warning">
-                        Warning: Only for JupyterLab deployments
-                      </HelperTextItem>
-                      Culling scales the number of pods in a Workspace to zero based on its last
-                      activity by polling Jupyter&apos;s status endpoint.
-                    </HelperText>
-                  }
-                />
-              }
-            >
-              <FormGroup>
-                <Switch
-                  isChecked={podTemplate.culling.enabled || false}
-                  label="Enabled"
-                  aria-label="pod template enable culling controlled check"
-                  onChange={(_, checked) => toggleCullingEnabled(checked)}
-                  id="workspace-kind-pod-template-culling-enabled"
-                  name="culling-enabled"
-                />
-              </FormGroup>
-              <FormGroup label="Max Inactive Period">
-                <ResourceInputWrapper
-                  value={String(podTemplate.culling.maxInactiveSeconds || 86400)}
-                  type="time"
-                  onChange={(value) =>
-                    podTemplate.culling &&
-                    updatePodTemplate({
-                      ...podTemplate,
-                      culling: {
-                        ...podTemplate.culling,
-                        maxInactiveSeconds: Number(value),
-                      },
-                    })
-                  }
-                  step={1}
-                  aria-label="max inactive period input"
-                  isDisabled={!podTemplate.culling.enabled}
-                />
-              </FormGroup>
-            </FormFieldGroup>
-          )}
-          <FormFieldGroup
-            aria-label="Additional Volumes"
-            header={
-              <FormFieldGroupHeader
-                titleText={{
-                  text: 'Additional Volumes',
-                  id: 'workspace-kind-extra-volume',
-                }}
-                titleDescription={
-                  <HelperText>Configure the paths to mount additional PVCs.</HelperText>
-                }
+            <FormGroup>
+              <Switch
+                isChecked={podTemplate.culling.enabled || false}
+                label="Enabled"
+                aria-label="pod template enable culling controlled check"
+                onChange={(_, checked) => toggleCullingEnabled(checked)}
+                id="workspace-kind-pod-template-culling-enabled"
+                name="culling-enabled"
               />
-            }
-          >
-            <WorkspaceFormPropertiesVolumes volumes={volumes} setVolumes={handleVolumes} />
+            </FormGroup>
+            <FormGroup label="Max Inactive Period">
+              <ResourceInputWrapper
+                value={String(podTemplate.culling.maxInactiveSeconds || 86400)}
+                type="time"
+                onChange={(value) =>
+                  podTemplate.culling &&
+                  updatePodTemplate({
+                    ...podTemplate,
+                    culling: {
+                      ...podTemplate.culling,
+                      maxInactiveSeconds: Number(value),
+                    },
+                  })
+                }
+                step={1}
+                aria-label="max inactive period input"
+                isDisabled={!podTemplate.culling.enabled}
+              />
+            </FormGroup>
           </FormFieldGroup>
-        </Form>
-      </ExpandableSection>
-    </div>
+        )}
+        <FormFieldGroup
+          aria-label="Additional Volumes"
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'Additional Volumes',
+                id: 'workspace-kind-extra-volume',
+              }}
+              titleDescription={
+                <HelperText>Configure the paths to mount additional PVCs.</HelperText>
+              }
+            />
+          }
+        >
+          <WorkspaceFormPropertiesVolumes volumes={volumes} setVolumes={handleVolumes} />
+        </FormFieldGroup>
+      </Form>
+    </ExpandableSection>
   );
 };

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindFormProperties.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindFormProperties.tsx
@@ -21,108 +21,104 @@ export const WorkspaceKindFormProperties: React.FC<WorkspaceKindFormPropertiesPr
   const [isExpanded, setIsExpanded] = useState(false);
   return (
     <Content>
-      <div className="pf-u-mb-0">
-        <ExpandableSection
-          toggleText="Properties"
-          onToggle={() => setIsExpanded((prev) => !prev)}
-          isExpanded={isExpanded}
-          isIndented
-        >
-          <Form>
-            <FormGroup label="Workspace Kind Name" isRequired fieldId="workspace-kind-name">
-              <TextInput
-                isRequired
-                type="text"
-                value={properties.displayName}
-                onChange={(_, value) => updateField({ ...properties, displayName: value })}
-                id="workspace-kind-name"
-              />
-            </FormGroup>
-            <FormGroup label="Description" fieldId="workspace-kind-description">
-              <TextInput
-                type="text"
-                value={properties.description}
-                onChange={(_, value) => updateField({ ...properties, description: value })}
-                id="workspace-kind-description"
-              />
-            </FormGroup>
-            {mode === 'edit' && (
-              <FormGroup
-                style={{ marginTop: 'var(--mui-spacing-16px)' }}
-                fieldId="workspace-kind-deprecated"
-              >
-                <Switch
-                  aria-label="workspace-kind-deprecated"
-                  isChecked={properties.deprecated}
-                  label={
-                    <div>
-                      <div>Deprecated</div>
-                      <HelperText>
-                        Flag this workspace kind as deprecated and optionally set a deprecation
-                        message
-                      </HelperText>
-                    </div>
-                  }
-                  onChange={() =>
-                    updateField({ ...properties, deprecated: !properties.deprecated })
-                  }
-                  id="workspace-kind-deprecated"
-                  name="workspace-kind-deprecated-switch"
-                />
-              </FormGroup>
-            )}
-            {mode === 'edit' && properties.deprecated && (
-              <FormGroup>
-                <TextInput
-                  isDisabled={!properties.deprecated}
-                  type="text"
-                  label="Deprecation message"
-                  value={properties.deprecationMessage}
-                  placeholder="Deprecation message"
-                  onChange={(_, value) => updateField({ ...properties, deprecationMessage: value })}
-                  id="workspace-kind-deprecated-msg"
-                />
-              </FormGroup>
-            )}
+      <ExpandableSection
+        toggleText="Properties"
+        onToggle={() => setIsExpanded((prev) => !prev)}
+        isExpanded={isExpanded}
+        isIndented
+      >
+        <Form>
+          <FormGroup label="Workspace Kind Name" isRequired fieldId="workspace-kind-name">
+            <TextInput
+              isRequired
+              type="text"
+              value={properties.displayName}
+              onChange={(_, value) => updateField({ ...properties, displayName: value })}
+              id="workspace-kind-name"
+            />
+          </FormGroup>
+          <FormGroup label="Description" fieldId="workspace-kind-description">
+            <TextInput
+              type="text"
+              value={properties.description}
+              onChange={(_, value) => updateField({ ...properties, description: value })}
+              id="workspace-kind-description"
+            />
+          </FormGroup>
+          {mode === 'edit' && (
             <FormGroup
-              fieldId="workspace-kind-hidden"
               style={{ marginTop: 'var(--mui-spacing-16px)' }}
+              fieldId="workspace-kind-deprecated"
             >
               <Switch
-                isChecked={properties.hidden}
-                onChange={() => updateField({ ...properties, hidden: !properties.hidden })}
-                id="workspace-kind-hidden"
-                name="workspace-kind-hidden-switch"
-                aria-label="workspace-kind-hidden"
+                aria-label="workspace-kind-deprecated"
+                isChecked={properties.deprecated}
                 label={
                   <div>
-                    <div>Hidden</div>
-                    <HelperText>Hide this workspace kind from users</HelperText>
+                    <div>Deprecated</div>
+                    <HelperText>
+                      Flag this workspace kind as deprecated and optionally set a deprecation
+                      message
+                    </HelperText>
                   </div>
                 }
+                onChange={() => updateField({ ...properties, deprecated: !properties.deprecated })}
+                id="workspace-kind-deprecated"
+                name="workspace-kind-deprecated-switch"
               />
             </FormGroup>
-            <FormGroup label="Icon URL" isRequired fieldId="workspace-kind-icon">
+          )}
+          {mode === 'edit' && properties.deprecated && (
+            <FormGroup>
               <TextInput
-                isRequired
+                isDisabled={!properties.deprecated}
                 type="text"
-                value={properties.icon.url}
-                onChange={(_, value) => updateField({ ...properties, icon: { url: value } })}
-                id="workspace-kind-icon"
+                label="Deprecation message"
+                value={properties.deprecationMessage}
+                placeholder="Deprecation message"
+                onChange={(_, value) => updateField({ ...properties, deprecationMessage: value })}
+                id="workspace-kind-deprecated-msg"
               />
             </FormGroup>
-            <FormGroup label="Logo URL" isRequired fieldId="workspace-kind-logo">
-              <TextInput
-                isRequired
-                type="text"
-                value={properties.logo.url}
-                onChange={(_, value) => updateField({ ...properties, logo: { url: value } })}
-                id="workspace-kind-logo"
-              />
-            </FormGroup>
-          </Form>
-        </ExpandableSection>
-      </div>
+          )}
+          <FormGroup
+            fieldId="workspace-kind-hidden"
+            style={{ marginTop: 'var(--mui-spacing-16px)' }}
+          >
+            <Switch
+              isChecked={properties.hidden}
+              onChange={() => updateField({ ...properties, hidden: !properties.hidden })}
+              id="workspace-kind-hidden"
+              name="workspace-kind-hidden-switch"
+              aria-label="workspace-kind-hidden"
+              label={
+                <div>
+                  <div>Hidden</div>
+                  <HelperText>Hide this workspace kind from users</HelperText>
+                </div>
+              }
+            />
+          </FormGroup>
+          <FormGroup label="Icon URL" isRequired fieldId="workspace-kind-icon">
+            <TextInput
+              isRequired
+              type="text"
+              value={properties.icon.url}
+              onChange={(_, value) => updateField({ ...properties, icon: { url: value } })}
+              id="workspace-kind-icon"
+            />
+          </FormGroup>
+          <FormGroup label="Logo URL" isRequired fieldId="workspace-kind-logo">
+            <TextInput
+              isRequired
+              type="text"
+              value={properties.logo.url}
+              onChange={(_, value) => updateField({ ...properties, logo: { url: value } })}
+              id="workspace-kind-logo"
+            />
+          </FormGroup>
+        </Form>
+      </ExpandableSection>
     </Content>
   );
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -410,7 +410,7 @@ const WorkspaceForm: React.FC = () => {
                     )}
                   </FlexItem>
                   <FlexItem>
-                    <Button variant="link" isInline onClick={cancel}>
+                    <Button variant="link" onClick={cancel}>
                       Cancel
                     </Button>
                   </FlexItem>


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Closes #716 #717

**What changed:**

1) `isInline` prop removed on "Cancel" buttons - no longer showing underline. (Applies "link" variant):

<img width="1157" height="418" alt="Screenshot 2025-11-10 at 1 33 13 PM" src="https://github.com/user-attachments/assets/85cbce41-ca6f-431c-94a0-10dd88c67265" />
<img width="1155" height="633" alt="Screenshot 2025-11-10 at 1 33 21 PM" src="https://github.com/user-attachments/assets/b650220c-2ed4-436a-aad7-756185396c04" />

<img width="1187" height="444" alt="Screenshot 2025-11-10 at 3 34 10 PM" src="https://github.com/user-attachments/assets/cc526d97-8a77-4415-9634-0fffd75494b0" />

<br />
<br />
2) Added `Stack` layout with gutter to resolve spacing issue:

Before:
<img width="303" height="141" alt="Screenshot 2025-11-10 at 3 12 57 PM" src="https://github.com/user-attachments/assets/b84c8e53-896e-4ab6-abb1-f3e41e1762b6" />

After:
<img width="1189" height="259" alt="Screenshot 2025-11-10 at 1 59 22 PM" src="https://github.com/user-attachments/assets/63b233c6-8993-44ce-9925-c2b4971a7980" />

cc @tobiastal, per your feedback
