### PR TITLE
feat: add show hidden and only latest filters to image list during workspace creation

### DIFF
--- a/workspaces/frontend/config/cspell-ignore-words.txt
+++ b/workspaces/frontend/config/cspell-ignore-words.txt
@@ -9,3 +9,4 @@ healthcheck
 pficon
 svgs
 labelledby
+xlarge

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
@@ -168,11 +168,77 @@ class WorkspaceForm {
   clickCreateNewSecret(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findCreateNewSecretButton().click();
   }
+
+  findLabelFilterPanel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('label-filter-panel');
+  }
+
+  findLabelCategory(labelKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`label-category-${labelKey}`);
+  }
+
+  clickLabelFilter(labelKey: string, labelValue: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy
+      .findByTestId(`label-filter-${labelKey}-${labelValue}`)
+      .find('input[type="checkbox"]')
+      .click();
+  }
+
+  assertLabelFilterChecked(
+    labelKey: string,
+    labelValue: string,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy
+      .findByTestId(`label-filter-${labelKey}-${labelValue}`)
+      .find('input[type="checkbox"]')
+      .should('be.checked');
+  }
+
+  assertLabelFilterNotChecked(
+    labelKey: string,
+    labelValue: string,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy
+      .findByTestId(`label-filter-${labelKey}-${labelValue}`)
+      .find('input[type="checkbox"]')
+      .should('not.be.checked');
+  }
+
+  findExtraFilter(filterKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`extra-filter-${filterKey}`);
+  }
+
+  clickExtraFilter(filterKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findExtraFilter(filterKey).find('input[type="checkbox"]').click();
+  }
+
+  checkExtraFilter(filterKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findExtraFilter(filterKey).find('input[type="checkbox"]').check();
+  }
+
+  uncheckExtraFilter(filterKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findExtraFilter(filterKey).find('input[type="checkbox"]').uncheck();
+  }
+
+  assertExtraFilterChecked(filterKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findExtraFilter(filterKey).find('input[type="checkbox"]').should('be.checked');
+  }
+
+  assertExtraFilterNotChecked(filterKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findExtraFilter(filterKey).find('input[type="checkbox"]').should('not.be.checked');
+  }
+
+  assertLabelCategoryExists(labelKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findLabelCategory(labelKey).should('exist');
+  }
+
+  assertLabelCategoryNotExists(labelKey: string): void {
+    cy.findByTestId(`label-category-${labelKey}`).should('not.exist');
+  }
 }
 
 class SecretsCreateModal {
   find() {
-    // eslint-disable-next-line @cspell/spellchecker
     return cy.get('[aria-labelledby="create-secret-modal-title"]');
   }
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -36,6 +36,7 @@ const selectWorkspaceKind = (kindName: string): void => {
 };
 
 const selectImage = (imageId: string): void => {
+  createWorkspace.clickExtraFilter('showRedirected');
   createWorkspace.selectImage(imageId);
   createWorkspace.assertImageSelected(imageId);
   createWorkspace.clickNext();
@@ -142,6 +143,7 @@ describe('Create workspace', () => {
       createWorkspace.assertPreviousButtonEnabled();
       createWorkspace.assertNextButtonDisabled();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.assertImageSelected(mockImage.id);
       createWorkspace.assertNextButtonEnabled();
@@ -195,6 +197,7 @@ describe('Create workspace', () => {
       // Go back to image selection
       createWorkspace.clickPrevious();
       createWorkspace.assertProgressStepVisible(STEP_NAMES.IMAGE);
+      createWorkspace.clickExtraFilter('showRedirected');
       createWorkspace.assertImageSelected(mockImage.id);
 
       // Go back to kind selection
@@ -240,6 +243,7 @@ describe('Create workspace', () => {
       createWorkspace.selectKind(mockWorkspaceKind.name);
       createWorkspace.clickNext();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
 
@@ -312,6 +316,7 @@ describe('Create workspace', () => {
       createWorkspace.selectKind(mockWorkspaceKindWithMultipleImages.name);
       createWorkspace.clickNext();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       // Select first image
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.assertImageSelected(mockImage.id);
@@ -360,6 +365,7 @@ describe('Create workspace', () => {
       createWorkspace.selectKind(mockWorkspaceKindWithMultiplePodConfigs.name);
       createWorkspace.clickNext();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
 
@@ -396,6 +402,7 @@ describe('Create workspace', () => {
       createWorkspace.selectKind(mockWorkspaceKind.name);
       createWorkspace.clickNext();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
 
@@ -472,6 +479,7 @@ describe('Create workspace', () => {
       createWorkspace.selectKind(mockWorkspaceKindSingleImage.name);
       createWorkspace.clickNext();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       // Select the single available image
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.assertImageSelected(mockImage.id);
@@ -506,6 +514,7 @@ describe('Create workspace', () => {
       createWorkspace.selectKind(mockWorkspaceKindSinglePodConfig.name);
       createWorkspace.clickNext();
 
+      createWorkspace.clickExtraFilter('showRedirected');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
 
@@ -684,6 +693,7 @@ describe('Create workspace', () => {
         createWorkspace.selectKind(mockWorkspaceKindWithMultipleOptions.name);
         createWorkspace.clickNext();
 
+        createWorkspace.clickExtraFilter('showRedirected');
         createWorkspace.selectImage(mockImage.id);
         createWorkspace.clickNext();
 
@@ -703,6 +713,7 @@ describe('Create workspace', () => {
         createWorkspace.selectKind(mockWorkspaceKindWithMultipleOptions.name);
         createWorkspace.clickNext();
 
+        createWorkspace.clickExtraFilter('showRedirected');
         createWorkspace.selectImage(mockImage.id);
         createWorkspace.clickNext();
 
@@ -719,6 +730,7 @@ describe('Create workspace', () => {
         createWorkspace.selectKind(mockWorkspaceKindWithMultipleOptions.name);
         createWorkspace.clickNext();
 
+        createWorkspace.clickExtraFilter('showRedirected');
         createWorkspace.selectImage(mockImage.id);
         createWorkspace.clickNext();
 
@@ -734,6 +746,7 @@ describe('Create workspace', () => {
         createWorkspace.selectKind(mockWorkspaceKindWithMultipleOptions.name);
         createWorkspace.clickNext();
 
+        createWorkspace.clickExtraFilter('showRedirected');
         createWorkspace.selectImage(mockImage.id);
         createWorkspace.clickNext();
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
@@ -237,6 +237,7 @@ describe('Edit workspace', () => {
       editWorkspace.clickNext();
 
       // Step 2: Image Selection - change to a different image
+      editWorkspace.clickExtraFilter('showRedirected');
       editWorkspace.selectImage(newImageConfigId);
       editWorkspace.clickNext();
 
@@ -272,6 +273,7 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKind');
       editWorkspace.clickNext();
 
+      editWorkspace.clickExtraFilter('showRedirected');
       editWorkspace.assertImageSelected(IMAGE_CONFIG_ID);
     });
 
@@ -426,6 +428,7 @@ describe('Edit workspace', () => {
       editWorkspace.clickNext();
 
       // Step 2: Image Selection
+      editWorkspace.clickExtraFilter('showRedirected');
       editWorkspace.assertImageSelected(IMAGE_CONFIG_ID);
       editWorkspace.assertNextButtonEnabled();
       editWorkspace.clickNext();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterImagesByLabels.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterImagesByLabels.cy.ts
@@ -1,0 +1,325 @@
+import { mockModArchResponse } from 'mod-arch-core';
+import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
+import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
+import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import {
+  buildMockNamespace,
+  buildMockWorkspace,
+  buildMockWorkspaceKind,
+} from '~/shared/mock/mockBuilder';
+import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { buildMockImageWithLabels } from '~/__tests__/cypress/cypress/utils/testBuilders';
+import type { WorkspacekindsWorkspaceKind } from '~/generated/data-contracts';
+
+const STEP_NAMES = {
+  KIND: 'Workspace Kind',
+  IMAGE: 'Image',
+  POD_CONFIG: 'Pod Config',
+  PROPERTIES: 'Properties',
+} as const;
+
+describe('Filter Images by Labels', () => {
+  const mockNamespace = buildMockNamespace({ name: 'default' });
+  const mockWorkspaces = [buildMockWorkspace({})];
+
+  const mockImages = [
+    buildMockImageWithLabels(
+      'pytorch-39',
+      'PyTorch 3.9',
+      [
+        { key: 'pythonVersion', value: '3.9' },
+        { key: 'framework', value: 'pytorch' },
+        { key: 'cpu', value: '2' },
+      ],
+      false,
+    ),
+    buildMockImageWithLabels(
+      'pytorch-310',
+      'PyTorch 3.10',
+      [
+        { key: 'pythonVersion', value: '3.10' },
+        { key: 'framework', value: 'pytorch' },
+        { key: 'cpu', value: '4' },
+      ],
+      false,
+    ),
+    buildMockImageWithLabels(
+      'tensorflow-39',
+      'TensorFlow 3.9',
+      [
+        { key: 'pythonVersion', value: '3.9' },
+        { key: 'framework', value: 'tensorflow' },
+        { key: 'cpu', value: '2' },
+      ],
+      false,
+    ),
+    buildMockImageWithLabels(
+      'tensorflow-310',
+      'TensorFlow 3.10',
+      [
+        { key: 'pythonVersion', value: '3.10' },
+        { key: 'framework', value: 'tensorflow' },
+        { key: 'cpu', value: '4' },
+      ],
+      false,
+    ),
+    buildMockImageWithLabels(
+      'pytorch-gpu',
+      'PyTorch GPU',
+      [
+        { key: 'pythonVersion', value: '3.9' },
+        { key: 'framework', value: 'pytorch' },
+        { key: 'gpu', value: '1' },
+      ],
+      true,
+    ),
+    buildMockImageWithLabels(
+      'tensorflow-gpu',
+      'TensorFlow GPU',
+      [
+        { key: 'pythonVersion', value: '3.10' },
+        { key: 'framework', value: 'tensorflow' },
+        { key: 'gpu', value: '1' },
+      ],
+      true,
+    ),
+    buildMockImageWithLabels(
+      'special-chars',
+      'Special Chars',
+      [
+        { key: 'version', value: '1.0-alpha' },
+        { key: 'tag', value: 'test_value' },
+      ],
+      false,
+    ),
+  ];
+
+  const mockWorkspaceKind: WorkspacekindsWorkspaceKind = buildMockWorkspaceKind({
+    name: 'jupyterlab',
+    podTemplate: {
+      ...buildMockWorkspaceKind().podTemplate,
+      options: {
+        imageConfig: {
+          default: 'pytorch-39',
+          values: mockImages,
+        },
+        podConfig: {
+          default: 'tiny_cpu',
+          values: [
+            {
+              id: 'tiny_cpu',
+              displayName: 'Tiny CPU',
+              description: 'Small CPU configuration',
+              labels: [],
+              hidden: false,
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  beforeEach(() => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/namespaces',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+      mockModArchResponse([mockNamespace]),
+    ).as('getNamespaces');
+
+    cy.interceptApi(
+      'GET /api/:apiVersion/workspaces/:namespace',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
+      mockModArchResponse(mockWorkspaces),
+    ).as('getWorkspaces');
+
+    cy.interceptApi(
+      'GET /api/:apiVersion/workspacekinds',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+      mockModArchResponse([mockWorkspaceKind]),
+    ).as('getWorkspaceKinds');
+
+    workspaces.visit();
+    cy.wait('@getNamespaces');
+
+    navBar.selectNamespace(mockNamespace.name);
+    cy.wait('@getWorkspaces');
+
+    workspaces.findCreateWorkspaceButton().click();
+    cy.wait('@getWorkspaceKinds');
+
+    createWorkspace.selectKind(mockWorkspaceKind.name);
+    createWorkspace.clickNext();
+
+    createWorkspace.findImageCard('pytorch-39').should('be.visible');
+  });
+
+  describe('Label filtering', () => {
+    it('should display all unique label categories', () => {
+      createWorkspace.assertLabelCategoryExists('pythonVersion');
+      createWorkspace.assertLabelCategoryExists('framework');
+      createWorkspace.assertLabelCategoryExists('cpu');
+      createWorkspace.assertLabelCategoryExists('gpu');
+      createWorkspace.assertLabelCategoryExists('version');
+      createWorkspace.assertLabelCategoryExists('tag');
+    });
+
+    it('should filter images by selecting a single label value', () => {
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-39').should('be.visible');
+      createWorkspace.findImageCard('pytorch-310').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-310').should('be.visible');
+
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.assertLabelFilterChecked('pythonVersion', '3.9');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-39').should('be.visible');
+      createWorkspace.findImageCard('pytorch-310').should('not.exist');
+      createWorkspace.findImageCard('tensorflow-310').should('not.exist');
+    });
+
+    it('should filter images by multiple values within same category (OR logic)', () => {
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.clickLabelFilter('pythonVersion', '3.10');
+
+      createWorkspace.assertLabelFilterChecked('pythonVersion', '3.9');
+      createWorkspace.assertLabelFilterChecked('pythonVersion', '3.10');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-39').should('be.visible');
+      createWorkspace.findImageCard('pytorch-310').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-310').should('be.visible');
+    });
+
+    it('should filter images by multiple categories (AND logic)', () => {
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.clickLabelFilter('framework', 'pytorch');
+
+      createWorkspace.assertLabelFilterChecked('pythonVersion', '3.9');
+      createWorkspace.assertLabelFilterChecked('framework', 'pytorch');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-39').should('not.exist');
+      createWorkspace.findImageCard('pytorch-310').should('not.exist');
+      createWorkspace.findImageCard('tensorflow-310').should('not.exist');
+    });
+
+    it('should uncheck label filter and restore filtered images', () => {
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.assertLabelFilterChecked('pythonVersion', '3.9');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('pytorch-310').should('not.exist');
+
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.assertLabelFilterNotChecked('pythonVersion', '3.9');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('pytorch-310').should('be.visible');
+    });
+
+    it('should show no results when no images match filter', () => {
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.clickLabelFilter('cpu', '4');
+
+      createWorkspace.assertNoResultsFound();
+    });
+
+    it('should handle labels with special characters', () => {
+      createWorkspace.clickLabelFilter('version', '1.0-alpha');
+      createWorkspace.assertLabelFilterChecked('version', '1.0-alpha');
+
+      createWorkspace.findImageCard('special-chars').should('be.visible');
+      createWorkspace.findImageCard('pytorch-39').should('not.exist');
+    });
+
+    it('should format label keys correctly', () => {
+      createWorkspace.findLabelCategory('pythonVersion').should('contain', 'Python');
+      createWorkspace.findLabelCategory('cpu').should('contain', 'CPU');
+      createWorkspace.findLabelCategory('gpu').should('contain', 'GPU');
+      createWorkspace.findLabelCategory('framework').should('contain', 'Framework');
+    });
+  });
+
+  describe('Extra filters', () => {
+    it('should display extra filter checkboxes', () => {
+      createWorkspace.findExtraFilter('showHidden').should('exist');
+      createWorkspace.findExtraFilter('showRedirected').should('exist');
+    });
+
+    it('should filter hidden images with "Show hidden" checkbox', () => {
+      createWorkspace.findImageCard('pytorch-gpu').should('not.exist');
+      createWorkspace.findImageCard('tensorflow-gpu').should('not.exist');
+
+      createWorkspace.assertExtraFilterNotChecked('showHidden');
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertExtraFilterChecked('showHidden');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+
+      createWorkspace.findImageCard('pytorch-gpu').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-gpu').should('be.visible');
+    });
+
+    it('should toggle extra filters on and off', () => {
+      createWorkspace.assertExtraFilterNotChecked('showHidden');
+
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertExtraFilterChecked('showHidden');
+
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertExtraFilterNotChecked('showHidden');
+    });
+
+    it('should combine extra filters with label filters', () => {
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertExtraFilterChecked('showHidden');
+
+      createWorkspace.findImageCard('pytorch-gpu').should('be.visible');
+
+      createWorkspace.clickLabelFilter('framework', 'pytorch');
+      createWorkspace.assertLabelFilterChecked('framework', 'pytorch');
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+      createWorkspace.findImageCard('pytorch-310').should('be.visible');
+      createWorkspace.findImageCard('pytorch-gpu').should('be.visible');
+      createWorkspace.findImageCard('tensorflow-39').should('not.exist');
+      createWorkspace.findImageCard('tensorflow-gpu').should('not.exist');
+    });
+
+    it('should toggle both extra filters together', () => {
+      createWorkspace.assertExtraFilterNotChecked('showRedirected');
+
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertExtraFilterChecked('showHidden');
+    });
+  });
+
+  describe('UI state', () => {
+    it('should maintain selected image when navigating back and forth', () => {
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+      createWorkspace.selectImage('pytorch-39');
+      createWorkspace.assertImageSelected('pytorch-39');
+
+      createWorkspace.clickNext();
+      createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
+
+      createWorkspace.clickPrevious();
+      createWorkspace.assertProgressStepVisible(STEP_NAMES.IMAGE);
+
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+
+      createWorkspace.assertImageSelected('pytorch-39');
+    });
+
+    it('should preserve selected image when applying filters', () => {
+      createWorkspace.selectImage('pytorch-39');
+      createWorkspace.assertImageSelected('pytorch-39');
+
+      createWorkspace.clickLabelFilter('pythonVersion', '3.9');
+
+      createWorkspace.assertImageSelected('pytorch-39');
+      createWorkspace.findImageCard('pytorch-39').should('be.visible');
+    });
+  });
+});

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterPodConfigsByLabels.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterPodConfigsByLabels.cy.ts
@@ -1,0 +1,245 @@
+import { mockModArchResponse } from 'mod-arch-core';
+import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
+import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
+import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import {
+  buildMockNamespace,
+  buildMockWorkspace,
+  buildMockWorkspaceKind,
+} from '~/shared/mock/mockBuilder';
+import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { buildMockPodConfigWithLabels } from '~/__tests__/cypress/cypress/utils/testBuilders';
+import type { WorkspacekindsWorkspaceKind } from '~/generated/data-contracts';
+
+const STEP_NAMES = {
+  KIND: 'Workspace Kind',
+  IMAGE: 'Image',
+  POD_CONFIG: 'Pod Config',
+  PROPERTIES: 'Properties',
+} as const;
+
+describe('Filter Pod Configs by Labels', () => {
+  const mockNamespace = buildMockNamespace({ name: 'default' });
+  const mockWorkspaces = [buildMockWorkspace({})];
+
+  const mockPodConfigs = [
+    buildMockPodConfigWithLabels('tiny-cpu', 'Tiny CPU', [
+      { key: 'cpu', value: '1' },
+      { key: 'memory', value: '2Gi' },
+    ]),
+    buildMockPodConfigWithLabels('small-cpu', 'Small CPU', [
+      { key: 'cpu', value: '2' },
+      { key: 'memory', value: '4Gi' },
+    ]),
+    buildMockPodConfigWithLabels('medium-cpu', 'Medium CPU', [
+      { key: 'cpu', value: '4' },
+      { key: 'memory', value: '8Gi' },
+    ]),
+    buildMockPodConfigWithLabels('large-cpu', 'Large CPU', [
+      { key: 'cpu', value: '8' },
+      { key: 'memory', value: '16Gi' },
+    ]),
+    buildMockPodConfigWithLabels('small-gpu', 'Small GPU', [
+      { key: 'cpu', value: '2' },
+      { key: 'memory', value: '4Gi' },
+      { key: 'gpu', value: '1' },
+    ]),
+    buildMockPodConfigWithLabels('large-gpu', 'Large GPU', [
+      { key: 'cpu', value: '8' },
+      { key: 'memory', value: '16Gi' },
+      { key: 'gpu', value: '2' },
+    ]),
+    buildMockPodConfigWithLabels('xlarge-mem', 'XLarge Memory', [
+      { key: 'cpu', value: '4' },
+      { key: 'memory', value: '32Gi' },
+    ]),
+  ];
+
+  const mockWorkspaceKind: WorkspacekindsWorkspaceKind = buildMockWorkspaceKind({
+    name: 'jupyterlab',
+    podTemplate: {
+      ...buildMockWorkspaceKind().podTemplate,
+      options: {
+        imageConfig: {
+          default: 'jupyter',
+          values: [
+            {
+              id: 'jupyter',
+              displayName: 'Jupyter',
+              description: 'Standard Jupyter image',
+              labels: [],
+              hidden: false,
+            },
+          ],
+        },
+        podConfig: {
+          default: 'tiny-cpu',
+          values: mockPodConfigs,
+        },
+      },
+    },
+  });
+
+  beforeEach(() => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/namespaces',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+      mockModArchResponse([mockNamespace]),
+    ).as('getNamespaces');
+
+    cy.interceptApi(
+      'GET /api/:apiVersion/workspaces/:namespace',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
+      mockModArchResponse(mockWorkspaces),
+    ).as('getWorkspaces');
+
+    cy.interceptApi(
+      'GET /api/:apiVersion/workspacekinds',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+      mockModArchResponse([mockWorkspaceKind]),
+    ).as('getWorkspaceKinds');
+
+    workspaces.visit();
+    cy.wait('@getNamespaces');
+
+    navBar.selectNamespace(mockNamespace.name);
+    cy.wait('@getWorkspaces');
+
+    workspaces.findCreateWorkspaceButton().click();
+    cy.wait('@getWorkspaceKinds');
+
+    createWorkspace.selectKind(mockWorkspaceKind.name);
+    createWorkspace.clickNext();
+
+    createWorkspace.selectImage('jupyter');
+    createWorkspace.clickNext();
+  });
+
+  describe('Label filtering', () => {
+    it('should display all unique label categories', () => {
+      createWorkspace.assertLabelCategoryExists('cpu');
+      createWorkspace.assertLabelCategoryExists('memory');
+      createWorkspace.assertLabelCategoryExists('gpu');
+    });
+
+    it('should filter pod configs by CPU label', () => {
+      createWorkspace.findPodConfigCard('tiny-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('medium-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('large-cpu').should('be.visible');
+
+      createWorkspace.clickLabelFilter('cpu', '1');
+      createWorkspace.assertLabelFilterChecked('cpu', '1');
+
+      createWorkspace.findPodConfigCard('tiny-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-cpu').should('not.exist');
+      createWorkspace.findPodConfigCard('medium-cpu').should('not.exist');
+      createWorkspace.findPodConfigCard('large-cpu').should('not.exist');
+    });
+
+    it('should filter pod configs by Memory label', () => {
+      createWorkspace.clickLabelFilter('memory', '4Gi');
+      createWorkspace.assertLabelFilterChecked('memory', '4Gi');
+
+      createWorkspace.findPodConfigCard('small-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-gpu').should('be.visible');
+      createWorkspace.findPodConfigCard('tiny-cpu').should('not.exist');
+      createWorkspace.findPodConfigCard('medium-cpu').should('not.exist');
+    });
+
+    it('should filter pod configs by GPU label', () => {
+      createWorkspace.clickLabelFilter('gpu', '1');
+      createWorkspace.assertLabelFilterChecked('gpu', '1');
+
+      createWorkspace.findPodConfigCard('small-gpu').should('be.visible');
+      createWorkspace.findPodConfigCard('tiny-cpu').should('not.exist');
+      createWorkspace.findPodConfigCard('large-gpu').should('not.exist');
+    });
+
+    it('should filter pod configs by multiple values within same category (OR logic)', () => {
+      createWorkspace.clickLabelFilter('cpu', '2');
+      createWorkspace.clickLabelFilter('cpu', '4');
+
+      createWorkspace.assertLabelFilterChecked('cpu', '2');
+      createWorkspace.assertLabelFilterChecked('cpu', '4');
+
+      createWorkspace.findPodConfigCard('small-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('medium-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-gpu').should('be.visible');
+      createWorkspace.findPodConfigCard('xlarge-mem').should('be.visible');
+      createWorkspace.findPodConfigCard('tiny-cpu').should('not.exist');
+      createWorkspace.findPodConfigCard('large-cpu').should('not.exist');
+    });
+
+    it('should filter pod configs by multiple categories (AND logic)', () => {
+      createWorkspace.clickLabelFilter('cpu', '2');
+      createWorkspace.clickLabelFilter('memory', '4Gi');
+
+      createWorkspace.assertLabelFilterChecked('cpu', '2');
+      createWorkspace.assertLabelFilterChecked('memory', '4Gi');
+
+      createWorkspace.findPodConfigCard('small-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-gpu').should('be.visible');
+      createWorkspace.findPodConfigCard('tiny-cpu').should('not.exist');
+      createWorkspace.findPodConfigCard('medium-cpu').should('not.exist');
+    });
+
+    it('should uncheck label filter and restore filtered pod configs', () => {
+      createWorkspace.clickLabelFilter('cpu', '1');
+      createWorkspace.assertLabelFilterChecked('cpu', '1');
+
+      createWorkspace.findPodConfigCard('tiny-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-cpu').should('not.exist');
+
+      createWorkspace.clickLabelFilter('cpu', '1');
+      createWorkspace.assertLabelFilterNotChecked('cpu', '1');
+
+      createWorkspace.findPodConfigCard('tiny-cpu').should('be.visible');
+      createWorkspace.findPodConfigCard('small-cpu').should('be.visible');
+    });
+
+    it('should show no results when no pod configs match filter', () => {
+      createWorkspace.clickLabelFilter('cpu', '1');
+      createWorkspace.clickLabelFilter('memory', '16Gi');
+
+      createWorkspace.assertNoResultsFound();
+    });
+
+    it('should format label keys correctly', () => {
+      createWorkspace.findLabelCategory('cpu').should('contain', 'CPU');
+      createWorkspace.findLabelCategory('memory').should('contain', 'Memory');
+      createWorkspace.findLabelCategory('gpu').should('contain', 'GPU');
+    });
+  });
+
+  describe('UI state', () => {
+    it('should maintain selected pod config when navigating back and forth', () => {
+      createWorkspace.clickLabelFilter('cpu', '2');
+      createWorkspace.selectPodConfig('small-cpu');
+
+      createWorkspace.clickNext();
+      createWorkspace.assertProgressStepVisible(STEP_NAMES.PROPERTIES);
+
+      createWorkspace.clickPrevious();
+      createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
+
+      createWorkspace.assertPodConfigSelected('small-cpu');
+    });
+
+    it('should preserve selected pod config when applying filters', () => {
+      createWorkspace.selectPodConfig('small-cpu');
+      createWorkspace.assertPodConfigSelected('small-cpu');
+
+      createWorkspace.clickLabelFilter('cpu', '2');
+
+      createWorkspace.assertPodConfigSelected('small-cpu');
+      createWorkspace.findPodConfigCard('small-cpu').should('be.visible');
+    });
+  });
+
+  describe('No extra filters', () => {
+    it('should not display extra filters category for pod configs', () => {
+      cy.findByTestId('extra-filters-category').should('not.exist');
+    });
+  });
+});

--- a/workspaces/frontend/src/__tests__/cypress/cypress/utils/testBuilders.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/utils/testBuilders.ts
@@ -118,3 +118,48 @@ export const createMockPodTemplateWithImage = (
       }),
     }),
   });
+
+export const buildMockImageWithLabels = (
+  id: string,
+  displayName: string,
+  labels: { key: string; value: string }[],
+  hidden = false,
+): {
+  id: string;
+  displayName: string;
+  description: string;
+  labels: { key: string; value: string }[];
+  hidden: boolean;
+  redirect?: undefined;
+  clusterMetrics?: undefined;
+} => ({
+  id,
+  displayName,
+  description: `Image: ${displayName}`,
+  labels,
+  hidden,
+  redirect: undefined,
+  clusterMetrics: undefined,
+});
+
+export const buildMockPodConfigWithLabels = (
+  id: string,
+  displayName: string,
+  labels: { key: string; value: string }[],
+): {
+  id: string;
+  displayName: string;
+  description: string;
+  labels: { key: string; value: string }[];
+  hidden: boolean;
+  redirect?: undefined;
+  clusterMetrics?: undefined;
+} => ({
+  id,
+  displayName,
+  description: `Pod config: ${displayName}`,
+  labels,
+  hidden: false,
+  redirect: undefined,
+  clusterMetrics: undefined,
+});

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageList.tsx
@@ -85,31 +85,29 @@ export const WorkspaceFormImageList: React.FunctionComponent<WorkspaceFormImageL
         )}
         {filteredWorkspaceImages.length > 0 && (
           <Gallery hasGutter aria-label="Selectable card container">
-            {filteredWorkspaceImages
-              .filter((image) => !image.hidden)
-              .map((image) => (
-                <Card
-                  isCompact
-                  isSelectable
-                  key={image.id}
-                  id={image.id.replace(/ /g, '-')}
-                  isSelected={image.id === selectedImage?.id}
-                  onClick={() => handleCardClick(image)}
+            {filteredWorkspaceImages.map((image) => (
+              <Card
+                isCompact
+                isSelectable
+                key={image.id}
+                id={image.id.replace(/ /g, '-')}
+                isSelected={image.id === selectedImage?.id}
+                onClick={() => handleCardClick(image)}
+              >
+                <CardHeader
+                  selectableActions={{
+                    selectableActionId: `selectable-actions-item-${image.id.replace(/ /g, '-')}`,
+                    selectableActionAriaLabelledby: image.displayName.replace(/ /g, '-'),
+                    name: image.displayName,
+                    variant: 'single',
+                    onChange,
+                  }}
                 >
-                  <CardHeader
-                    selectableActions={{
-                      selectableActionId: `selectable-actions-item-${image.id.replace(/ /g, '-')}`,
-                      selectableActionAriaLabelledby: image.displayName.replace(/ /g, '-'),
-                      name: image.displayName,
-                      variant: 'single',
-                      onChange,
-                    }}
-                  >
-                    <CardTitle>{image.displayName}</CardTitle>
-                    <CardBody>{image.id}</CardBody>
-                  </CardHeader>
-                </Card>
-              ))}
+                  <CardTitle>{image.displayName}</CardTitle>
+                  <CardBody>{image.id}</CardBody>
+                </CardHeader>
+              </Card>
+            ))}
           </Gallery>
         )}
       </PageSection>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
@@ -2,7 +2,10 @@ import React, { useMemo, useState } from 'react';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import { WorkspaceFormImageList } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageList';
-import { FilterByLabels } from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
+import {
+  ExtraFilter,
+  FilterByLabels,
+} from '~/app/pages/Workspaces/Form/labelFilter/FilterByLabels';
 import { WorkspacekindsImageConfigValue } from '~/generated/data-contracts';
 
 interface WorkspaceFormImageSelectionProps {
@@ -18,14 +21,35 @@ const WorkspaceFormImageSelection: React.FunctionComponent<WorkspaceFormImageSel
 }) => {
   const [filteredImages, setFilteredImages] = useState<WorkspacekindsImageConfigValue[]>(images);
 
+  const extraFilters: ExtraFilter<WorkspacekindsImageConfigValue>[] = useMemo(
+    () => [
+      {
+        label: 'Show hidden',
+        value: false,
+        key: 'showHidden',
+        matchesFilter: (image: WorkspacekindsImageConfigValue, value: boolean) =>
+          value || !image.hidden,
+      },
+      {
+        label: 'Show redirected',
+        value: false,
+        key: 'showRedirected',
+        matchesFilter: (image: WorkspacekindsImageConfigValue, value: boolean) =>
+          value || image.redirect === undefined,
+      },
+    ],
+    [],
+  );
+
   const imageFilterContent = useMemo(
     () => (
       <FilterByLabels
         labelledObjects={images}
         setLabelledObjects={(obj) => setFilteredImages(obj as WorkspacekindsImageConfigValue[])}
+        extraFilters={extraFilters}
       />
     ),
-    [images, setFilteredImages],
+    [images, setFilteredImages, extraFilters],
   );
 
   return (

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/labelFilter/FilterByLabels.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/labelFilter/FilterByLabels.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FilterSidePanel,
   FilterSidePanelCategory,
@@ -7,20 +7,34 @@ import {
 import '@patternfly/react-catalog-view-extension/dist/css/react-catalog-view-extension.css';
 import { formatLabelKey } from '~/shared/utilities/WorkspaceUtils';
 
-type FilterByLabelsProps = {
-  labelledObjects: { labels: { key: string; value: string }[] }[];
-  setLabelledObjects: (labelledObjects: { labels: { key: string; value: string }[] }[]) => void;
+type LabelledObject<T> = { labels: { key: string; value: string }[] } & T;
+
+export type ExtraFilter<T> = {
+  key: string;
+  value: boolean;
+  label: string;
+  matchesFilter: (obj: LabelledObject<T>, value: boolean) => boolean;
 };
 
-export const FilterByLabels: React.FunctionComponent<FilterByLabelsProps> = ({
-  labelledObjects,
-  setLabelledObjects,
-}) => {
+type FilterByLabelsProps<T> = {
+  labelledObjects: LabelledObject<T>[];
+  setLabelledObjects: (labelledObjects: LabelledObject<T>[]) => void;
+  extraFilters?: ExtraFilter<T>[];
+};
+
+export const FilterByLabels = <T,>(props: FilterByLabelsProps<T>): React.ReactElement => {
   const [selectedLabels, setSelectedLabels] = useState<Map<string, Set<string>>>(new Map());
+  const [selectedExtraFilters, setSelectedExtraFilters] = useState<Map<string, ExtraFilter<T>>>(
+    () => {
+      const extraFiltersMap = new Map();
+      props.extraFilters?.map((extraFilter) => extraFiltersMap.set(extraFilter.key, extraFilter));
+      return extraFiltersMap;
+    },
+  );
 
   const filterMap = useMemo(() => {
     const labelsMap = new Map<string, Set<string>>();
-    labelledObjects
+    props.labelledObjects
       .flatMap((labelledObject) => labelledObject.labels)
       .forEach((label) => {
         if (!labelsMap.has(label.key)) {
@@ -29,12 +43,42 @@ export const FilterByLabels: React.FunctionComponent<FilterByLabelsProps> = ({
         labelsMap.get(label.key)?.add(label.value);
       });
     return labelsMap;
-  }, [labelledObjects]);
+  }, [props.labelledObjects]);
 
-  const isChecked = useCallback(
+  const isLabelChecked = useCallback(
     (label: string, labelValue: string) => selectedLabels.get(label)?.has(labelValue),
     [selectedLabels],
   );
+
+  const updateLabelledObjects = useCallback(() => {
+    props.setLabelledObjects(
+      props.labelledObjects.filter(
+        (labelledObject) =>
+          [...selectedExtraFilters.values()].reduce(
+            (accumulator, selectedExtraFilter) =>
+              accumulator &&
+              selectedExtraFilter.matchesFilter(labelledObject, selectedExtraFilter.value),
+            true,
+          ) &&
+          [...selectedLabels.entries()].reduce(
+            (accumulator, [selectedLabelKey, selectedLabelValues]) => {
+              if (selectedLabelValues.size > 0) {
+                return (
+                  accumulator &&
+                  labelledObject.labels.some(
+                    (imageLabel) =>
+                      imageLabel.key === selectedLabelKey &&
+                      selectedLabelValues.has(imageLabel.value),
+                  )
+                );
+              }
+              return accumulator;
+            },
+            true,
+          ),
+      ),
+    );
+  }, [selectedExtraFilters, selectedLabels, props]);
 
   const onChange = useCallback(
     (labelKey: string, labelValue: string, event: React.SyntheticEvent<HTMLElement>) => {
@@ -54,40 +98,59 @@ export const FilterByLabels: React.FunctionComponent<FilterByLabelsProps> = ({
         }
       }
 
-      setLabelledObjects(
-        labelledObjects.filter((labelledObject) =>
-          [...newSelectedLabels.entries()].reduce(
-            (accumulator, [selectedLabelKey, selectedLabelValues]) => {
-              if (selectedLabelValues.size > 0) {
-                return (
-                  accumulator &&
-                  labelledObject.labels.some(
-                    (imageLabel) =>
-                      imageLabel.key === selectedLabelKey &&
-                      selectedLabelValues.has(imageLabel.value),
-                  )
-                );
-              }
-              return accumulator;
-            },
-            true,
-          ),
-        ),
-      );
-
       setSelectedLabels(newSelectedLabels);
     },
-    [selectedLabels, labelledObjects, setLabelledObjects],
+    [selectedLabels],
   );
 
+  const onChangeExtraFilters = useCallback(
+    (extraFilter: ExtraFilter<T>, event: React.SyntheticEvent<HTMLElement>) => {
+      const { checked } = event.currentTarget as HTMLInputElement;
+      const newSelectedExtraFilters: Map<string, ExtraFilter<T>> = new Map(selectedExtraFilters);
+
+      newSelectedExtraFilters.set(extraFilter.key, {
+        key: extraFilter.key,
+        value: checked,
+        label: extraFilter.label,
+        matchesFilter: extraFilter.matchesFilter,
+      });
+
+      setSelectedExtraFilters(newSelectedExtraFilters);
+    },
+    [selectedExtraFilters],
+  );
+
+  useEffect(() => {
+    updateLabelledObjects();
+  }, [selectedLabels, selectedExtraFilters, updateLabelledObjects]);
+
   return (
-    <FilterSidePanel id="filter-panel">
+    <FilterSidePanel id="filter-panel" data-testid="label-filter-panel">
+      {selectedExtraFilters.size > 0 && (
+        <FilterSidePanelCategory key="extraFilters" data-testid="extra-filters-category">
+          {[...selectedExtraFilters.values()].map((extraFilter) => (
+            <FilterSidePanelCategoryItem
+              key={extraFilter.key}
+              data-testid={`extra-filter-${extraFilter.key}`}
+              checked={extraFilter.value}
+              onClick={(e) => onChangeExtraFilters(extraFilter, e)}
+            >
+              {extraFilter.label}
+            </FilterSidePanelCategoryItem>
+          ))}
+        </FilterSidePanelCategory>
+      )}
       {[...filterMap.keys()].map((label) => (
-        <FilterSidePanelCategory key={label} title={formatLabelKey(label)}>
+        <FilterSidePanelCategory
+          key={label}
+          data-testid={`label-category-${label}`}
+          title={formatLabelKey(label)}
+        >
           {Array.from(filterMap.get(label)?.values() ?? []).map((labelValue) => (
             <FilterSidePanelCategoryItem
               key={`${label}|||${labelValue}`}
-              checked={isChecked(label, labelValue)}
+              data-testid={`label-filter-${label}-${labelValue}`}
+              checked={isLabelChecked(label, labelValue)}
               onClick={(e) => onChange(label, labelValue, e)}
             >
               {labelValue}

--- a/workspaces/frontend/src/shared/mock/mockBuilder.ts
+++ b/workspaces/frontend/src/shared/mock/mockBuilder.ts
@@ -297,13 +297,6 @@ export const buildMockWorkspaceKind = (
               { key: 'jupyterlabVersion', value: '2.1.0' },
             ],
             hidden: false,
-            redirect: {
-              to: 'jupyterlab_scipy_220',
-              message: {
-                text: 'This update will change...',
-                level: WorkspacekindsRedirectMessageLevel.RedirectMessageLevelWarning,
-              },
-            },
             clusterMetrics: {
               workspacesCount: 3,
             },


### PR DESCRIPTION
closes: https://github.com/kubeflow/notebooks/issues/919

Adds two extra filters to the left column while listing images during Workspace creation: `Show hidden` and `Show redirected`.

<img width="1420" height="628" alt="image" src="https://github.com/user-attachments/assets/45ad65bc-80b3-40a8-9d8e-2f2879f0fb9b" />


<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->