### PR TITLE
chore: fix the line wrapping in ruamel.yaml

### DIFF
--- a/releasing/update-manifests-images.py
+++ b/releasing/update-manifests-images.py
@@ -126,6 +126,7 @@ def update_manifests_images(components, tag):
         kustomize["images"] = images
 
         with open(component["kustomization"], "w") as file:
+            yaml.width = 4096
             yaml.dump(kustomize, file)
 
 


### PR DESCRIPTION
So far the library has caused line wraps when the version used is
(some version) greater than 18.11, which annoyed Mathew when doing
releases. Fix this by setting a really high value for maximum line
length.

This causes diffs like the following:

```diff
-    value: ghcr.io/kubeflow/kubeflow/notebook-servers/codeserver-python:latest
+    value:
+      ghcr.io/kubeflow/kubeflow/notebook-servers/codeserver-python:v1.11.0-rc.
```

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
