### PR TITLE
chore: pin all github actions to their shasum

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Approve Pending Workflow Runs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           retries: 3
           script: |

--- a/.github/workflows/slash-commands.yaml
+++ b/.github/workflows/slash-commands.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Handle slash commands
         id: handle-commands
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const parseIssueNumber = (input) => {
@@ -198,7 +198,7 @@ jobs:
 
       - name: Post error comment if failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             try {

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 60
           days-before-close: 21

--- a/.github/workflows/trivy-fs-scanning.yaml
+++ b/.github/workflows/trivy-fs-scanning.yaml
@@ -29,12 +29,12 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: refs/heads/${{ matrix.branch }}  # using explicit refs syntax due to requirements of upload-sarif action
 
     - name: Run Trivy vulnerability scanner in fs mode
-      uses: aquasecurity/trivy-action@0.33.1
+      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
       with:
         scan-type: 'fs'
         format: 'sarif'
@@ -51,7 +51,7 @@ jobs:
         mv trivy-fs-scan-results-${{ matrix.branch }}-processed.sarif trivy-fs-scan-results-${{ matrix.branch }}.sarif
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
       with:
           sarif_file: 'trivy-fs-scan-results-${{ matrix.branch }}.sarif'
           ref: ${{ steps.checkout.outputs.ref }}

--- a/.github/workflows/validate-planning-label.yml
+++ b/.github/workflows/validate-planning-label.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log trigger
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             console.log(`Action triggered by: ${context.eventName} event with action: ${context.payload.action}`);
@@ -30,7 +30,7 @@ jobs:
 
       - name: Handle labeled action
         if: github.event.action == 'labeled'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const AUTHORIZED_USERS = JSON.parse(process.env.AUTHORIZED_USERS);
@@ -96,7 +96,7 @@ jobs:
 
       - name: Handle opened action
         if: github.event.action == 'opened'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const AUTHORIZED_USERS = JSON.parse(process.env.AUTHORIZED_USERS);


### PR DESCRIPTION
This way we're not so easy to be targeted by supply chain attacks such
as the trivy incident that motivated this initially.

The changes were generated via a script that I wrote to do this, see the
second link below.

Link: https://www.openwall.com/lists/oss-security/2026/03/21/1
Link: https://github.com/christian-heusel/dotfiles/blob/main/misc/scripts/pin-github-actions.sh

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
