### PR TITLE
fix: pvc apis should not return null for empty list

### DIFF
--- a/workspaces/backend/internal/models/pvcs/funcs.go
+++ b/workspaces/backend/internal/models/pvcs/funcs.go
@@ -60,13 +60,13 @@ func NewPVCListItemFromPVC(pvc *corev1.PersistentVolumeClaim, pv *corev1.Persist
 	}
 
 	// build the list of PodInfo for pods that mount this PVC, if any.
-	var podList []PodInfo
+	podList := make([]PodInfo, 0)
 	if pvcToPodInfoList[pvc.Name] != nil {
 		podList = pvcToPodInfoList[pvc.Name]
 	}
 
 	// build the list of WorkspaceInfo for workspaces that reference this PVC, if any.
-	var workspaceList []WorkspaceInfo
+	workspaceList := make([]WorkspaceInfo, 0)
 	if pvcToWorkspaceInfoList[pvc.Name] != nil {
 		workspaceList = pvcToWorkspaceInfoList[pvc.Name]
 	}


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Currently the API contract for PVC in backend is not respected if there are no Pods / Workspaces which sue the PVC (as we return null in JSON when we should return an empty list).

In future we will discuss if we should always add "ommitempty" on lists in backend models, so that frontend sees them as optional fields, as while its semantically less correct, actually enforcing the JSON Marshal to replace un-initialized slices with empty ones is not trivial.