### PR TITLE
chore: fix typo in swagger handler to fix CI

### DIFF
--- a/workspaces/backend/api/swagger_handler.go
+++ b/workspaces/backend/api/swagger_handler.go
@@ -28,7 +28,7 @@ import (
 
 func (a *App) GetSwaggerHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	httpSwagger.Handler(
-		// this url is the one that the swagger frontend uses to fetch the OpenAPI definiton
+		// this url is the one that the swagger frontend uses to fetch the OpenAPI definition
 		httpSwagger.URL(fmt.Sprintf("%s/swagger/doc.json", openapi.SwaggerInfo.BasePath)),
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("list"),


### PR DESCRIPTION
Link: https://github.com/kubeflow/notebooks/actions/runs/22734589466/job/65932442524?pr=951#step:5:8

No clue why the checks on https://github.com/kubeflow/notebooks/pull/944 didn't catch this one 🤔 