### PR TITLE
fix: make deploy supports release branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ Sessionx.vim
 *.elc
 .\#*
 
+## Kustomize intermediate output
+**/kustomize/.output/
+
 ## macOS
 .DS_Store
 .AppleDouble

--- a/workspaces/backend/Makefile
+++ b/workspaces/backend/Makefile
@@ -154,8 +154,13 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 
 .PHONY: deploy
 deploy: kustomize ## Deploy backend to the K8s cluster specified in ~/.kube/config.
-	cd manifests/kustomize/overlays/istio && $(KUSTOMIZE) edit set image workspaces-backend=${IMG}
-	$(KUBECTL) apply -k manifests/kustomize/overlays/istio
+	@echo "Copying kustomize directory structure to .output..."
+	@rm -rf manifests/kustomize/.output
+	@mkdir -p manifests/kustomize/.output
+	@cp -r manifests/kustomize/* manifests/kustomize/.output/
+	# Match both short name and registry-prefixed name (base kustomization may transform either)
+	@cd manifests/kustomize/.output/overlays/istio && $(KUSTOMIZE) edit set image $(NAME)=${IMG} $(REGISTRY)/$(NAME)=${IMG}
+	@$(KUBECTL) apply -k manifests/kustomize/.output/overlays/istio
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy backend from the K8s cluster specified in ~/.kube/config.

--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -143,8 +143,13 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd manifests/kustomize/overlays/istio && $(KUSTOMIZE) edit set image workspaces-controller=${IMG}
-	$(KUBECTL) apply -k manifests/kustomize/overlays/istio
+	@echo "Copying kustomize directory structure to .output..."
+	@rm -rf manifests/kustomize/.output
+	@mkdir -p manifests/kustomize/.output
+	@cp -r manifests/kustomize/* manifests/kustomize/.output/
+	# Match both short name and registry-prefixed name (base kustomization may transform either)
+	@cd manifests/kustomize/.output/overlays/istio && $(KUSTOMIZE) edit set image $(NAME)=${IMG} $(REGISTRY)/$(NAME)=${IMG}
+	@$(KUBECTL) apply -k manifests/kustomize/.output/overlays/istio
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/workspaces/frontend/Makefile
+++ b/workspaces/frontend/Makefile
@@ -55,8 +55,13 @@ docker-build-push-multi-arch:
 
 .PHONY: deploy
 deploy: kustomize ## Deploy frontend to the K8s cluster specified in ~/.kube/config.
-	cd manifests/kustomize/overlays/istio && $(KUSTOMIZE) edit set image workspaces-frontend=${IMG}
-	$(KUBECTL) apply -k manifests/kustomize/overlays/istio
+	@echo "Copying kustomize directory structure to .output..."
+	@rm -rf manifests/kustomize/.output
+	@mkdir -p manifests/kustomize/.output
+	@cp -r manifests/kustomize/* manifests/kustomize/.output/
+	# Match both short name and registry-prefixed name (base kustomization may transform either)
+	@cd manifests/kustomize/.output/overlays/istio && $(KUSTOMIZE) edit set image $(NAME)=${IMG} $(REGISTRY)/$(NAME)=${IMG}
+	@$(KUBECTL) apply -k manifests/kustomize/.output/overlays/istio
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy frontend from the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
The deploy target's `kustomize edit set image` was never actually overriding the base kustomization's image tag. This was masked on non-release branches because the base newTag (latest) happened to match the hardcoded test image tag. On release branches, the base newTag changes to the release version, exposing the mismatch and causing e2e test pods to stay Pending (image not found in Kind).

Fix by:
- Copying kustomize to .output/ so edits don't modify tracked files
- Matching both short name and registry-prefixed name to ensure the override works regardless of base kustomization state

Extracted from #763.
