### PR TITLE
chore: align cert-manager ready check with e2e tests

### DIFF
--- a/developing/scripts/setup-cert-manager.sh
+++ b/developing/scripts/setup-cert-manager.sh
@@ -29,8 +29,8 @@ kubectl wait deployment.apps --for condition=Available \
   --all-namespaces \
   --timeout=120s
 
-kubectl wait endpoints \
-  --for "jsonpath=subsets[0].addresses[0].targetRef.kind=Pod" \
+kubectl wait endpointslice \
+  --for="jsonpath=endpoints[0].targetRef.kind=Pod" \
   --selector app.kubernetes.io/instance=cert-manager \
   --all-namespaces \
   --timeout=120s

--- a/workspaces/controller/test/utils/certmanager.go
+++ b/workspaces/controller/test/utils/certmanager.go
@@ -79,8 +79,8 @@ func WaitCertManagerRunning() error {
 	// Wait for the cert-manager Endpoints to be ready
 	// NOTE: the webhooks will not function correctly until this is ready
 	cmd = exec.Command("kubectl", "wait",
-		"endpoints",
-		"--for", "jsonpath=subsets[0].addresses[0].targetRef.kind=Pod",
+		"endpointslice",
+		"--for", "jsonpath=endpoints[0].targetRef.kind=Pod",
 		"--selector", "app.kubernetes.io/instance=cert-manager",
 		"--all-namespaces",
 		"--timeout", "2m",


### PR DESCRIPTION
Link: https://github.com/kubeflow/notebooks/blob/d76af839376385ee893ac666447a0ca1ed00e85d/workspaces/controller/test/utils/certmanager.go#L67-L73

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->