### PR TITLE
feat: add display name support for workspaces

### DIFF
--- a/workspaces/backend/api/suite_test.go
+++ b/workspaces/backend/api/suite_test.go
@@ -176,8 +176,9 @@ func NewExampleWorkspace(name string, namespace string, workspaceKind string) *k
 			Namespace: namespace,
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
-			Paused: ptr.To(false),
-			Kind:   workspaceKind,
+			Paused:      ptr.To(false),
+			DisplayName: ptr.To("Example Workspace"),
+			Kind:        workspaceKind,
 			PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspacePodMetadata{
 					Labels:      nil,

--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -67,6 +67,8 @@ var _ = Describe("Workspaces Handler", func() {
 			workspaceKey2  types.NamespacedName
 			workspaceName3 string
 			workspaceKey3  types.NamespacedName
+			workspaceName4 string
+			workspaceKey4  types.NamespacedName
 
 			workspaceKindName string
 			workspaceKindKey  types.NamespacedName
@@ -80,6 +82,8 @@ var _ = Describe("Workspaces Handler", func() {
 			workspaceKey2 = types.NamespacedName{Name: workspaceName2, Namespace: namespaceName1}
 			workspaceName3 = fmt.Sprintf("workspace-3-%s", uniqueName)
 			workspaceKey3 = types.NamespacedName{Name: workspaceName3, Namespace: namespaceName2}
+			workspaceName4 = fmt.Sprintf("workspace-4-%s", uniqueName)
+			workspaceKey4 = types.NamespacedName{Name: workspaceName4, Namespace: namespaceName1}
 			workspaceKindName = fmt.Sprintf("workspacekind-%s", uniqueName)
 			workspaceKindKey = types.NamespacedName{Name: workspaceKindName}
 
@@ -114,6 +118,11 @@ var _ = Describe("Workspaces Handler", func() {
 			By("creating Workspace 3 in Namespace 2")
 			workspace3 := NewExampleWorkspace(workspaceName3, namespaceName2, workspaceKindName)
 			Expect(k8sClient.Create(ctx, workspace3)).To(Succeed())
+
+			By("creating Workspace with nil DisplayName in Namespace 1")
+			workspaceNilDN := NewExampleWorkspace(workspaceName4, namespaceName1, workspaceKindName)
+			workspaceNilDN.Spec.DisplayName = nil
+			Expect(k8sClient.Create(ctx, workspaceNilDN)).To(Succeed())
 		})
 
 		AfterAll(func() {
@@ -143,6 +152,15 @@ var _ = Describe("Workspaces Handler", func() {
 				},
 			}
 			Expect(k8sClient.Delete(ctx, workspace3)).To(Succeed())
+
+			By("deleting Workspace with nil DisplayName from Namespace 1")
+			workspaceNilDN := &kubefloworgv1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workspaceName4,
+					Namespace: namespaceName1,
+				},
+			}
+			Expect(k8sClient.Delete(ctx, workspaceNilDN)).To(Succeed())
 
 			By("deleting WorkspaceKind")
 			workspaceKind := &kubefloworgv1beta1.WorkspaceKind{
@@ -207,12 +225,15 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKey2, workspace2)).To(Succeed())
 			workspace3 := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey3, workspace3)).To(Succeed())
+			workspaceNilDN := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey4, workspaceNilDN)).To(Succeed())
 
 			By("ensuring the response contains the expected Workspaces")
 			Expect(response.Data).To(ConsistOf(
 				models.NewWorkspaceListItemFromWorkspace(a.Config, workspace1, workspaceKind),
 				models.NewWorkspaceListItemFromWorkspace(a.Config, workspace2, workspaceKind),
 				models.NewWorkspaceListItemFromWorkspace(a.Config, workspace3, workspaceKind),
+				models.NewWorkspaceListItemFromWorkspace(a.Config, workspaceNilDN, workspaceKind),
 			))
 
 			By("ensuring the response can be marshaled to JSON and back to []WorkspaceListItem")
@@ -262,11 +283,14 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace1)).To(Succeed())
 			workspace2 := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey2, workspace2)).To(Succeed())
