### PR TITLE
chore: return minified json from backend API

### DIFF
--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -37,12 +37,10 @@ type Envelope[D any] struct {
 // WriteJSON writes a JSON response with the given status code, data, and headers.
 func (a *App) WriteJSON(w http.ResponseWriter, status int, data any, headers http.Header) error {
 
-	js, err := json.MarshalIndent(data, "", "\t")
+	js, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
-
-	js = append(js, '\n')
 
 	for key, value := range headers {
 		w.Header()[key] = value


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_

Updated the WriteJSON method to use json.Marshal instead of json.MarshalIndent for a more straightforward JSON response formatting. Removed unnecessary newline appending to the JSON output.


**BEFORE**

<img width="1302" height="840" alt="image" src="https://github.com/user-attachments/assets/25b38a46-6826-4fc8-9443-ff95a16e995e" />


**AFTER**

<img width="2602" height="1298" alt="image" src="https://github.com/user-attachments/assets/80beb55c-3b0b-4b56-bdeb-47d5233716b9" />
