### PR TITLE
fix: use `equality.Semantic.DeepEqual` rather than `reflect.DeepEqual`

### DIFF
--- a/workspaces/controller/internal/helper/helper.go
+++ b/workspaces/controller/internal/helper/helper.go
@@ -17,15 +17,11 @@ limitations under the License.
 package helper
 
 import (
-	"reflect"
-
 	"google.golang.org/protobuf/proto"
 	istiov1 "istio.io/client-go/pkg/apis/networking/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-
-	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // copyLabelFields copies metadata.labels from desired to target, returning the updated map and whether an update is required.
@@ -80,7 +76,7 @@ func CopyStatefulSetFields(desired *appsv1.StatefulSet, target *appsv1.StatefulS
 	// TODO: confirm if StatefulSets support updates to the selector
 	//       if not, we might need to recreate the StatefulSet
 	//
-	if !reflect.DeepEqual(target.Spec.Selector, desired.Spec.Selector) {
+	if !equality.Semantic.DeepEqual(target.Spec.Selector, desired.Spec.Selector) {
 		target.Spec.Selector = desired.Spec.Selector
 		requireUpdate = true
 	}
@@ -90,7 +86,7 @@ func CopyStatefulSetFields(desired *appsv1.StatefulSet, target *appsv1.StatefulS
 	// TODO: confirm if there is a problem with doing the update at the `spec.template` level
 	//       or if only `spec.template.spec` should be updated
 	//
-	if !reflect.DeepEqual(target.Spec.Template, desired.Spec.Template) {
+	if !equality.Semantic.DeepEqual(target.Spec.Template, desired.Spec.Template) {
 		target.Spec.Template = desired.Spec.Template
 		requireUpdate = true
 	}
@@ -118,13 +114,13 @@ func CopyServiceFields(desired *corev1.Service, target *corev1.Service) bool {
 	// NOTE: we don't copy the entire `spec` because we can't overwrite the `spec.clusterIp` and similar fields
 
 	// copy `spec.ports`
-	if !reflect.DeepEqual(target.Spec.Ports, desired.Spec.Ports) {
+	if !equality.Semantic.DeepEqual(target.Spec.Ports, desired.Spec.Ports) {
 		target.Spec.Ports = desired.Spec.Ports
 		requireUpdate = true
 	}
 
 	// copy `spec.selector`
-	if !reflect.DeepEqual(target.Spec.Selector, desired.Spec.Selector) {
+	if !equality.Semantic.DeepEqual(target.Spec.Selector, desired.Spec.Selector) {
 		target.Spec.Selector = desired.Spec.Selector
 		requireUpdate = true
 	}
@@ -164,69 +160,4 @@ func CopyVirtualServiceFields(desired *istiov1.VirtualService, target *istiov1.V
 	}
 
 	return requireUpdate
-}
-
-// NormalizePodConfigSpec normalizes a PodConfigSpec so that it can be compared with reflect.DeepEqual
-func NormalizePodConfigSpec(spec kubefloworgv1beta1.PodConfigSpec) error {
-
-	// normalize Affinity
-	if spec.Affinity != nil {
-
-		// set Affinity to nil if it is empty
-		if reflect.DeepEqual(spec.Affinity, corev1.Affinity{}) {
-			spec.Affinity = nil
-		}
-	}
-
-	// normalize NodeSelector
-	if spec.NodeSelector != nil {
-
-		// set NodeSelector to nil if it is empty
-		if len(spec.NodeSelector) == 0 {
-			spec.NodeSelector = nil
-		}
-	}
-
-	// normalize Tolerations
-	if spec.Tolerations != nil {
-
-		// set Tolerations to nil if it is empty
-		if len(spec.Tolerations) == 0 {
-			spec.Tolerations = nil
-		}
-	}
-
-	// normalize Resources
-	if spec.Resources != nil {
-
-		// if Resources.Requests is empty, set it to nil
-		if len(spec.Resources.Requests) == 0 {
-			spec.Resources.Requests = nil
-		} else {
-			// otherwise, normalize the values in Resources.Requests
-			for key, value := range spec.Resources.Requests {
-				q, err := resource.ParseQuantity(value.String())
-				if err != nil {
-					return err
-				}
-				spec.Resources.Requests[key] = q
-			}
-		}
-
-		// if Resources.Limits is empty, set it to nil
-		if len(spec.Resources.Limits) == 0 {
-			spec.Resources.Limits = nil
-		} else {
-			// otherwise, normalize the values in Resources.Limits
-			for key, value := range spec.Resources.Limits {
-				q, err := resource.ParseQuantity(value.String())
-				if err != nil {
-					return err
-				}
-				spec.Resources.Limits[key] = q
-			}
-		}
-	}
-
-	return nil
 }

--- a/workspaces/controller/internal/webhook/workspacekind_webhook.go
+++ b/workspaces/controller/internal/webhook/workspacekind_webhook.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -207,12 +206,12 @@ func (v *WorkspaceKindValidator) ValidateUpdate(ctx context.Context, oldObj, new
 		} else {
 			// if we haven't already decided to validate the imageConfig redirects,
 			// check if the redirect has changed
-			if !shouldValidateImageConfigRedirects && !reflect.DeepEqual(oldImageConfigIdMap[imageConfigValue.Id].Redirect, imageConfigValue.Redirect) {
+			if !shouldValidateImageConfigRedirects && !equality.Semantic.DeepEqual(oldImageConfigIdMap[imageConfigValue.Id].Redirect, imageConfigValue.Redirect) {
 				shouldValidateImageConfigRedirects = true
 			}
 
 			// check if the spec has changed
-			if !reflect.DeepEqual(oldImageConfigIdMap[imageConfigValue.Id].Spec, imageConfigValue.Spec) {
+			if !equality.Semantic.DeepEqual(oldImageConfigIdMap[imageConfigValue.Id].Spec, imageConfigValue.Spec) {
 				// we need to validate this imageConfig value since it has changed
 				toValidateImageConfigIds[imageConfigValue.Id] = true
 
@@ -278,33 +277,16 @@ func (v *WorkspaceKindValidator) ValidateUpdate(ctx context.Context, oldObj, new
 		} else {
 			// if we haven't already decided to validate the podConfig redirects,
 			// check if the redirect has changed
-			if !shouldValidatePodConfigRedirects && !reflect.DeepEqual(oldPodConfigIdMap[podConfigValue.Id].Redirect, podConfigValue.Redirect) {
+			if !shouldValidatePodConfigRedirects && !equality.Semantic.DeepEqual(oldPodConfigIdMap[podConfigValue.Id].Redirect, podConfigValue.Redirect) {
 				shouldValidatePodConfigRedirects = true
 			}
 
 			// we must normalize the podConfig specs so that we can compare them
 			newPodConfigSpec := podConfigValue.Spec
-			err := helper.NormalizePodConfigSpec(newPodConfigSpec)
-			if err != nil {
-				podConfigValueSpecPath := field.NewPath("spec", "podTemplate", "options", "podConfig", "values").Key(podConfigValue.Id).Child("spec")
-				allErrs = append(allErrs, field.InternalError(podConfigValueSpecPath, fmt.Errorf("failed to normalize podConfig spec: %w", err)))
-
-				// if the spec could not be normalized, we cannot validate the WorkspaceKind further
-				return nil, apierrors.NewInvalid(
-					schema.GroupKind{Group: kubefloworgv1beta1.GroupVersion.Group, Kind: "WorkspaceKind"},
-					newWorkspaceKind.Name,
-					allErrs,
-				)
-			}
 			oldPodConfigSpec := oldPodConfigIdMap[podConfigValue.Id].Spec
-			err = helper.NormalizePodConfigSpec(oldPodConfigSpec)
-			if err != nil {
-				// this should never happen, as it would indicate that the old podConfig spec is invalid
-				return nil, apierrors.NewInternalError(fmt.Errorf("old podConfig spec of %q could not be normalized: %w", podConfigValue.Id, err))
-			}
 
 			// check if the spec has changed
-			if !reflect.DeepEqual(oldPodConfigSpec, newPodConfigSpec) {
+			if !equality.Semantic.DeepEqual(oldPodConfigSpec, newPodConfigSpec) {
 				// check how many workspaces are using this podConfig value
 				usageCount, err := getPodConfigUsageCount(podConfigValue.Id)
 				if err != nil {


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
fixes #69

While this change was important either way, the old approach of `NormalizePodConfigSpec` was not working because it did not acutally mutate in-place as its type of input was not a pointer, this is part of what broke the tests in https://github.com/kubeflow/notebooks/pull/906 when we moved the empty `nodeSelector` and `tolerations` to the `tiny_cpu` pod-config, which is used in the E2E tests, so the webhook started failing because it though we were updating the WorkspaceKind every loop.