### PR TITLE
feat: use generateName for PVCs created by Notebook form

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-data-volumes/form-data-volumes.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-data-volumes/form-data-volumes.component.ts
@@ -39,7 +39,7 @@ export class FormDataVolumesComponent implements OnInit {
   addNewVolume() {
     const volId = this.volsArray.length + 1;
     const volGroup = createNewPvcVolumeFormGroup(
-      `{notebook-name}-datavol-${volId}`,
+      `{notebook-name}-datavol-${volId}-`,
     );
 
     this.volsArray.push(volGroup);

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.ts
@@ -50,7 +50,7 @@ export class FormWorkspaceVolumeComponent implements OnInit, OnDestroy {
   }
 
   addNewVolume() {
-    this.volGroup.addControl('newPvc', createNewPvcFormGroup());
+    this.volGroup.addControl('newPvc', createNewPvcFormGroup('{notebook-name}-workspace-'));
     this.volGroup.get('mount').setValue('/home/jovyan');
     this.volGroup.enable();
     this.volGroup.get('newPvc.spec.storageClassName').disable();

--- a/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts
@@ -70,11 +70,11 @@ export function createExistingSourceFormGroup(): FormGroup {
 
 // for volume.newPvc
 export function createNewPvcFormGroup(
-  name = '{notebook-name}-volume',
+  name = '{notebook-name}-volume-',
 ): FormGroup {
   return new FormGroup({
     metadata: new FormGroup({
-      name: new FormControl(name, Validators.required),
+      generateName: new FormControl(name, Validators.required),
     }),
     spec: new FormGroup({
       accessModes: new FormControl(['ReadWriteOnce']),


### PR DESCRIPTION
## What this PR does

Changes the Jupyter Notebook form to use Kubernetes `generateName` instead of `name` when creating new PVCs. This prevents naming conflicts when notebooks are recreated or when PVCs from deleted notebooks still exist.

## Why

Currently, PVCs are created with static names like `{notebook-name}-volume`. If a notebook is deleted but the PVC persists (common with `Retain` reclaim policies or delayed cleanup), recreating a notebook with the same name fails due to PVC naming conflict.

Using `generateName` allows Kubernetes to auto-generate unique suffixes, e.g., `mynotebook-volume-x7k2m`.

## Changes

| File | Change |
|------|--------|
| [shared/utils/volumes/forms.ts](cci:7://file:///Users/feiyuzhang/notebooks/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts:0:0-0:0) | [createNewPvcFormGroup()](cci:1://file:///Users/feiyuzhang/notebooks/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts:70:0-91:1): use `generateName` instead of `name`; default name ends with `-` |
| [form-workspace-volume.component.ts](cci:7://file:///Users/feiyuzhang/notebooks/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.ts:0:0-0:0) | Update workspace volume name to `{notebook-name}-workspace-` |
| [form-data-volumes.component.ts](cci:7://file:///Users/feiyuzhang/notebooks/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-data-volumes/form-data-volumes.component.ts:0:0-0:0) | Update data volume name to `{notebook-name}-datavol-{n}-` |

## How to test

1. Deploy the updated Jupyter web app
2. Create a new notebook with default volume settings
3. Verify PVC is created with a generated suffix (e.g., `mynotebook-workspace-x7k2m`)
4. Delete the notebook (keeping the PVC)
5. Create a new notebook with the same name
6. Verify a new PVC is created without conflict

## Notes

- The [setGenerateNameCtrl](cci:1://file:///Users/feiyuzhang/notebooks/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts:9:0-31:1) helper and `generateName` handling in [createMetadataFormGroupFromPvc](cci:1://file:///Users/feiyuzhang/notebooks/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts:113:0-156:1) already exist, so this change builds on existing infrastructure
- Volume name templates now end with `-` as required by Kubernetes `generateName` spec

Closes #842 