### PR TITLE
feat: add short names for WorkspaceKind and Workspace

### DIFF
--- a/workspaces/controller/api/v1beta1/workspace_types.go
+++ b/workspaces/controller/api/v1beta1/workspace_types.go
@@ -292,6 +292,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state",description="The current state of the Workspace"
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=ws
 
 // Workspace is the Schema for the Workspaces API
 type Workspace struct {

--- a/workspaces/controller/api/v1beta1/workspacekind_types.go
+++ b/workspaces/controller/api/v1beta1/workspacekind_types.go
@@ -575,7 +575,7 @@ type OptionMetric struct {
 // +kubebuilder:printcolumn:name="Deprecated",type="boolean",JSONPath=".spec.spawner.deprecated",description="If this WorkspaceKind is deprecated"
 // +kubebuilder:printcolumn:name="Hidden",type="boolean",JSONPath=".spec.spawner.hidden",description="If this WorkspaceKind is hidden from the spawner UI"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=wsk
 
 // WorkspaceKind is the Schema for the WorkspaceKinds API
 type WorkspaceKind struct {

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
@@ -11,6 +11,8 @@ spec:
     kind: WorkspaceKind
     listKind: WorkspaceKindList
     plural: workspacekinds
+    shortNames:
+    - wsk
     singular: workspacekind
   scope: Cluster
   versions:

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspaces.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspaces.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Workspace
     listKind: WorkspaceList
     plural: workspaces
+    shortNames:
+    - ws
     singular: workspace
   scope: Namespaced
   versions:


### PR DESCRIPTION
This makes it easier to reference the resources via `k9s` or `kubectl`:

    $ kubectl get wsk
    NAME         WORKSPACES   DEPRECATED   HIDDEN
    codeserver   0            false        false
    jupyterlab   1            false        false
    rstudio      0            false        false

    $ kubectl get ws
    NAME                   STATE
    jupyterlab-workspace   Running

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->