### PR TITLE
docs: Document current feature status of notebooks v2

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,28 @@
+# Current status of Kubeflow Notebooks v2
+
+> [!WARNING]
+>
+> Kubeflow Notebooks v2 is __not yet released__ and currently in an alpha stage.
+> We are actively developing the first stable release and will share updates soon.
+> See [`kubeflow/notebooks#85`](https://github.com/kubeflow/notebooks/issues/85) for more details.
+
+| Feature                                   | Frontend      | Backend      | Controller   |
+| ----------------------------------------- | ------------- | ------------ | ------------ |
+| **Create a `Workspace`**                  | 🚧 Partially | ✅ Available | ✅ Available |
+| **Delete a `Workspace`**                  | ✅ Available  | ✅ Available | ✅ Available |
+| **Edit a `Workspace`**                    | 🚧 Partially | ✅ Available | ✅ Available |
+| **Create a `WorkspaceKind`**              | 🚧 Partially | ✅ Available | ✅ Available |
+| **Delete a `WorkspaceKind`**              | 📆 Planned   | 📆 Planned  | 📆 Planned  |
+| **Modify a `WorkspaceKind`**              | 📆 Planned   | 📆 Planned  | 📆 Planned  |
+| **Apply an image redirect / deprecation** | 🚧 Partially | ✅ Available | ✅ Available |
+| **Manage a `Secret`**                     | ✅ Available  | ✅ Available | ✅ Available |
+| **Manage a `PersistentVolumeClaim`**      | ✅ Available  | ✅ Available | ✅ Available |
+| **Culling / ACLs**                        | 📆 Planned   | 📆 Planned  | 📆 Planned  |
+| **SSH access to a `Workspace`**           | 📆 Planned   | 📆 Planned  | 📆 Planned  |
+| **Authentication**                        | 📆 Planned   | 📆 Planned  | 📆 Planned  |
+
+Currently all `CustomResourceDefinitions` are unstable as denoted by `beta` their respective versions.
+
+## Feedbacks and Bug Reporting
+
+TBA reference CONTRIBUTING.md


### PR DESCRIPTION
> [!NOTE]
> This change is a WIP and the feature status displayed in the table is not yet accurate. 

The idea of this change is to have a source of truth where users can be pointed to in order to understand the current state of the project. We also want to link this state in the pre-GA banner (see #836 for more details on the banner).

The structure of the table is roughly inspired by https://github.com/kubeflow/sdk?tab=readme-ov-file#supported-kubeflow-projects

---

Feedback would be appreciated in general but especially on the following points:
- Is the current granularity too fine? Do we need to focus on higher-level / user-visible features?
- What is the current status on some of those features?
- Should we also add a link to documentation or details of each feature?
- Is the structure in a table good for the information that we want to convey or should we break it up into a list?