### PR TITLE
feat: Add secrets management page

### DIFF
--- a/workspaces/frontend/src/app/AppRoutes.tsx
+++ b/workspaces/frontend/src/app/AppRoutes.tsx
@@ -9,6 +9,7 @@ import { NotFound } from './pages/notFound/NotFound';
 import { WorkspaceKinds } from './pages/WorkspaceKinds/WorkspaceKinds';
 import { WorkspacesWrapper } from './pages/Workspaces/WorkspacesWrapper';
 import { WorkspaceKindForm } from './pages/WorkspaceKinds/Form/WorkspaceKindForm';
+import { Secrets } from './pages/Secrets/Secrets';
 
 export const isNavDataGroup = (navItem: NavDataItem): navItem is NavDataGroup =>
   'children' in navItem;
@@ -51,6 +52,10 @@ export const useNavData = (): NavDataItem[] => [
     label: 'Workspaces',
     path: AppRoutePaths.workspaces,
   },
+  {
+    label: 'Secrets',
+    path: AppRoutePaths.secrets,
+  },
   ...useAdminDebugSettings(),
 ];
 
@@ -62,6 +67,7 @@ const AppRoutes: React.FC = () => {
       <Route path={AppRoutePaths.workspaceCreate} element={<WorkspaceForm />} />
       <Route path={AppRoutePaths.workspaceEdit} element={<WorkspaceForm />} />
       <Route path={AppRoutePaths.workspaces} element={<WorkspacesWrapper />} />
+      <Route path={AppRoutePaths.secrets} element={<Secrets />} />
       <Route path={AppRoutePaths.workspaceKindSummary} element={<WorkspaceKindSummaryWrapper />} />
       <Route path={AppRoutePaths.workspaceKinds} element={<WorkspaceKinds />} />
       <Route path={AppRoutePaths.workspaceKindCreate} element={<WorkspaceKindForm />} />

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -14,19 +14,27 @@ body,
 .pf-v6-c-page__main-section .pf-v6-c-page__main-body {
   height: 100%;
 }
-.pf-v6-c-page__main-body > .pf-v6-l-stack,
-.pf-v6-c-page__main-section.pf-m-fill > .pf-v6-l-stack {
+
+.pf-v6-c-page__main-body>.pf-v6-l-stack,
+.pf-v6-c-page__main-section.pf-m-fill>.pf-v6-l-stack {
   height: 100%;
   flex-grow: 1;
 }
+
 .pf-v6-c-file-upload {
   height: 100%;
   display: flex;
   flex-direction: column;
 }
+
 .pf-v6-c-file-upload__file-details {
   flex-grow: 1;
 }
+
 .pf-v6-c-file-upload__file-details .pf-v6-c-form-control {
   height: 100%;
+}
+
+.delete-secret-modal .pf-v6-c-modal-box__body {
+  padding: 2rem 2.5rem;
 }

--- a/workspaces/frontend/src/app/hooks/useSecrets.ts
+++ b/workspaces/frontend/src/app/hooks/useSecrets.ts
@@ -1,0 +1,23 @@
+import { FetchState, useFetchState } from 'mod-arch-core';
+import { useCallback } from 'react';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import { ApiSecretListEnvelope } from '~/generated/data-contracts';
+
+export const useSecretsByNamespace = (
+  namespace: string,
+): FetchState<ApiSecretListEnvelope['data']> => {
+  const { api, apiAvailable } = useNotebookAPI();
+
+  const call = useCallback(async () => {
+    if (!apiAvailable) {
+      throw new Error('API not yet available');
+    }
+    if (!namespace) {
+      throw new Error('Namespace is required');
+    }
+    const envelope = await api.secrets.listSecrets(namespace);
+    return envelope.data;
+  }, [api.secrets, apiAvailable, namespace]);
+
+  return useFetchState(call, []);
+};

--- a/workspaces/frontend/src/app/pages/Secrets/Secrets.tsx
+++ b/workspaces/frontend/src/app/pages/Secrets/Secrets.tsx
@@ -1,0 +1,222 @@
+import React, { useState, useCallback } from 'react';
+import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+} from '@patternfly/react-core/dist/esm/components/EmptyState';
+import {
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+  TableVariant,
+  ActionsColumn,
+  IActions,
+} from '@patternfly/react-table/dist/esm/components/Table';
+import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core/dist/esm/components/Toolbar';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
+import {
+  Modal,
+  ModalHeader,
+  ModalFooter,
+  ModalVariant,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { useSecretsByNamespace } from '~/app/hooks/useSecrets';
+import { useNamespaceSelectorWrapper } from '~/app/hooks/useNamespaceSelectorWrapper';
+import { LoadError } from '~/app/components/LoadError';
+import { SecretsSecretListItem } from '~/generated/data-contracts';
+import { SecretsCreateModal } from '~/app/pages/Workspaces/Form/properties/secrets/SecretsCreateModal';
+import { SecretsViewPopover } from '~/app/pages/Workspaces/Form/properties/secrets/SecretsViewPopover';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+
+export const Secrets: React.FunctionComponent = () => {
+  const { selectedNamespace } = useNamespaceSelectorWrapper();
+  const [secrets, secretsLoaded, secretsError, refreshSecrets] =
+    useSecretsByNamespace(selectedNamespace);
+  const { api } = useNotebookAPI();
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [activeSecret, setActiveSecret] = useState<SecretsSecretListItem | undefined>(undefined);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const handleCreateSecret = () => {
+    setActiveSecret(undefined);
+    setIsCreateModalOpen(true);
+  };
+
+  const handleEditSecret = (secret: SecretsSecretListItem) => {
+    setActiveSecret(secret);
+    setIsEditModalOpen(true);
+  };
+
+  const handleDeleteSecret = (secret: SecretsSecretListItem) => {
+    setActiveSecret(secret);
+    setIsDeleteModalOpen(true);
+  };
+
+  const onSecretCreatedOrUpdated = useCallback(() => {
+    refreshSecrets();
+    setIsCreateModalOpen(false);
+    setIsEditModalOpen(false);
+  }, [refreshSecrets]);
+
+  const confirmDelete = async () => {
+    if (!activeSecret) {
+      return;
+    }
+    setDeleteLoading(true);
+    try {
+      await api.secrets.deleteSecret(selectedNamespace, activeSecret.name);
+      refreshSecrets();
+      setIsDeleteModalOpen(false);
+    } catch (err) {
+      // Handle error (maybe show notification)
+      console.error(err);
+    } finally {
+      setDeleteLoading(false);
+      setActiveSecret(undefined);
+    }
+  };
+
+  const columns = ['Name', 'Type', 'Immutable', 'Created At', 'Mounted By'];
+
+  const getRowActions = (secret: SecretsSecretListItem): IActions => {
+    const actions: IActions = [];
+
+    if (secret.canUpdate) {
+      actions.push({
+        title: 'Edit',
+        onClick: () => handleEditSecret(secret),
+      });
+    }
+
+    // Assuming we can delete if we can update, or strictly if not mounted?
+    // For now allowing delete if canUpdate is true, similar to other resources.
+    if (secret.canUpdate) {
+      actions.push({
+        title: 'Delete',
+        onClick: () => handleDeleteSecret(secret),
+      });
+    }
+
+    return actions;
+  };
+
+  if (secretsError) {
+    return <LoadError title="Failed to load secrets" error={secretsError} />;
+  }
+
+  if (!secretsLoaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <PageSection>
+      <Title headingLevel="h1" size="2xl">
+        Secrets
+      </Title>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem>
+            <Button variant="primary" onClick={handleCreateSecret}>
+              Create Secret
+            </Button>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+      {secrets.length === 0 ? (
+        <EmptyState
+          variant={EmptyStateVariant.full}
+          icon={CubesIcon}
+          titleText="No secrets found"
+          headingLevel="h5"
+        >
+          <EmptyStateBody>No secrets are currently available in this namespace.</EmptyStateBody>
+        </EmptyState>
+      ) : (
+        <Table aria-label="Secrets table" variant={TableVariant.compact}>
+          <Thead>
+            <Tr>
+              {columns.map((column, columnIndex) => (
+                <Th key={columnIndex}>{column}</Th>
+              ))}
+              <Th screenReaderText="Actions" />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {secrets.map((secret: SecretsSecretListItem, rowIndex: number) => (
+              <Tr key={rowIndex}>
+                <Td dataLabel={columns[0]}>
+                  {secret.name} <SecretsViewPopover secretName={secret.name} />
+                </Td>
+                <Td dataLabel={columns[1]}>{secret.type}</Td>
+                <Td dataLabel={columns[2]}>{secret.immutable ? 'Yes' : 'No'}</Td>
+                <Td dataLabel={columns[3]}>{secret.audit.createdAt}</Td>
+                <Td dataLabel={columns[4]}>
+                  {secret.mounts?.map((m) => m.name).join(', ') || '-'}
+                </Td>
+                <Td isActionCell>
+                  <ActionsColumn items={getRowActions(secret)} />
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+
+      <SecretsCreateModal
+        isOpen={isCreateModalOpen}
+        setIsOpen={setIsCreateModalOpen}
+        onSecretCreated={onSecretCreatedOrUpdated}
+        existingSecretNames={secrets.map((s) => s.name)}
+      />
+
+      {activeSecret && (
+        <SecretsCreateModal
+          isOpen={isEditModalOpen}
+          setIsOpen={setIsEditModalOpen}
+          secretToEdit={activeSecret}
+          onSecretUpdated={onSecretCreatedOrUpdated}
+          existingSecretNames={secrets.map((s) => s.name)}
+        />
+      )}
+
+      <Modal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        variant={ModalVariant.small}
+      >
+        <ModalHeader title="Delete Secret?" />
+        <EmptyStateBody>
+          Are you sure you want to delete secret <b>{activeSecret?.name}</b>? This action cannot be
+          undone.
+        </EmptyStateBody>
+        <ModalFooter>
+          <Button key="delete" variant="danger" isLoading={deleteLoading} onClick={confirmDelete}>
+            Delete
+          </Button>
+          <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </PageSection>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Secrets/Secrets.tsx
+++ b/workspaces/frontend/src/app/pages/Secrets/Secrets.tsx
@@ -18,6 +18,7 @@ import {
   IActions,
 } from '@patternfly/react-table/dist/esm/components/Table';
 import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import {
   Toolbar,
@@ -29,6 +30,7 @@ import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 import {
   Modal,
   ModalHeader,
+  ModalBody,
   ModalFooter,
   ModalVariant,
 } from '@patternfly/react-core/dist/esm/components/Modal';
@@ -198,25 +200,65 @@ export const Secrets: React.FunctionComponent = () => {
         />
       )}
 
-      <Modal
-        isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
-        variant={ModalVariant.small}
-      >
-        <ModalHeader title="Delete Secret?" />
-        <EmptyStateBody>
-          Are you sure you want to delete secret <b>{activeSecret?.name}</b>? This action cannot be
-          undone.
-        </EmptyStateBody>
-        <ModalFooter>
-          <Button key="delete" variant="danger" isLoading={deleteLoading} onClick={confirmDelete}>
-            Delete
-          </Button>
-          <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
-            Cancel
-          </Button>
-        </ModalFooter>
-      </Modal>
+      {activeSecret && (
+        <Modal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          variant={ModalVariant.small}
+          className="delete-secret-modal"
+        >
+          <ModalHeader title="Delete Secret?" titleIconVariant="warning" />
+          <ModalBody>
+            <div style={{ marginBottom: 'var(--pf-v6-global--spacer--md)' }}>
+              Are you sure you want to delete secret <b>{activeSecret.name}</b>? This action cannot
+              be undone.
+            </div>
+            {activeSecret.mounts && activeSecret.mounts.length > 0 && (
+              <div
+                style={{
+                  marginTop: 'var(--pf-v6-global--spacer--md)',
+                  background: 'var(--pf-v5-global--danger-color--200)',
+                  padding: 'var(--pf-v6-global--spacer--md)',
+                  borderRadius: 'var(--pf-v5-global--BorderRadius--sm)',
+                  borderLeft: '4px solid var(--pf-v5-global--danger-color--100)',
+                }}
+              >
+                <p
+                  style={{
+                    color: 'var(--pf-v5-global--danger-color--100)',
+                    fontWeight: 'bold',
+                    marginBottom: 'var(--pf-v5-global--spacer--xs)',
+                  }}
+                >
+                  <ExclamationTriangleIcon /> This secret is in use!
+                </p>
+                <p style={{ fontSize: 'var(--pf-v5-global--FontSize--sm)' }}>
+                  It is currently mounted by the following workspaces:
+                </p>
+                <ul
+                  style={{
+                    fontSize: 'var(--pf-v5-global--FontSize--sm)',
+                    marginLeft: 'var(--pf-v5-global--spacer--md)',
+                    marginTop: 'var(--pf-v5-global--spacer--xs)',
+                  }}
+                >
+                  {activeSecret.mounts.map((m) => (
+                    <li key={m.name}>{m.name}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button key="delete" variant="danger" isLoading={deleteLoading} onClick={confirmDelete}>
+              Delete
+            </Button>
+            <Button key="cancel" variant="link" onClick={() => setIsDeleteModalOpen(false)}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
     </PageSection>
   );
 };

--- a/workspaces/frontend/src/app/routes.ts
+++ b/workspaces/frontend/src/app/routes.ts
@@ -8,6 +8,7 @@ export const AppRoutePaths = {
   workspaceKindCreate: '/workspacekinds/create',
   workspaceKindEdit: '/workspacekinds/:kind/edit',
   notebookDebugSettings: '/notebookDebugSettings',
+  secrets: '/secrets',
 } satisfies Record<string, `/${string}`>;
 
 export type AppRoute = (typeof AppRoutePaths)[keyof typeof AppRoutePaths];
@@ -37,6 +38,7 @@ export type RouteParamsMap = {
     kind: string;
   };
   notebookDebugSettings: undefined;
+  secrets: undefined;
 };
 
 /**
@@ -73,6 +75,7 @@ export type RouteStateMap = {
     workspaceKindName: string;
   };
   notebookDebugSettings: undefined;
+  secrets: undefined;
 };
 
 /**
@@ -95,4 +98,5 @@ export type RouteSearchParamsMap = {
   workspaceKindCreate: undefined;
   workspaceKindEdit: undefined;
   notebookDebugSettings: undefined;
+  secrets: undefined;
 };

--- a/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
@@ -13,12 +13,14 @@ import {
   mockWorkspaceUpdate,
 } from '~/shared/mock/mockNotebookServiceData';
 import { buildAxiosError, isInvalidWorkspace, isInvalidYaml } from '~/shared/mock/mockUtils';
-import { buildMockWorkspaceUpdateFromWorkspace } from './mockBuilder';
+import { buildMockSecret, buildMockWorkspaceUpdateFromWorkspace } from './mockBuilder';
 
 const delay = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+
+let secretsStore = [...mockSecretsList];
 
 export const mockNotebookApisImpl = (): NotebookApis => ({
   healthCheck: {
@@ -113,20 +115,43 @@ export const mockNotebookApisImpl = (): NotebookApis => ({
   },
   secrets: {
     listSecrets: async () => ({
-      data: mockSecretsList,
+      data: secretsStore,
     }),
-    createSecret: async () => ({
-      data: mockSecretCreate,
-    }),
+    createSecret: async (_namespace, body) => {
+      const newSecret = buildMockSecret({
+        name: body.data.name,
+        type: body.data.type,
+        immutable: body.data.immutable,
+      });
+      secretsStore = [newSecret, ...secretsStore];
+      return {
+        data: {
+          name: body.data.name,
+          type: body.data.type,
+          immutable: body.data.immutable,
+          contents: body.data.contents,
+        },
+      };
+    },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getSecret: async (_, name) => ({
       data: name === 'secret-3' ? mockSecretCreate3 : mockSecretCreate,
     }),
-    updateSecret: async () => ({
-      data: mockSecretCreate,
-    }),
-    deleteSecret: async () => {
+    updateSecret: async (_namespace, name, body) => {
+      secretsStore = secretsStore.map((s) =>
+        s.name === name ? { ...s, type: body.type, immutable: body.immutable } : s,
+      );
+      return {
+        data: {
+          type: body.type,
+          immutable: body.immutable,
+          contents: body.contents,
+        },
+      };
+    },
+    deleteSecret: async (_namespace, name) => {
       await delay(1500);
+      secretsStore = secretsStore.filter((s) => s.name !== name);
     },
   },
 });


### PR DESCRIPTION
**Description:**
This PR introduces a dedicated **Secrets Management** page for Notebooks 2.0, enabling users to manage Kubernetes secrets directly from the UI. It fulfills the user story requirements for managing secrets within a selected namespace.

**Changes:**
* Added a new **Secrets** page (`/secrets`) accessible from the main navigation.
* Implemented `useSecretsByNamespace` hook to fetch and manage secrets data.
* Added functionality to:
  * List all secrets in the current namespace.
  * Create new **Opaque** secrets with key/value pairs.
  * Edit existing mutable secrets.
  * Delete secrets.
* Integrated `SecretsCreateModal` and `SecretsViewPopover` for a consistent UI/UX.
* Updated routing configuration in `AppRoutes.tsx` and `routes.ts`.

**Related Issues:**
* Closes: #679
* Related: #654
* Related: #659

**Testing:**
* Verified that the **Secrets** menu item appears in navigation.
* Confirmed secrets list loads correctly for the selected namespace.
* Tested creating, editing, and deleting secrets.
* Confirmed immutable secrets cannot be edited.
* Ran lint checks (`npm run test:lint`) — all passed.