### PR TITLE
chore: update oauth2 to v0.27.0 in pvcviewer-controller

### DIFF
--- a/components/pvcviewer-controller/go.mod
+++ b/components/pvcviewer-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/components/pvcviewer-controller
 
-go 1.24.0
+go 1.24.12
 
 require (
 	github.com/go-logr/logr v1.4.1
@@ -49,7 +49,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/oauth2 v0.19.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/components/pvcviewer-controller/go.sum
+++ b/components/pvcviewer-controller/go.sum
@@ -110,8 +110,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
-golang.org/x/oauth2 v0.19.0 h1:9+E/EZBCbTLNrbN35fHv/a/d/mOBatymz1zbtQrXpIg=
-golang.org/x/oauth2 v0.19.0/go.mod h1:vYi7skDa1x015PmRRYZ7+s1cWyPgrPiSYRe4rnsexc8=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Description

Update `golang.org/x/oauth2` dependency from `v0.19.0` to `v0.27.0` in the pvcviewer-controller component.

### Security Fix

This update resolves **CVE-2025-22868** - a security vulnerability in the oauth2 package.

The oauth2 package is an indirect dependency used by `k8s.io/client-go` for GCP authentication. No code changes required as there is no direct usage in pvcviewer-controller.

## Changes

- Updated `golang.org/x/oauth2` from `v0.19.0` → `v0.27.0`
- Ran `go mod tidy` to update `go.sum`

## Testing Performed

-  `go mod tidy` - completed successfully
-  `go vet ./...` - no issues found
-  `make manager` - controller builds cleanly
- `Unit tests`: passed
- `Integration tests`: passed
- `Multi-arch tests`: passed

## Related Issue

Closes #782