### PR TITLE
Fix: Disappearing "Create workspace" button on narrow viewports

### DIFF
--- a/workspaces/frontend/src/shared/components/ToolbarFilter.tsx
+++ b/workspaces/frontend/src/shared/components/ToolbarFilter.tsx
@@ -6,15 +6,19 @@ import {
   ToolbarFilter as PFToolbarFilter,
   ToolbarToggleGroup,
   ToolbarItem,
+} from '@patternfly/react-core/dist/esm/components/Toolbar';
+import {
   Select,
   SelectList,
   SelectOption,
+} from '@patternfly/react-core/dist/esm/components/Select';
+import {
   MenuToggle,
   MenuToggleElement,
-  Badge,
-} from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
-import ThemeAwareSearchInput from '../../app/components/ThemeAwareSearchInput';
+} from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Badge } from '@patternfly/react-core/dist/esm/components/Badge';
+import PFFilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import ThemeAwareSearchInput from '~/app/components/ThemeAwareSearchInput';
 
 interface CommonFilterConfig {
   label: string;
@@ -43,7 +47,6 @@ export type FilterConfigMap<K extends string> = {
   [key in K]: FilterConfig;
 };
 
-/** Filter value type - string for text/select, string[] for multiselect */
 export type FilterValue = string | string[];
 
 export type FilterState<K extends string> = Record<K, FilterValue>;
@@ -151,7 +154,7 @@ function ToolbarFilterInner<K extends string>(
             ref={toggleRef}
             onClick={onAttributeToggle}
             isExpanded={isAttributeMenuOpen}
-            icon={<FilterIcon />}
+            icon={<PFFilterIcon />}
             data-testid={`${testIdPrefix}-dropdown`}
           >
             {activeFilterLabel}
@@ -340,7 +343,6 @@ function ToolbarFilterInner<K extends string>(
       const newValues = currentValues.filter((v) => v !== labelToDelete);
       onFilterChange(key, newValues);
     } else {
-      // For text and select filters, clear the entire value
       onFilterChange(key, config.type === 'multiselect' ? [] : '');
     }
   };
@@ -352,7 +354,8 @@ function ToolbarFilterInner<K extends string>(
       data-testid={`${testIdPrefix}-toolbar`}
     >
       <ToolbarContent>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+        {toolbarActions && <ToolbarGroup variant="action-group">{toolbarActions}</ToolbarGroup>}
+        <ToolbarToggleGroup toggleIcon={<PFFilterIcon />} breakpoint="lg">
           <ToolbarGroup variant="filter-group">
             <ToolbarItem>{attributeDropdown}</ToolbarItem>
             {visibleFilterKeys.map((key) => (
@@ -392,7 +395,6 @@ function ToolbarFilterInner<K extends string>(
               ))}
           </ToolbarGroup>
         </ToolbarToggleGroup>
-        {toolbarActions && <ToolbarGroup variant="action-group">{toolbarActions}</ToolbarGroup>}
       </ToolbarContent>
     </Toolbar>
   );

--- a/workspaces/frontend/src/shared/components/ToolbarFilter.tsx
+++ b/workspaces/frontend/src/shared/components/ToolbarFilter.tsx
@@ -6,19 +6,15 @@ import {
   ToolbarFilter as PFToolbarFilter,
   ToolbarToggleGroup,
   ToolbarItem,
-} from '@patternfly/react-core/dist/esm/components/Toolbar';
-import {
   Select,
   SelectList,
   SelectOption,
-} from '@patternfly/react-core/dist/esm/components/Select';
-import {
   MenuToggle,
   MenuToggleElement,
-} from '@patternfly/react-core/dist/esm/components/MenuToggle';
-import { Badge } from '@patternfly/react-core/dist/esm/components/Badge';
-import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
-import ThemeAwareSearchInput from '~/app/components/ThemeAwareSearchInput';
+  Badge,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import ThemeAwareSearchInput from '../../app/components/ThemeAwareSearchInput';
 
 interface CommonFilterConfig {
   label: string;
@@ -394,9 +390,9 @@ function ToolbarFilterInner<K extends string>(
                   {null}
                 </PFToolbarFilter>
               ))}
-            {toolbarActions}
           </ToolbarGroup>
         </ToolbarToggleGroup>
+        {toolbarActions && <ToolbarGroup variant="action-group">{toolbarActions}</ToolbarGroup>}
       </ToolbarContent>
     </Toolbar>
   );

--- a/workspaces/frontend/src/shared/components/__tests__/ToolbarFilter.spec.tsx
+++ b/workspaces/frontend/src/shared/components/__tests__/ToolbarFilter.spec.tsx
@@ -7,27 +7,32 @@ import ToolbarFilter, {
   ToolbarFilterRef,
 } from '~/shared/components/ToolbarFilter';
 
-// Mock ThemeAwareSearchInput to simplify testing
-jest.mock('~/app/components/ThemeAwareSearchInput', () => {
-  const MockSearchInput = ({
-    value,
-    onChange,
-    placeholder,
-    'data-testid': testId,
-  }: {
-    value: string;
-    onChange: (val: string) => void;
-    placeholder: string;
-    'data-testid': string;
-  }) => (
-    <input
-      data-testid={testId}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder={placeholder}
-    />
-  );
-  return MockSearchInput;
+// Mock SearchInput from @patternfly/react-core to simplify testing
+jest.mock('@patternfly/react-core', () => {
+  const actual = jest.requireActual('@patternfly/react-core');
+  return {
+    ...actual,
+    SearchInput: jest.fn(
+      ({
+        value,
+        onChange,
+        placeholder,
+        'data-testid': testId,
+      }: {
+        value: string;
+        onChange: (event: React.FormEvent<HTMLInputElement>, val: string) => void;
+        placeholder: string;
+        'data-testid': string;
+      }) => (
+        <input
+          data-testid={testId}
+          value={value}
+          onChange={(e) => onChange(e as any, e.target.value)}
+          placeholder={placeholder}
+        />
+      ),
+    ),
+  };
 });
 
 describe('ToolbarFilter', () => {


### PR DESCRIPTION
**Fixes** #909

When the browser window is narrow (e.g., on a tiled window manager or half-screen view), the `Create workspace` button in the Workspaces list disappears and only reappears when the filters view is manually opened. This is unintuitive and creates a UX barrier for users with horizontal viewports below 1200px.

This PR fixes the layout priority in `ToolbarFilter.tsx` to ensure that action buttons are always accessible.

**Changes:**
- Action Priority: Moved `toolbarActions` to be rendered before the `ToolbarToggleGroup`. This keeps the `Create workspace` button visible next to the filter icon even when the toolbar is collapsed.
- Responsive Breakpoint: Reduced the filter collapse breakpoint from xl (1200px) to lg (1024px) to better accommodate standard screen scaling and window tiling.