+			workspaceNilDN := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey4, workspaceNilDN)).To(Succeed())
 
 			By("ensuring the response contains the expected Workspaces")
 			Expect(response.Data).To(ConsistOf(
 				models.NewWorkspaceListItemFromWorkspace(a.Config, workspace1, workspaceKind),
 				models.NewWorkspaceListItemFromWorkspace(a.Config, workspace2, workspaceKind),
+				models.NewWorkspaceListItemFromWorkspace(a.Config, workspaceNilDN, workspaceKind),
 			))
 
 			By("ensuring the response can be marshaled to JSON and back to []WorkspaceListItem")
@@ -327,6 +351,51 @@ var _ = Describe("Workspaces Handler", func() {
 			var dataObject models.WorkspaceUpdate
 			err = json.Unmarshal(dataJSON, &dataObject)
 			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal JSON to WorkspaceUpdate")
+		})
+
+		It("should retrieve a single Workspace with nil DisplayName successfully", func() {
+			By("creating the HTTP request")
+			path := strings.Replace(constants.WorkspacesByNamePath, ":"+constants.NamespacePathParam, namespaceName1, 1)
+			path = strings.Replace(path, ":"+constants.ResourceNamePathParam, workspaceName4, 1)
+			req, err := http.NewRequest(http.MethodGet, path, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetWorkspaceHandler")
+			ps := httprouter.Params{
+				httprouter.Param{Key: constants.NamespacePathParam, Value: namespaceName1},
+				httprouter.Param{Key: constants.ResourceNamePathParam, Value: workspaceName4},
+			}
+			rr := httptest.NewRecorder()
+			a.GetWorkspaceHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response JSON to WorkspaceEnvelope")
+			var response WorkspaceEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("getting the Workspace from the Kubernetes API")
+			workspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey4, workspace)).To(Succeed())
+
+			By("ensuring the response matches the expected WorkspaceUpdate with empty DisplayName")
+			expectedWorkspaceUpdate := models.NewWorkspaceUpdateModelFromWorkspace(workspace)
+			if len(expectedWorkspaceUpdate.PodTemplate.Volumes.Secrets) == 0 {
+				expectedWorkspaceUpdate.PodTemplate.Volumes.Secrets = nil
+			}
+			Expect(response.Data).To(BeComparableTo(expectedWorkspaceUpdate))
+			Expect(response.Data.DisplayName).To(Equal(""))
 		})
 	})
 
