### PR TITLE
feat: add pagination to workspace kind table

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/workspaceKinds.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/workspaceKinds.ts
@@ -133,6 +133,39 @@ class WorkspaceKinds {
   assertEmptyStateVisible() {
     this.findEmptyState().should('exist');
   }
+
+  findPagination() {
+    return cy.findByTestId('workspace-kinds-pagination');
+  }
+
+  goToNextPage() {
+    return this.findPagination().find('button[aria-label*="Go to next page"]').click();
+  }
+
+  goToPreviousPage() {
+    return this.findPagination().find('button[aria-label*="Go to previous page"]').click();
+  }
+
+  selectPerPage(perPage: number) {
+    this.findPagination().find('.pf-v6-c-menu-toggle').first().click({ force: true });
+    return cy.get('.pf-v6-c-menu__item').contains(`${perPage}`).click({ force: true });
+  }
+
+  assertPaginationExists() {
+    this.findPagination().should('exist');
+  }
+
+  assertPrevNextDisabled() {
+    this.findPagination().find('button[aria-label*="Go to previous page"]').should('be.disabled');
+    this.findPagination().find('button[aria-label*="Go to next page"]').should('be.disabled');
+  }
+
+  assertPaginationRange(args: { firstItem: number; lastItem: number; totalItems: number }) {
+    this.findPagination().should(
+      'contain.text',
+      `${args.firstItem} - ${args.lastItem} of ${args.totalItems}`,
+    );
+  }
 }
 
 class WorkspaceKindDetailsDrawer {


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This pull request adds pagination support to the Workspace Kinds page, including both frontend implementation and test coverage. Pagination controls now allow users to navigate between pages, change the number of items per page, and see accurate item ranges. The test suite has been expanded to cover various pagination scenarios, including filtering and empty states.

<img width="1100" height="667" alt="image" src="https://github.com/user-attachments/assets/cfe2fca3-14a3-43ea-947d-babeff2514a9" />
