### PR TITLE
chore: Increase memory for frontend container while running the Tilt dev env

### DIFF
--- a/developing/Tiltfile
+++ b/developing/Tiltfile
@@ -183,11 +183,11 @@ if enable_frontend:
                     container["resources"] = {
                         "limits": {
                             "cpu": "2",
-                            "memory": "2Gi",
+                            "memory": "4Gi",
                         },
                         "requests": {
                             "cpu": "500m",
-                            "memory": "1Gi",
+                            "memory": "3Gi",
                         },
                     }
 


### PR DESCRIPTION
In the Tilt development environment, sometimes the frontend container keeps restarting when it exceeds the memory limit (OOMKilled). This PR increases the memory limit and request for it.