@@ -773,9 +842,10 @@ var _ = Describe("Workspaces Handler", func() {
 
 			By("defining a WorkspaceCreate model")
 			workspaceCreate := &models.WorkspaceCreate{
-				Name:   workspaceName,
-				Kind:   workspaceKindName,
-				Paused: false,
+				Name:        workspaceName,
+				DisplayName: "My Test Workspace",
+				Kind:        workspaceKindName,
+				Paused:      false,
 				PodTemplate: models.PodTemplateMutate{
 					PodMetadata: models.PodMetadataMutate{
 						Labels: map[string]string{
@@ -837,6 +907,7 @@ var _ = Describe("Workspaces Handler", func() {
 
 			By("ensuring the created Workspace matches the expected Workspace")
 			Expect(createdWorkspace.ObjectMeta.Name).To(Equal(workspaceName))
+			Expect(createdWorkspace.Spec.DisplayName).To(Equal(ptr.To(workspaceCreate.DisplayName)))
 			Expect(createdWorkspace.Spec.Kind).To(Equal(workspaceKindName))
 			Expect(createdWorkspace.Spec.Paused).To(Equal(&workspaceCreate.Paused))
 			Expect(createdWorkspace.Spec.PodTemplate.PodMetadata.Labels).To(Equal(workspaceCreate.PodTemplate.PodMetadata.Labels))
@@ -933,8 +1004,9 @@ var _ = Describe("Workspaces Handler", func() {
 
 			// Create a workspace with secrets
 			workspace := &models.WorkspaceCreate{
-				Name: "test-workspace",
-				Kind: workspaceKindName,
+				Name:        "test-workspace",
+				DisplayName: "Test Workspace",
+				Kind:        workspaceKindName,
 				PodTemplate: models.PodTemplateMutate{
 					Options: models.PodTemplateOptionsMutate{
 						ImageConfig: "jupyterlab_scipy_180",
@@ -996,13 +1068,85 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(Equal(expected))
 		})
 
+		It("should create a Workspace without displayName successfully", func() {
+			wsName := "workspace-no-display-name"
+			wsKey := types.NamespacedName{Name: wsName, Namespace: namespaceNameCrud}
+
+			By("defining a WorkspaceCreate model without displayName")
+			workspaceCreate := &models.WorkspaceCreate{
+				Name:   wsName,
+				Kind:   workspaceKindName,
+				Paused: false,
+				PodTemplate: models.PodTemplateMutate{
+					PodMetadata: models.PodMetadataMutate{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+					Volumes: models.PodVolumesMutate{
+						Home: ptr.To("my-home-pvc"),
+						Data: []models.PodVolumeMount{
+							{
+								PVCName:   "my-data-pvc",
+								MountPath: "/data/1",
+								ReadOnly:  false,
+							},
+						},
+					},
+					Options: models.PodTemplateOptionsMutate{
+						ImageConfig: "jupyterlab_scipy_180",
+						PodConfig:   "tiny_cpu",
+					},
+				},
+			}
+			bodyEnvelope := WorkspaceCreateEnvelope{Data: workspaceCreate}
+
+			By("marshaling the WorkspaceCreate model to JSON")
+			bodyEnvelopeJSON, err := json.Marshal(bodyEnvelope)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating an HTTP request to create the Workspace")
+			path := strings.Replace(constants.WorkspacesByNamespacePath, ":"+constants.NamespacePathParam, namespaceNameCrud, 1)
+			req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(string(bodyEnvelopeJSON)))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", constants.MediaTypeJson)
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing CreateWorkspaceHandler")
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{
+					Key:   constants.NamespacePathParam,
+					Value: namespaceNameCrud,
+				},
+			}
+			a.CreateWorkspaceHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("getting the created Workspace from the Kubernetes API")
+			createdWorkspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, wsKey, createdWorkspace)).To(Succeed())
+
+			By("ensuring the created Workspace has nil displayName")
+			Expect(createdWorkspace.Spec.DisplayName).To(BeNil())
+
+			By("deleting the Workspace")
+			Expect(k8sClient.Delete(ctx, createdWorkspace)).To(Succeed())
+		})
+
 		It("should update a Workspace successfully", func() {
 
 			By("creating a Workspace via the API")
 			workspaceCreate := &models.WorkspaceCreate{
-				Name:   workspaceName,
-				Kind:   workspaceKindName,
-				Paused: false,
+				Name:        workspaceName,
+				DisplayName: "Original Display Name",
+				Kind:        workspaceKindName,
+				Paused:      false,
 				PodTemplate: models.PodTemplateMutate{
 					PodMetadata: models.PodMetadataMutate{
 						Labels: map[string]string{
@@ -1047,15 +1191,17 @@ var _ = Describe("Workspaces Handler", func() {
 			defer rs.Body.Close()
 			Expect(rs.StatusCode).To(Equal(http.StatusCreated), descUnexpectedHTTPStatus, rr.Body.String())
 
-			By("getting the Workspace from the Kubernetes API to obtain its current revision")
+			By("verifying the created Workspace has the original display name")
 			createdWorkspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey, createdWorkspace)).To(Succeed())
+			Expect(createdWorkspace.Spec.DisplayName).To(Equal(ptr.To("Original Display Name")))
 			originalRevision := commonModels.CalculateRevision(&createdWorkspace.ObjectMeta)
 
-			By("building a WorkspaceUpdate model with changed fields")
+			By("building a WorkspaceUpdate model with changed fields including displayName")
 			workspaceUpdate := &models.WorkspaceUpdate{
-				Revision: originalRevision,
-				Paused:   true,
+				Revision:    originalRevision,
+				DisplayName: "Updated Display Name",
+				Paused:      true,
 				PodTemplate: models.PodTemplateMutate{
 					PodMetadata: models.PodMetadataMutate{
 						Labels: map[string]string{
@@ -1128,6 +1274,7 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(updatedWorkspace.Annotations[commonModels.AnnotationUpdatedAt]).NotTo(BeEmpty())
 
 			By("verifying all fields were applied")
+			Expect(updatedWorkspace.Spec.DisplayName).To(Equal(ptr.To("Updated Display Name")))
 			Expect(ptr.Deref(updatedWorkspace.Spec.Paused, false)).To(BeTrue())
 			Expect(updatedWorkspace.Spec.PodTemplate.PodMetadata.Labels).To(Equal(workspaceUpdate.PodTemplate.PodMetadata.Labels))
 			Expect(updatedWorkspace.Spec.PodTemplate.PodMetadata.Annotations).To(Equal(workspaceUpdate.PodTemplate.PodMetadata.Annotations))
@@ -1139,6 +1286,106 @@ var _ = Describe("Workspaces Handler", func() {
 					ReadOnly:  ptr.To(true),
 				},
 			}))
+
+			By("cleaning up the Workspace")
+			Expect(k8sClient.Delete(ctx, updatedWorkspace)).To(Succeed())
+		})
+
+		It("should clear displayName when updated with empty string", func() {
+
+			By("creating a Workspace with a display name via the API")
+			workspaceCreate := &models.WorkspaceCreate{
+				Name:        workspaceName,
+				DisplayName: "Name To Clear",
+				Kind:        workspaceKindName,
+				Paused:      false,
+				PodTemplate: models.PodTemplateMutate{
+					PodMetadata: models.PodMetadataMutate{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+					Volumes: models.PodVolumesMutate{
+						Home: ptr.To("my-home-pvc"),
+					},
+					Options: models.PodTemplateOptionsMutate{
+						ImageConfig: "jupyterlab_scipy_180",
+						PodConfig:   "tiny_cpu",
+					},
+				},
+			}
+			createEnvelope := WorkspaceCreateEnvelope{Data: workspaceCreate}
+			createJSON, err := json.Marshal(createEnvelope)
+			Expect(err).NotTo(HaveOccurred())
+
+			path := strings.Replace(constants.WorkspacesByNamespacePath, ":"+constants.NamespacePathParam, namespaceNameCrud, 1)
+			req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(string(createJSON)))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", constants.MediaTypeJson)
+			req.Header.Set(userIdHeader, adminUser)
+
+			rr := httptest.NewRecorder()
+			ps := httprouter.Params{
+				httprouter.Param{Key: constants.NamespacePathParam, Value: namespaceNameCrud},
+			}
+			a.CreateWorkspaceHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("verifying the created Workspace has the display name set")
+			createdWorkspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey, createdWorkspace)).To(Succeed())
+			Expect(createdWorkspace.Spec.DisplayName).To(Equal(ptr.To("Name To Clear")))
+			originalRevision := commonModels.CalculateRevision(&createdWorkspace.ObjectMeta)
+
+			By("building a WorkspaceUpdate model with displayName omitted")
+			workspaceUpdate := &models.WorkspaceUpdate{
+				Revision: originalRevision,
+				Paused:   false,
+				PodTemplate: models.PodTemplateMutate{
+					PodMetadata: models.PodMetadataMutate{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+					Volumes: models.PodVolumesMutate{
+						Home: ptr.To("my-home-pvc"),
+					},
+					Options: models.PodTemplateOptionsMutate{
+						ImageConfig: "jupyterlab_scipy_180",
+						PodConfig:   "tiny_cpu",
+					},
+				},
+			}
+			updateEnvelope := WorkspaceEnvelope{Data: workspaceUpdate}
+			updateJSON, err := json.Marshal(updateEnvelope)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("executing UpdateWorkspaceHandler")
+			path = strings.Replace(constants.WorkspacesByNamePath, ":"+constants.NamespacePathParam, namespaceNameCrud, 1)
+			path = strings.Replace(path, ":"+constants.ResourceNamePathParam, workspaceName, 1)
+			req, err = http.NewRequest(http.MethodPut, path, strings.NewReader(string(updateJSON)))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", constants.MediaTypeJson)
+			req.Header.Set(userIdHeader, adminUser)
+
+			rr = httptest.NewRecorder()
+			ps = httprouter.Params{
+				httprouter.Param{Key: constants.NamespacePathParam, Value: namespaceNameCrud},
+				httprouter.Param{Key: constants.ResourceNamePathParam, Value: workspaceName},
+			}
+			a.UpdateWorkspaceHandler(rr, req, ps)
+			rs = rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("getting the updated Workspace from the Kubernetes API")
+			updatedWorkspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey, updatedWorkspace)).To(Succeed())
+
+			By("verifying the displayName was cleared back to nil")
+			Expect(updatedWorkspace.Spec.DisplayName).To(BeNil())
 
 			By("cleaning up the Workspace")
 			Expect(k8sClient.Delete(ctx, updatedWorkspace)).To(Succeed())

--- a/workspaces/backend/internal/models/workspaces/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/funcs.go
@@ -54,8 +54,9 @@ func NewWorkspaceListItemFromWorkspace(cfg *config.EnvConfig, ws *kubefloworgv1b
 	}
 
 	workspaceModel := WorkspaceListItem{
-		Name:      ws.Name,
-		Namespace: ws.Namespace,
+		Name:        ws.Name,
+		DisplayName: ptr.Deref(ws.Spec.DisplayName, ""),
+		Namespace:   ws.Namespace,
 		WorkspaceKind: WorkspaceKindInfo{
 			Name:    ws.Spec.Kind,
 			Missing: !commonWorkspaces.WskExists(wsk),

--- a/workspaces/backend/internal/models/workspaces/funcs_write.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_write.go
@@ -40,6 +40,7 @@ import (
 func NewWorkspaceCreateModelFromWorkspace(ws *kubefloworgv1beta1.Workspace) *WorkspaceCreate {
 	return &WorkspaceCreate{
 		Name:        ws.Name,
+		DisplayName: ptr.Deref(ws.Spec.DisplayName, ""),
 		Kind:        ws.Spec.Kind,
 		Paused:      ptr.Deref(ws.Spec.Paused, false),
 		PodTemplate: buildPodTemplateMutate(ws),
@@ -50,6 +51,7 @@ func NewWorkspaceCreateModelFromWorkspace(ws *kubefloworgv1beta1.Workspace) *Wor
 func NewWorkspaceUpdateModelFromWorkspace(ws *kubefloworgv1beta1.Workspace) *WorkspaceUpdate {
 	return &WorkspaceUpdate{
 		Revision:    common.CalculateRevision(&ws.ObjectMeta),
+		DisplayName: ptr.Deref(ws.Spec.DisplayName, ""),
 		Paused:      ptr.Deref(ws.Spec.Paused, false),
 		PodTemplate: buildPodTemplateMutate(ws),
 	}
@@ -211,6 +213,7 @@ func NewWorkspaceFromWorkspaceCreateModel(ctx context.Context, k8sClient client.
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
 			Paused:      &workspaceCreate.Paused,
+			DisplayName: displayNamePtr(workspaceCreate.DisplayName),
 			Kind:        workspaceCreate.Kind,
 			PodTemplate: buildWorkspacePodTemplate(&workspaceCreate.PodTemplate, homeVolumeName, dataVolumeMounts, secretMounts),
 		},
@@ -229,7 +232,15 @@ func ApplyWorkspaceUpdateModelToWorkspace(ctx context.Context, k8sClient client.
 
 	// apply model fields to workspace spec
 	workspace.Spec.Paused = ptr.To(workspaceUpdate.Paused)
+	workspace.Spec.DisplayName = displayNamePtr(workspaceUpdate.DisplayName)
 	workspace.Spec.PodTemplate = buildWorkspacePodTemplate(&workspaceUpdate.PodTemplate, workspaceUpdate.PodTemplate.Volumes.Home, dataVolumeMounts, secretMounts)
 
 	return nil
+}
+
+func displayNamePtr(displayName string) *string {
+	if displayName == "" {
+		return nil
+	}
+	return ptr.To(displayName)
 }

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -29,7 +29,9 @@ import (
 // TODO: we need to validate which fields should actually be returned in the response
 //   - should only be returning fields relevant to the list view in the UI
 type WorkspaceListItem struct {
-	Name           string                            `json:"name"`
+	Name string `json:"name"`
+	// DisplayName is an optional human-readable name for the workspace.
+	DisplayName    string                            `json:"displayName,omitempty"`
 	Namespace      string                            `json:"namespace"`
 	WorkspaceKind  WorkspaceKindInfo                 `json:"workspaceKind"`
 	Paused         bool                              `json:"paused"`

--- a/workspaces/backend/internal/models/workspaces/types_write.go
+++ b/workspaces/backend/internal/models/workspaces/types_write.go
@@ -25,7 +25,9 @@ import (
 
 // WorkspaceCreate is used to create a new workspace.
 type WorkspaceCreate struct {
-	Name        string            `json:"name"`
+	Name string `json:"name"`
+	// DisplayName is an optional human-readable name for the workspace.
+	DisplayName string            `json:"displayName,omitempty"`
 	Kind        string            `json:"kind"`
 	Paused      bool              `json:"paused"`
 	PodTemplate PodTemplateMutate `json:"podTemplate"`
@@ -60,6 +62,8 @@ type WorkspaceUpdate struct {
 	//   - Clients must not parse, interpret, or compare revision values
 	//     other than for equality, as the format is not guaranteed to be stable.
 	Revision common.RevisionString `json:"revision"`
+	// DisplayName is an optional human-readable name for the workspace.
+	DisplayName string `json:"displayName,omitempty"`
 
 	Paused      bool              `json:"paused"` // TODO: remove `paused` once we have an "actions" api for pausing workspaces
 	PodTemplate PodTemplateMutate `json:"podTemplate"`

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -7508,6 +7508,10 @@ const docTemplate = `{
                 "podTemplate"
             ],
             "properties": {
+                "displayName": {
+                    "description": "DisplayName is an optional human-readable name for the workspace.",
+                    "type": "string"
+                },
                 "kind": {
                     "type": "string"
                 },
@@ -7568,6 +7572,10 @@ const docTemplate = `{
                 "audit": {
                     "$ref": "#/definitions/common.Audit"
                 },
+                "displayName": {
+                    "description": "DisplayName is an optional human-readable name for the workspace.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -7611,6 +7619,10 @@ const docTemplate = `{
                 "revision"
             ],
             "properties": {
+                "displayName": {
+                    "description": "DisplayName is an optional human-readable name for the workspace.",
+                    "type": "string"
+                },
                 "paused": {
                     "description": "TODO: remove ` + "`" + `paused` + "`" + ` once we have an \"actions\" api for pausing workspaces",
                     "type": "boolean"

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -7506,6 +7506,10 @@
                 "podTemplate"
             ],
             "properties": {
+                "displayName": {
+                    "description": "DisplayName is an optional human-readable name for the workspace.",
+                    "type": "string"
+                },
                 "kind": {
                     "type": "string"
                 },
@@ -7566,6 +7570,10 @@
                 "audit": {
                     "$ref": "#/definitions/common.Audit"
                 },
+                "displayName": {
+                    "description": "DisplayName is an optional human-readable name for the workspace.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -7609,6 +7617,10 @@
                 "revision"
             ],
             "properties": {
+                "displayName": {
+                    "description": "DisplayName is an optional human-readable name for the workspace.",
+                    "type": "string"
+                },
                 "paused": {
                     "description": "TODO: remove `paused` once we have an \"actions\" api for pausing workspaces",
                     "type": "boolean"

--- a/workspaces/controller/api/v1beta1/workspace_types.go
+++ b/workspaces/controller/api/v1beta1/workspace_types.go
@@ -36,6 +36,13 @@ type WorkspaceSpec struct {
 	// +kubebuilder:default=false
 	Paused *bool `json:"paused,omitempty"`
 
+	// an optional human-readable name for the Workspace, displayed in the UI instead of metadata.name
+	// +kubebuilder:validation:MinLength:=1
+	// +kubebuilder:validation:MaxLength:=128
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:example:="My Workspace"
+	DisplayName *string `json:"displayName,omitempty"`
+
 	// the WorkspaceKind to use
 	// +kubebuilder:validation:MinLength:=1
 	// +kubebuilder:validation:MaxLength:=253

--- a/workspaces/controller/api/v1beta1/zz_generated.deepcopy.go
+++ b/workspaces/controller/api/v1beta1/zz_generated.deepcopy.go
@@ -1366,6 +1366,11 @@ func (in *WorkspaceSpec) DeepCopyInto(out *WorkspaceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisplayName != nil {
+		in, out := &in.DisplayName, &out.DisplayName
+		*out = new(string)
+		**out = **in
+	}
 	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
 }
 

--- a/workspaces/controller/internal/controller/suite_test.go
+++ b/workspaces/controller/internal/controller/suite_test.go
@@ -169,8 +169,9 @@ func NewExampleWorkspace1(name string, namespace string, workspaceKind string) *
 			Namespace: namespace,
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
-			Paused: ptr.To(false),
-			Kind:   workspaceKind,
+			Paused:      ptr.To(false),
+			DisplayName: ptr.To("Example Workspace"),
+			Kind:        workspaceKind,
 			PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspacePodMetadata{
 					Labels:      nil,
@@ -193,6 +194,13 @@ func NewExampleWorkspace1(name string, namespace string, workspaceKind string) *
 			},
 		},
 	}
+}
+
+// NewExampleWorkspace1WithoutDisplayName returns a Workspace with no DisplayName set (nil).
+func NewExampleWorkspace1WithoutDisplayName(name string, namespace string, workspaceKind string) *kubefloworgv1beta1.Workspace {
+	ws := NewExampleWorkspace1(name, namespace, workspaceKind)
+	ws.Spec.DisplayName = nil
+	return ws
 }
 
 // NewExampleWorkspaceKindWithConfigMapAssets returns a WorkspaceKind that uses ConfigMap-based

--- a/workspaces/controller/internal/webhook/suite_test.go
+++ b/workspaces/controller/internal/webhook/suite_test.go
@@ -757,7 +757,8 @@ func NewExampleWorkspace(name, namespace, workspaceKindName string) *kubefloworg
 			Namespace: namespace,
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
-			Kind: workspaceKindName,
+			DisplayName: ptr.To("Example Workspace"),
+			Kind:        workspaceKindName,
 			PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{Options: kubefloworgv1beta1.WorkspacePodOptions{
 				ImageConfig: "jupyterlab_scipy_180",
 				PodConfig:   "tiny_cpu",
@@ -772,4 +773,11 @@ func NewExampleWorkspaceKindWithActivityRules(name string, rules []kubefloworgv1
 	workspaceKind := NewExampleWorkspaceKind(name)
 	workspaceKind.Spec.ActivityRules = rules
 	return workspaceKind
+}
+
+// NewExampleWorkspaceWithoutDisplayName returns a Workspace with no DisplayName set (nil).
+func NewExampleWorkspaceWithoutDisplayName(name, namespace, workspaceKindName string) *kubefloworgv1beta1.Workspace {
+	ws := NewExampleWorkspace(name, namespace, workspaceKindName)
+	ws.Spec.DisplayName = nil
+	return ws
 }

--- a/workspaces/controller/internal/webhook/workspace_webhook_test.go
+++ b/workspaces/controller/internal/webhook/workspace_webhook_test.go
@@ -130,6 +130,20 @@ var _ = Describe("Workspace Webhook", func() {
 			By("deleting the Workspace")
 			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())
 		})
+
+		It("should accept a valid workspace without displayName", func() {
+			By("creating the Workspace")
+			workspace := NewExampleWorkspaceWithoutDisplayName(workspaceName, namespaceName, workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+
+			By("verifying displayName is nil")
+			created := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: workspaceName, Namespace: namespaceName}, created)).To(Succeed())
+			Expect(created.Spec.DisplayName).To(BeNil())
+
+			By("deleting the Workspace")
+			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())
+		})
 	})
 
 	Context("When updating a Workspace", Ordered, func() {

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspaces.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspaces.yaml
@@ -46,6 +46,13 @@ spec:
           spec:
             description: WorkspaceSpec defines the desired state of Workspace
             properties:
+              displayName:
+                description: an optional human-readable name for the Workspace, displayed
+                  in the UI instead of metadata.name
+                example: My Workspace
+                maxLength: 128
+                minLength: 1
+                type: string
               kind:
                 description: the WorkspaceKind to use
                 example: jupyterlab

--- a/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspace.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspace.yaml
@@ -6,6 +6,9 @@ spec:
   ## if the workspace is paused (no pods running)
   paused: false
 
+  ## an optional human-readable name, displayed in the UI instead of metadata.name
+  displayName: "Example JupyterLab Workspace"
+
   ## the WorkspaceKind to use
   kind: "jupyterlab"
 


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_

Add `displayName` as an optional field on `WorkspaceSpec`, following
the pattern established by WorkspaceKind. This allows users to set a
human-readable name for their workspaces in the UI.

Changes:
- Add `DisplayName` field to `WorkspaceSpec` CRD type (max 128 chars)
- Update backend models (`WorkspaceListItem`, `WorkspaceCreate`,
  `WorkspaceUpdate`) to read/write from the new spec field
- Mark `displayName` as optional in the API contract (`omitempty`)
- Add handler test coverage for display name round-trip
- Regenerate CRD manifests and Swagger docs