### PR TITLE
ci: enforce only publishing image version tags from release branches

### DIFF
--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -49,7 +49,8 @@ jobs:
           ARCH: ${{ inputs.build_arch }}
           IMAGE_FOLDERS: ${{ inputs.image_folders }}
           SHOULD_TAG_LATEST: ${{ github.ref == 'refs/heads/notebooks-v1' }}
-          SHOULD_TAG_VERSION: ${{ steps.filter.outputs.version == 'true' }}
+          # We only publish version-tagged images from release branches
+          SHOULD_TAG_VERSION: ${{ steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v') }}
         run: |
           if [[ "$SHOULD_TAG_LATEST" = "true" ]]; then
             export ALSO_TAG_LATEST=1

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -55,6 +55,7 @@ jobs:
 
     - name: Build and push multi-arch docker image on Version change
       id: version
-      if: steps.filter.outputs.version == 'true'
+      # We only publish version-tagged images from release branches
+      if: steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v')
       run: TAG=$(cat ../../../releasing/version/VERSION) make docker-build-push-multi-arch
 

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -59,7 +59,8 @@ jobs:
 
     - name: Build and push multi-arch docker image on Version change
       id: version
-      if: steps.filter.outputs.version == 'true'
+      # We only publish version-tagged images from release branches
+      if: steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v')
       run: |
         export TAG=$(cat releasing/version/VERSION)
         cd components/notebook-controller

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -60,7 +60,8 @@ jobs:
 
     - name: Build and push multi-arch docker image on Version change
       id: version
-      if: steps.filter.outputs.version == 'true'
+      # We only publish version-tagged images from release branches
+      if: steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v')
       run: |
         export TAG=$(cat releasing/version/VERSION)
         cd components/pvcviewer-controller

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -58,7 +58,8 @@ jobs:
 
     - name: Build and push multi-arch docker image on Version change
       id: version
-      if: steps.filter.outputs.version == 'true'
+      # We only publish version-tagged images from release branches
+      if: steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v')
       run: |
         export TAG=$(cat ../../releasing/version/VERSION)
         make docker-build-push-multi-arch

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -59,7 +59,8 @@ jobs:
 
     - name: Build and push multi-arch docker image on Version change
       id: version
-      if: steps.filter.outputs.version == 'true'
+      # We only publish version-tagged images from release branches
+      if: steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v')
       run: |
         export TAG=$(cat ../../../releasing/version/VERSION)
         make docker-build-push-multi-arch

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -55,5 +55,6 @@ jobs:
 
     - name: Build and push multi-arch docker image on Version change
       id: version
-      if: steps.filter.outputs.version == 'true'
+      # We only publish version-tagged images from release branches
+      if: steps.filter.outputs.version == 'true' && startsWith(github.ref, 'refs/heads/v')
       run: TAG=$(cat ../../../releasing/version/VERSION) make docker-build-push-multi-arch


### PR DESCRIPTION
This way the docker images are not accidentally updated from the `main` branch or the other development branches.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
