### PR TITLE
fix: update jsonpath-plus to 10.3.0 across CRUD web apps (Security v1.11) 

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
@@ -26,6 +26,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.12.0",
         "@fortawesome/free-solid-svg-icons": "^5.12.0",
         "date-fns": "1.29.0",
+        "jsonpath-plus": "10.3.0",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
         "material-icons": "^0.7.7",
@@ -3526,6 +3527,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.16.3.tgz",
@@ -3563,6 +3588,16 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@kubernetes/client-node/node_modules/jsonpath-plus": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/@kubernetes/client-node/node_modules/tslib": {
       "version": "1.14.1",
@@ -11330,6 +11365,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -11424,13 +11468,21 @@
       "license": "MIT"
     },
     "node_modules/jsonpath-plus": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
-      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
-      "dev": true,
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsprim": {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -47,7 +47,8 @@
     "monaco-editor": "^0.33.0",
     "rxjs": "~7.4.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4",
+    "jsonpath-plus": "10.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~14.2.13",

--- a/components/crud-web-apps/jupyter/frontend/package-lock.json
+++ b/components/crud-web-apps/jupyter/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@kubernetes/client-node": "^0.16.3",
         "date-fns": "1.29.0",
         "js-yaml": "^4.0.0",
+        "jsonpath-plus": "10.3.0",
         "lodash": "^4.17.21",
         "lodash-es": "~4.17.21",
         "material-icons": "^0.7.7",
@@ -3863,6 +3864,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.16.3.tgz",
@@ -3898,6 +3923,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "license": "MIT"
+    },
+    "node_modules/@kubernetes/client-node/node_modules/jsonpath-plus": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/@kubernetes/client-node/node_modules/tslib": {
       "version": "1.14.1",
@@ -11467,6 +11501,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -11556,12 +11599,21 @@
       "license": "MIT"
     },
     "node_modules/jsonpath-plus": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
-      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsprim": {

--- a/components/crud-web-apps/jupyter/frontend/package.json
+++ b/components/crud-web-apps/jupyter/frontend/package.json
@@ -53,7 +53,8 @@
     "raw-loader": "^4.0.0",
     "rxjs": "~7.4.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4",
+    "jsonpath-plus": "10.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.2.13",

--- a/components/crud-web-apps/tensorboards/frontend/package-lock.json
+++ b/components/crud-web-apps/tensorboards/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.12.0",
         "@kubernetes/client-node": "^0.16.3",
         "date-fns": "1.29.0",
+        "jsonpath-plus": "10.3.0",
         "lodash": "^4.17.21",
         "lodash-es": "~4.17.21",
         "material-icons": "^0.7.7",
@@ -3814,6 +3815,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.16.3.tgz",
@@ -3847,6 +3872,15 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
+    "node_modules/@kubernetes/client-node/node_modules/jsonpath-plus": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/@kubernetes/client-node/node_modules/tslib": {
       "version": "1.14.1",
@@ -11240,6 +11274,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -11322,11 +11365,21 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
-      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsprim": {

--- a/components/crud-web-apps/tensorboards/frontend/package.json
+++ b/components/crud-web-apps/tensorboards/frontend/package.json
@@ -50,7 +50,8 @@
     "rxjs": "~7.4.0",
     "tough-cookie": "4.1.3",
     "tslib": "^2.0.0",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4",
+    "jsonpath-plus": "10.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.2.13",

--- a/components/crud-web-apps/volumes/frontend/package-lock.json
+++ b/components/crud-web-apps/volumes/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.12.0",
         "@kubernetes/client-node": "^0.16.3",
         "date-fns": "1.29.0",
+        "jsonpath-plus": "10.3.0",
         "lodash": "^4.17.21",
         "lodash-es": "~4.17.21",
         "material-icons": "^0.7.7",
@@ -3926,6 +3927,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.16.3.tgz",
@@ -3961,6 +3986,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "license": "MIT"
+    },
+    "node_modules/@kubernetes/client-node/node_modules/jsonpath-plus": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/@kubernetes/client-node/node_modules/tslib": {
       "version": "1.14.1",
@@ -11917,6 +11951,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -12009,12 +12052,21 @@
       "license": "MIT"
     },
     "node_modules/jsonpath-plus": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
-      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsprim": {

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -50,7 +50,8 @@
     "raw-loader": "^4.0.0",
     "rxjs": "~7.4.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4",
+    "jsonpath-plus": "10.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.2.13",


### PR DESCRIPTION
This PR updates jsonpath-plus to version 10.3.0 across all CRUD web app frontends:

- common/frontend
- jupyter/frontend
- tensorboards/frontend
- volumes/frontend

This addresses:
- CVE-2024-21534
- CVE-2025-1302

Steps performed:
- Updated package.json and package-lock.json
- Ran npm install in each frontend directory
- Verified lint and build succeed

Signed-off-by: Uyen Truong <uyenthutruong09@gmail.com>