### PR TITLE
chore: fix envtest file permissions + backend k8s version

### DIFF
--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -9,6 +9,10 @@ IMG ?= $(REGISTRY)/$(NAME):$(TAG)
 ARCH ?= linux/arm64/v8,linux/amd64,linux/ppc64le
 
 
+# The version of Kubernetes to use for envtest.
+# If updating, also update the version referenced in `BinaryAssetsDirectory` of suite_test.go files.
+ENVTEST_K8S_VERSION = 1.31.0
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -56,7 +60,12 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	$(eval KUBEBUILDER_ASSETS := $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path))
+	## For unknown reasons, setup-envtest changes the binary permissions to 0555,
+	## this makes it difficult to clean up the downloaded binaries later.
+	## https://github.com/kubernetes-sigs/controller-runtime/blob/v0.22.4/tools/setup-envtest/store/store.go#L191
+	chmod -R u+w $(LOCALBIN)
+	KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS} go test ./... -coverprofile cover.out
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -9,7 +9,8 @@ IMG ?= $(REGISTRY)/$(NAME):$(TAG)
 ARCH ?= linux/arm64/v8,linux/amd64,linux/ppc64le
 
 
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# The version of Kubernetes to use for envtest.
+# If updating, also update the version referenced in `BinaryAssetsDirectory` of suite_test.go files.
 ENVTEST_K8S_VERSION = 1.31.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -64,7 +65,12 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	$(eval KUBEBUILDER_ASSETS := $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path))
+	## For unknown reasons, setup-envtest changes the binary permissions to 0555,
+	## this makes it difficult to clean up the downloaded binaries later.
+	## https://github.com/kubernetes-sigs/controller-runtime/blob/v0.22.4/tools/setup-envtest/store/store.go#L191
+	chmod -R u+w $(LOCALBIN)
+	KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS} go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # Prometheus, CertManager, and Istio are installed by default; skip with:


### PR DESCRIPTION
This PR does two things:

1. Fixes the fact that we forgot to set `ENVTEST_K8S_VERSION` in the backend makefile, meaning we were always testing with the latest version of Kubernetes in unit tests, rather than a specific one.
2. Introduces a workaround for the fact that `setup-envtest` [sets the file permissions of the binaries it downloads to `0555`](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.22.4/tools/setup-envtest/store/store.go#L191) (not writable by owner), this was making it painful to delete the binaries and confusing contributors. 