### PR TITLE
chore: enable auth in the production manifests

### DIFF
--- a/developing/Tiltfile
+++ b/developing/Tiltfile
@@ -93,8 +93,20 @@ for o in backend_objects:
             "SWAGGER_ENABLED": "true",
             "SWAGGER_SCHEME": "https",
             "SWAGGER_HOST": "localhost:8443",
-            "SWAGGER_BASE_PATH": "/workspaces/api/v1"
+            "SWAGGER_BASE_PATH": "/workspaces/api/v1",
+            "DISABLE_AUTH": "true",
         }
+
+        # Replace existing keys and add missing ones
+        for (i, var) in enumerate(env):
+            key = var["name"]
+            if key in tilt_env_vars.keys():
+                env[i] = {
+                    "name": key,
+                    "value": tilt_env_vars[key],
+                }
+                tilt_env_vars.pop(key)
+
         for (key, value) in tilt_env_vars.items():
             env.append({
                 "name": key,

--- a/workspaces/backend/manifests/kustomize/base/deployment.yaml
+++ b/workspaces/backend/manifests/kustomize/base/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         env:
         - name: PORT
           value: "4000"
+        # TODO: remove before GA
+        - name: DISABLE_AUTH
+          value: "false"
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
For the production manifests:

    $ kustomize build workspaces/backend/manifests/kustomize/overlays/istio/ | grep -iA1 DISABLE_AUTH
    - name: DISABLE_AUTH
      value: "false"

For the tilt setup:

    $ kubectl get deployments -n kubeflow-workspaces workspaces-backend -o yaml | grep -iA1 DISABLE_AUTH
    - name: DISABLE_AUTH
      value: "true"

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
