### PR TITLE
ci: add go mod tidy check

### DIFF
--- a/.github/workflows/ws-backend-test.yml
+++ b/.github/workflows/ws-backend-test.yml
@@ -32,6 +32,11 @@ jobs:
           check-latest: true
           cache-dependency-path: workspaces/backend/go.sum
 
+      - ## NOTE: this will cause the porcelain check to fail if go.mod/go.sum are out of date
+        name: Go Mod Tidy
+        working-directory: workspaces/backend
+        run: go mod tidy
+
       - name: Lint
         working-directory: workspaces/backend
         run: make lint

--- a/.github/workflows/ws-controller-test.yml
+++ b/.github/workflows/ws-controller-test.yml
@@ -32,6 +32,11 @@ jobs:
           check-latest: true
           cache-dependency-path: workspaces/controller/go.sum
 
+      - ## NOTE: this will cause the porcelain check to fail if go.mod/go.sum are out of date
+        name: Go Mod Tidy
+        working-directory: workspaces/controller
+        run: go mod tidy
+
       - name: Lint
         working-directory: workspaces/controller
         run: make lint

--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/workspaces/backend
 
-go 1.22.0
+go 1.22.12
 
 replace github.com/kubeflow/notebooks/workspaces/controller => ../controller
 

--- a/workspaces/controller/go.mod
+++ b/workspaces/controller/go.mod
@@ -1,12 +1,13 @@
 module github.com/kubeflow/notebooks/workspaces/controller
 
-go 1.22.0
+go 1.22.12
 
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	golang.org/x/time v0.3.0
+	google.golang.org/protobuf v1.34.2
 	istio.io/api v1.22.8
 	istio.io/client-go v1.22.8
 	k8s.io/api v0.31.0
@@ -62,7 +63,6 @@ require (
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
To avoid people forgetting to update the `go.mod` and `go.sum` files, this PR ensures we run `go mod tidy` in our PR tests, which should cause the porcelain check to fail as there would be uncommitted changes.

This PR also fixes the fact that someone forgot to run `go mod tidy` on the controller, and also updates to the latest version of Go 1.22 in our go mod files.