### PR TITLE
feat: Workspace Kind Create UI improvements

### DIFF
--- a/workspaces/frontend/.env
+++ b/workspaces/frontend/.env
@@ -6,3 +6,4 @@ FAVICON=favicon.ico
 PRODUCT_NAME="Notebooks"
 KUBEFLOW_USERNAME=user@example.com
 COMPANY_URI=oci://kubeflow.io
+WORKSPACE_KIND_EXAMPLES_URL=https://github.com/kubeflow/notebooks/tree/notebooks-v2/workspaces/controller/manifests/kustomize/samples

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -30,3 +30,8 @@ body,
 .pf-v6-c-file-upload__file-details .pf-v6-c-form-control {
   height: 100%;
 }
+
+/* Grey background for read-only file upload textarea */
+.workspacekind-file-upload .pf-v6-c-form-control:has(textarea[readonly]) {
+  background-color: var(--pf-t--global--background--color--disabled--default);
+}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -13,7 +13,7 @@ import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { WorkspaceKindFormData } from '~/app/types';
 import { extractErrorMessage, safeApiCall } from '~/shared/api/apiUtils';
 import { ErrorAlert } from '~/shared/components/ErrorAlert';
-import { CONTENT_TYPE_KEY } from '~/shared/utilities/const';
+import { CONTENT_TYPE_KEY, WORKSPACE_KIND_EXAMPLES_URL } from '~/shared/utilities/const';
 import { ContentType } from '~/shared/utilities/types';
 import { LoadError } from '~/app/components/LoadError';
 import { ApiErrorEnvelope, WorkspacekindsWorkspaceKind } from '~/generated/data-contracts';
@@ -129,10 +129,19 @@ export const WorkspaceKindForm: React.FC = () => {
                   {`${mode === 'create' ? 'Create' : 'Edit'} workspace kind`}
                 </Content>
                 <Content component={ContentVariants.p}>
-                  {mode === 'create'
-                    ? `Please upload or drag and drop a Workspace Kind YAML file.`
-                    : `View and edit the Workspace Kind's information. Some fields may not be
-                      represented in this form`}
+                  {mode === 'create' ? (
+                    <p>
+                      Please upload or drag and drop a Workspace Kind YAML file. Sample Workspace
+                      Kind YAML files can be downloaded from the{' '}
+                      <a href={WORKSPACE_KIND_EXAMPLES_URL} target="_blank" rel="noreferrer">
+                        Kubeflow Notebooks
+                      </a>{' '}
+                      repository.
+                    </p>
+                  ) : (
+                    `View and edit the Workspace Kind's information. Some fields may not be
+                      represented in this form`
+                  )}
                 </Content>
               </FlexItem>
             </Flex>

--- a/workspaces/frontend/src/shared/utilities/const.ts
+++ b/workspaces/frontend/src/shared/utilities/const.ts
@@ -15,6 +15,9 @@ export const URL_PREFIX = process.env.URL_PREFIX ?? '/workspaces';
 export const BFF_API_VERSION = 'v1';
 export const MANDATORY_NAMESPACE = process.env.MANDATORY_NAMESPACE || undefined;
 export const COMPANY_URI = process.env.COMPANY_URI || 'oci://kubeflow.io';
+export const WORKSPACE_KIND_EXAMPLES_URL =
+  process.env.WORKSPACE_KIND_EXAMPLES_URL ||
+  'https://github.com/kubeflow/notebooks/tree/notebooks-v2/workspaces/controller/manifests/kustomize/samples';
 export const MOCK_API_ENABLED = process.env.MOCK_API_ENABLED === 'true';
 export const SHOW_PRE_GA_BANNER = process.env.SHOW_PRE_GA_BANNER === 'true';
 


### PR DESCRIPTION
 closes: #916

Description:

- Grey out textarea in WorkspaceKindFileUpload once there is a file change
- Provide link to Workspace Kind samples in the repo

Before:
<img width="1494" height="754" alt="Screenshot 2026-02-24 at 4 13 40 PM" src="https://github.com/user-attachments/assets/43e0c3f0-797e-4dc0-b758-f2c6d914e87b" />


After:
<img width="1497" height="731" alt="Screenshot 2026-02-24 at 4 13 24 PM" src="https://github.com/user-attachments/assets/9dfb6299-691c-47f7-8cb8-0992cfb2c0f3" />
