### PR TITLE
feat: support namespaceFilter on GET /workspacekinds

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/custom_resource.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/custom_resource.py
@@ -1,3 +1,6 @@
+import re
+from flask import request
+from kubeflow.kubeflow.crud_backend import errors
 from .. import authz
 from . import custom_api
 
@@ -17,12 +20,36 @@ def delete_custom_rsrc(group, version, kind, name, namespace,
 
 
 def list_custom_rsrc(group, version, kind, namespace):
-    authz.ensure_authorized("list", group, version, kind, namespace)
-    return custom_api.list_namespaced_custom_object(group, version, namespace,
-                                                    kind)
+    namespace_filter = request.args.get("namespaceFilter")
+
+    if namespace_filter:
+        if (
+            len(namespace_filter) > 63
+            or not re.match(r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', namespace_filter)
+        ):
+            raise errors.UnprocessableEntity(
+                "Invalid Kubernetes namespace name for namespaceFilter"
+            )
+    
+        if kind.lower() == "workspacekinds":
+            authz.ensure_authorized(
+                "create",
+                "kubeflow.org",
+                "v1beta1",
+                "workspaces",
+                namespace_filter,
+            )
+        else:
+            authz.ensure_authorized("list", group, version, kind, namespace)
+    else:
+        authz.ensure_authorized("list", group, version, kind, namespace)
+    
+    return custom_api.list_namespaced_custom_object(
+        group, version, namespace, kind
+    )
 
 
-def get_custom_rsrc(group, version, kind, namespace, name):
+def get_custom_rsrc(group, version, kind, namespace, name): 
     authz.ensure_authorized("get", group, version, kind, namespace)
 
     return custom_api.get_namespaced_custom_object(group, version, namespace,


### PR DESCRIPTION
Adds optional namespaceFilter support to GET /workspacekinds.

When provided, the backend validates the namespace and performs
authorization using a CREATE Workspace check in that namespace.
Existing behavior is preserved when the parameter is absent.

Fixes kubeflow/notebooks#677