### PR TITLE
feat: support namespaceFilter on GET /workspacekinds

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -40,8 +40,9 @@ const (
 	MediaTypeJson = "application/json"
 	MediaTypeYaml = "application/yaml"
 
-	NamespacePathParam    = "namespace"
-	ResourceNamePathParam = "name"
+	NamespacePathParam        = "namespace"
+	ResourceNamePathParam     = "name"
+	NamespaceFilterQueryParam = "namespaceFilter"
 
 	// healthcheck
 	HealthCheckPath = PathPrefix + "/healthcheck"

--- a/workspaces/backend/api/response_errors.go
+++ b/workspaces/backend/api/response_errors.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	errMsgPathParamsInvalid    = "path parameters were invalid"
+	errMsgQueryParamsInvalid   = "query parameters were invalid"
 	errMsgRequestBodyInvalid   = "request body was invalid"
 	errMsgKubernetesValidation = "kubernetes validation error (note: .cause.validation_errors[] correspond to the internal k8s object, not the request body)"
 	errMsgKubernetesConflict   = "kubernetes conflict error (see .cause.conflict_cause[] for details)"

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -105,19 +105,19 @@ func (a *App) GetWorkspaceKindHandler(w http.ResponseWriter, r *http.Request, ps
 //	@ID				listWorkspaceKinds
 //	@Accept			json
 //	@Produce		json
-//	@Param			namespaceFilter	query	string	false	"Namespace used for workspace creation authorization"
-//	@Success		200	{object}	WorkspaceKindListEnvelope	"Successful operation. Returns a list of all available workspace kinds."
-//	@Failure		401	{object}	ErrorEnvelope				"Unauthorized. Authentication is required."
-//	@Failure		403	{object}	ErrorEnvelope				"Forbidden. User does not have permission to list workspace kinds."
-//	@Failure		422	{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
-//	@Failure		500	{object}	ErrorEnvelope				"Internal server error. An unexpected error occurred on the server."
+//	@Param			namespaceFilter	query		string						false	"Namespace used for workspace creation authorization"
+//	@Success		200				{object}	WorkspaceKindListEnvelope	"Successful operation. Returns a list of all available workspace kinds."
+//	@Failure		401				{object}	ErrorEnvelope				"Unauthorized. Authentication is required."
+//	@Failure		403				{object}	ErrorEnvelope				"Forbidden. User does not have permission to list workspace kinds."
+//	@Failure		422				{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
+//	@Failure		500				{object}	ErrorEnvelope				"Internal server error. An unexpected error occurred on the server."
 //	@Router			/workspacekinds [get]
 func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	namespaceFilter := r.URL.Query().Get("namespaceFilter")
+	namespaceFilter := r.URL.Query().Get(NamespaceFilterQueryParam)
 
 	if namespaceFilter != "" {
 		valErrs := helper.ValidateKubernetesNamespaceName(
-			field.NewPath("namespaceFilter"),
+			field.NewPath(NamespaceFilterQueryParam),
 			namespaceFilter,
 		)
 
@@ -125,7 +125,7 @@ func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _
 			a.failedValidationResponse(
 				w,
 				r,
-				errMsgPathParamsInvalid,
+				errMsgQueryParamsInvalid,
 				valErrs,
 				nil,
 			)

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -195,6 +195,37 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			err = json.Unmarshal(dataJSON, &dataObject)
 			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal JSON to WorkspaceKind")
 		})
+
+		It("should retrieve WorkspaceKinds with valid namespaceFilter query parameter", func() {
+			By("creating the HTTP request with namespaceFilter query parameter")
+			req, err := http.NewRequest(http.MethodGet, AllWorkspaceKindsPath+"?namespaceFilter="+namespaceName1, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetWorkspaceKindsHandler")
+			ps := httprouter.Params{}
+			rr := httptest.NewRecorder()
+			a.GetWorkspaceKindsHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response JSON to WorkspaceKindListEnvelope")
+			var response WorkspaceKindListEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("ensuring the response contains WorkspaceKinds")
+			Expect(response.Data).NotTo(BeEmpty())
+		})
 	})
 
 	// NOTE: these tests assume a specific state of the cluster, so cannot be run in parallel with other tests.

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -463,6 +463,14 @@ const docTemplate = `{
                 ],
                 "summary": "List workspace kinds",
                 "operationId": "listWorkspaceKinds",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace used for workspace creation authorization",
+                        "name": "namespaceFilter",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful operation. Returns a list of all available workspace kinds.",
@@ -478,6 +486,12 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "Forbidden. User does not have permission to list workspace kinds.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -461,6 +461,14 @@
                 ],
                 "summary": "List workspace kinds",
                 "operationId": "listWorkspaceKinds",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace used for workspace creation authorization",
+                        "name": "namespaceFilter",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful operation. Returns a list of all available workspace kinds.",
@@ -476,6 +484,12 @@
                     },
                     "403": {
                         "description": "Forbidden. User does not have permission to list workspace kinds.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }


### PR DESCRIPTION
### Summary
Adds optional `namespaceFilter` query parameter to `GET /workspacekinds` to support Bella-centric listing while preserving existing admin behavior.

### Behavior
- When `namespaceFilter` is provided:
  - Validates the value as a Kubernetes namespace
  - Applies `CREATE Workspace` authorization in the given namespace
- When not provided:
  - Uses existing `LIST WorkspaceKind` authorization

### Motivation
This supports the dual-persona nature of `/workspacekinds`:
- Bella: selecting a WorkspaceKind to create a Workspace
- Joel: administrative listing of WorkspaceKinds

### Acceptance Criteria
- [x] namespaceFilter query parameter supported
- [x] namespaceFilter validated (422 on invalid)
- [x] Authorization policy depends on presence of namespaceFilter
- [x] Existing behavior preserved when parameter is absent