### PR TITLE
fix: add back the `v` prefix to image tags

### DIFF
--- a/.github/workflows/ws-build-image.yml
+++ b/.github/workflows/ws-build-image.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
       tag_with_semver:
         default: false
-        description: "if true, image tags will include the version (from semver_raw, without 'v' prefix)"
+        description: "if true, image tags will include the version (from semver_raw), always adds 'v' prefix if not already provided in semver_raw"
         type: boolean
       tag_with_sha:
         default: false
@@ -78,8 +78,7 @@ jobs:
           flavor: |
             latest=${{ inputs.tag_with_latest }}
           tags: |
-            type=semver,priority=1000,pattern={{version}},enable=${{ inputs.tag_with_semver }},value=${{ inputs.semver_raw }}
-            type=semver,priority=900,pattern={{major}}.{{minor}},enable=${{ inputs.tag_with_semver }},value=${{ inputs.semver_raw }}
+            type=semver,priority=1000,pattern=v{{version}},enable=${{ inputs.tag_with_semver }},value=${{ inputs.semver_raw }}
             type=sha,priority=200,prefix=sha-,format=short,enable=${{ inputs.tag_with_sha }}
             type=sha,priority=100,prefix=sha-,format=long,enable=${{ inputs.tag_with_sha }}
 


### PR DESCRIPTION



---

# Old Changes

The `ws-publish.yml` GHA pushes tags without "v" prefix if `tag_with_semver` is set, which is the case for all release workflows. Without this we're running into `ImagePullBackOff` issues in the release manifests.

---

`python releasing/update-manifests-images.py`
```diff
diff --git a/releasing/version/VERSION b/releasing/version/VERSION
index 9001211..ee6c00d 100644
--- a/releasing/version/VERSION
+++ b/releasing/version/VERSION
@@ -1 +1 @@
-dev
\ No newline at end of file
+v2.0.0-alpha.0
diff --git a/workspaces/backend/manifests/kustomize/base/kustomization.yaml b/workspaces/backend/manifests/kustomize/base/kustomization.yaml
index 793103a..9a8f6e0 100644
--- a/workspaces/backend/manifests/kustomize/base/kustomization.yaml
+++ b/workspaces/backend/manifests/kustomize/base/kustomization.yaml
@@ -18,4 +18,4 @@ labels:
 images:
 - name: workspaces-backend
   newName: ghcr.io/kubeflow/notebooks/workspaces-backend
-  newTag: latest
+  newTag: 2.0.0-alpha.0
diff --git a/workspaces/controller/manifests/kustomize/base/manager/kustomization.yaml b/workspaces/controller/manifests/kustomize/base/manager/kustomization.yaml
index 9bab808..e467be1 100644
--- a/workspaces/controller/manifests/kustomize/base/manager/kustomization.yaml
+++ b/workspaces/controller/manifests/kustomize/base/manager/kustomization.yaml
@@ -19,4 +19,4 @@ labels:
 images:
 - name: workspaces-controller
   newName: ghcr.io/kubeflow/notebooks/workspaces-controller
-  newTag: latest
+  newTag: 2.0.0-alpha.0
diff --git a/workspaces/frontend/manifests/kustomize/base/kustomization.yaml b/workspaces/frontend/manifests/kustomize/base/kustomization.yaml
index e3c2960..d41cd34 100644
--- a/workspaces/frontend/manifests/kustomize/base/kustomization.yaml
+++ b/workspaces/frontend/manifests/kustomize/base/kustomization.yaml
@@ -16,4 +16,4 @@ labels:
 images:
 - name: workspaces-frontend
   newName: ghcr.io/kubeflow/notebooks/workspaces-frontend
-  newTag: latest
+  newTag: 2.0.0-alpha.0
```

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
