### PR TITLE
fix: allow empty deprecationMessage in WorkspaceKind spawner

### DIFF
--- a/workspaces/controller/api/v1beta1/workspacekind_types.go
+++ b/workspaces/controller/api/v1beta1/workspacekind_types.go
@@ -46,7 +46,7 @@ type WorkspaceKindSpec struct {
 	PodTemplate WorkspaceKindPodTemplate `json:"podTemplate"`
 }
 
-// +kubebuilder:validation:XValidation:message="deprecationMessage must be empty or at least 2 characters",rule="!has(self.deprecationMessage) || self.deprecationMessage == ” || size(self.deprecationMessage) >= 2"
+// +kubebuilder:validation:XValidation:message="deprecationMessage must be empty or at least 2 characters",rule="!has(self.deprecationMessage) || size(self.deprecationMessage) == 0 || size(self.deprecationMessage) >= 2"
 type WorkspaceKindSpawner struct {
 	// the display name of the WorkspaceKind
 	// +kubebuilder:validation:MinLength:=2

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
@@ -4563,8 +4563,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: deprecationMessage must be empty or at least 2 characters
-                  rule: '!has(self.deprecationMessage) || self.deprecationMessage
-                    == ” || size(self.deprecationMessage) >= 2'
+                  rule: '!has(self.deprecationMessage) || size(self.deprecationMessage)
+                    == 0 || size(self.deprecationMessage) >= 2'
             required:
             - podTemplate
             - spawner


### PR DESCRIPTION
closes: #910 

## Changes

- **CEL validation** on `WorkspaceKindSpawner`: allow missing, empty, or non-empty with length ≥ 2; otherwise validation fails with a clear message.
- **OpenAPI**: removed `MinLength` from `deprecationMessage` so the schema accepts `""`; non-empty length is enforced only by the CEL rule above.
