### PR TITLE
fix: jwa backend missing cachetools dependency

### DIFF
--- a/.github/workflows/jwa_backend_unittests.yaml
+++ b/.github/workflows/jwa_backend_unittests.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/jupyter/backend/**
+      - components/crud-web-apps/common/backend/**
       - releasing/version/VERSION
     branches:
       - main

--- a/.github/workflows/jwa_frontend_tests.yaml
+++ b/.github/workflows/jwa_frontend_tests.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/jupyter/frontend/**
+      - components/crud-web-apps/common/frontend/**
       - releasing/version/VERSION
     branches:
       - main

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -7,7 +7,6 @@ on:
       - notebooks-v1
     paths:
       - components/notebook-controller/**
-      - components/common/**
       - releasing/version/VERSION
 
 env:

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -8,7 +8,6 @@ on:
       - notebooks-v1
     paths:
       - components/pvcviewer-controller/**
-      - components/common/**
       - releasing/version/VERSION
 
 env:

--- a/.github/workflows/twa_frontend_tests.yaml
+++ b/.github/workflows/twa_frontend_tests.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/tensorboards/frontend/**
+      - components/crud-web-apps/common/frontend/**
       - releasing/version/VERSION
     branches:
       - main

--- a/.github/workflows/vwa_frontend_tests.yaml
+++ b/.github/workflows/vwa_frontend_tests.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/volumes/frontend/**
+      - components/crud-web-apps/common/frontend/**
       - releasing/version/VERSION
     branches:
       - main

--- a/components/crud-web-apps/jupyter/backend/requirements.txt
+++ b/components/crud-web-apps/jupyter/backend/requirements.txt
@@ -1,1 +1,2 @@
 gunicorn
+cachetools


### PR DESCRIPTION
Fixes the fact we are missing a dependency `cachetools` in the JWA backend python library after https://github.com/kubeflow/notebooks/pull/757

We need to explicitly put `cachetools` in the requirements because older versions of `kubernetes` library had a transitive dependency on `cachetools` but no longer do, here is `pipdeptree` of old image:
```
kubeflow==1.2
├── kubernetes [required: ==22.6.0, installed: 22.6.0]
│   ├── certifi [required: >=14.05.14, installed: 2025.1.31]
│   ├── six [required: >=1.9.0, installed: 1.17.0]
│   ├── python-dateutil [required: >=2.5.3, installed: 2.9.0.post0]
│   │   └── six [required: >=1.5, installed: 1.17.0]
│   ├── setuptools [required: >=21.0.0, installed: 65.5.1]
│   ├── PyYAML [required: >=5.4.1, installed: 6.0.2]
│   ├── google-auth [required: >=1.0.1, installed: 2.38.0]
│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.2]
│   │   ├── pyasn1_modules [required: >=0.2.1, installed: 0.4.1]
│   │   │   └── pyasn1 [required: >=0.4.6,<0.7.0, installed: 0.6.1]
│   │   └── rsa [required: >=3.1.4,<5, installed: 4.9]
│   │       └── pyasn1 [required: >=0.1.3, installed: 0.6.1]
```

It also ensures we run tests when common crud paths change, to try catch stuff like this sooner.