### PR TITLE
fix: use the intended istio version in the tilt setup

### DIFF
--- a/developing/Makefile
+++ b/developing/Makefile
@@ -68,19 +68,21 @@ $(KUSTOMIZE): $(LOCALBIN)
 # Install istioctl
 istioctl: $(ISTIOCTL)
 $(ISTIOCTL): $(LOCALBIN)
-	$(call go-install-tool,$(ISTIOCTL),istio.io/istio/istioctl/cmd/istioctl,$(ISTIOCTL_VERSION))
+	$(call go-install-tool,$(ISTIOCTL),istio.io/istio/istioctl/cmd/istioctl,$(ISTIOCTL_VERSION),"-X istio.io/istio/pkg/version.buildVersion=$(ISTIOCTL_VERSION) -X istio.io/istio/pkg/version.buildTag=$(ISTIOCTL_VERSION) -X istio.io/istio/pkg/version.buildHub=docker.io/istio")
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
+# $4 - (optional) extra ldflags to set with the installation
 define go-install-tool
 @[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
+ldflags=$(4) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install $${ldflags:+-ldflags "$${ldflags}"} $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -173,13 +173,15 @@ $(KUSTOMIZE): $(LOCALBIN)
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
+# $4 - (optional) extra ldflags to set with the installation
 define go-install-tool
 @[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
+ldflags=$(4) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install $${ldflags:+-ldflags "$${ldflags}"} $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -191,7 +191,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: istioctl
 istioctl: $(ISTIOCTL) ## Download istioctl locally if necessary.
 $(ISTIOCTL): $(LOCALBIN)
-	$(call go-install-tool,$(ISTIOCTL),istio.io/istio/istioctl/cmd/istioctl,$(ISTIOCTL_VERSION))
+	$(call go-install-tool,$(ISTIOCTL),istio.io/istio/istioctl/cmd/istioctl,$(ISTIOCTL_VERSION),"-X istio.io/istio/pkg/version.buildVersion=$(ISTIOCTL_VERSION) -X istio.io/istio/pkg/version.buildTag=$(ISTIOCTL_VERSION) -X istio.io/istio/pkg/version.buildHub=docker.io/istio")
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
@@ -202,13 +202,15 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
+# $4 - (optional) extra ldflags to set with the installation
 define go-install-tool
 @[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
+ldflags=$(4) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install $${ldflags:+-ldflags "$${ldflags}"} $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/workspaces/frontend/Makefile
+++ b/workspaces/frontend/Makefile
@@ -86,13 +86,15 @@ $(KUSTOMIZE): $(LOCALBIN)
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
+# $4 - (optional) extra ldflags to set with the installation
 define go-install-tool
 @[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
+ldflags=$(4) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install $${ldflags:+-ldflags "$${ldflags}"} $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)


### PR DESCRIPTION
Previously we were deploying an alpha version due to missing ldflags in the installation via `go install`. Fix this by introducing a bit of pluming for the Makefile and set the missing flags.

Previously:
```
$ bin/istioctl version
client version: unknown
control plane version: 1.30-alpha.031588a86a8bced9b77812967b714ae9963e34b0
data plane version: 1.30-alpha.031588a86a8bced9b77812967b714ae9963e34b0 (1 proxies)
```

With this PR applied:
```
$ bin/istioctl version
client version: 1.27.3
control plane version: 1.27.3
data plane version: 1.27.3 (2 proxies)
```

# 🔍 Reviewer notice 

- I'm not a fan of the current approach with the inline bash script / macro approach that `go-install-tool` takes, so I'd propose that we externalize it as a script to easier keep it in sync across the different usages in the `Makefile`s.
- Also we should probably not set the `-ldflags ""` when `$4` has no value.

I'd like to get a quick input especially on the first point before I raise a (potentially separate) PR for it.