### PR TITLE
fix: frontend Dockerfile.dev live_reload

### DIFF
--- a/workspaces/frontend/Dockerfile.dev
+++ b/workspaces/frontend/Dockerfile.dev
@@ -9,12 +9,14 @@
 
 FROM node:20-slim
 
-# Set working directory
+# Create app directory with correct ownership, then switch to non-root user
+RUN mkdir /app && chown 1000:1000 /app
+USER 1000:1000
 WORKDIR /app
 
 # Copy package files first for better layer caching
-# This allows npm install to be cached when only source files change
-COPY package*.json ./
+# chmod=777 allows Tilt live_update to write files without CAP_CHOWN
+COPY --chmod=777 package*.json ./
 
 # Install dependencies
 # Using npm ci for reproducible builds, but falling back to npm install
@@ -22,7 +24,7 @@ COPY package*.json ./
 RUN npm ci || npm install
 
 # Copy source code and configuration
-COPY . ./
+COPY --chmod=777 . ./
 
 # Expose the webpack dev server port (matches production deployment)
 EXPOSE 8080


### PR DESCRIPTION
Tilt's `live_reload` functionality - in addition to the `frontend` deployment's `securityContext` that drops ALL capabilities - requires a little more open permissions than we would ever configure on a production `Dockerfile`

- Create app directory with correct ownership and switch to non-root user
- Adjust permissions for package files and source code to support Tilt live updates

While generally a `chmod 777` is a pretty "scary" thing to do - as Tilt is really used solely for local development - I opted for this wide open permission to maximum chance of no issues _ever_ arising in the future.

This was not properly being handled on the initial PR that introduced Tilt as called out by @thesuperzapper in his review:
- https://github.com/kubeflow/notebooks/pull/744