### PR TITLE
chore: trigger GHA tests on VERSION change

### DIFF
--- a/.github/workflows/ws-backend-test.yml
+++ b/.github/workflows/ws-backend-test.yml
@@ -11,6 +11,7 @@ on:
       - v*-branch
   pull_request:
     paths:
+      - releasing/version/VERSION
       - workspaces/backend/**
       ## NOTE: we also test on changes to the controller as the backend depends on the controller
       - workspaces/controller/**

--- a/.github/workflows/ws-controller-test.yml
+++ b/.github/workflows/ws-controller-test.yml
@@ -11,6 +11,7 @@ on:
       - v*-branch
   pull_request:
     paths:
+      - releasing/version/VERSION
       - workspaces/controller/**
       ## NOTE: we also test on changes to the backend as the backend depends on the controller
       - workspaces/backend/**

--- a/.github/workflows/ws-frontend-test.yml
+++ b/.github/workflows/ws-frontend-test.yml
@@ -11,6 +11,7 @@ on:
       - v*-branch
   pull_request:
     paths:
+      - releasing/version/VERSION
       - workspaces/frontend/**
     branches:
       - main


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_


Added the path 'releasing/version/VERSION' to the pull request triggers in the `backend`, `controller`, and `frontend` test workflows to ensure that changes to the version file are tested appropriately on release branches.
