### PR TITLE
fix: Wrap empty-state table row in Tbody to fix validateDOMNesting warning

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
@@ -28,7 +28,7 @@ class Workspaces {
   }
 
   findWorkspacesTableRows() {
-    return this.findWorkspacesTable().find('tbody tr');
+    return this.findWorkspacesTable().find('tr[data-testid^="workspace-row-"]');
   }
 
   findWorkspaceTableRow(workspaceName: string) {

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -562,11 +562,13 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                 </Tbody>
               ))}
           {sortedWorkspaces.length === 0 && (
-            <Tr>
-              <Td colSpan={8} id="empty-state-cell">
-                <Bullseye>{emptyState}</Bullseye>
-              </Td>
-            </Tr>
+            <Tbody>
+              <Tr>
+                <Td colSpan={8} id="empty-state-cell">
+                  <Bullseye>{emptyState}</Bullseye>
+                </Td>
+              </Tr>
+            </Tbody>
           )}
         </Table>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>


### PR DESCRIPTION

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Closes #927 

Before:
<img width="1512" height="859" alt="Screenshot 2026-02-23 at 11 18 55 AM" src="https://github.com/user-attachments/assets/91445fb3-7212-4f5e-930d-c80f88314e2c" />

After:
<img width="1505" height="848" alt="Screenshot 2026-02-23 at 11 18 31 AM" src="https://github.com/user-attachments/assets/6b60ae13-9dc1-428a-a8d9-5fe67935b2e4" />
