### PR TITLE
fix: forward incoming auth headers in webpack dev proxy

### DIFF
--- a/workspaces/frontend/config/webpack.dev.js
+++ b/workspaces/frontend/config/webpack.dev.js
@@ -28,36 +28,56 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
 
-// Function to generate headers based on deployment mode
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    // eslint-disable-next-line no-console
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      // eslint-disable-next-line no-console
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -102,6 +122,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {


### PR DESCRIPTION
## Description

The webpack dev server captures the kubeconfig token at startup and sets it as a static proxy header via `headers: getProxyHeaders()`. This overwrites any dynamically forwarded auth headers from a host backend proxy, breaking dev impersonation (e.g. `DEV_IMPERSONATE_USER`/`DEV_IMPERSONATE_PASSWORD`).

This PR replaces the static `headers` approach with an `onProxyReq` callback that dynamically forwards the `Authorization` header from each incoming request when present, falling back to the startup-captured token for standalone dev mode.

The same fix was applied to the model-registry UI in https://github.com/kubeflow/model-registry/pull/2544.

## Changes

- Split `getProxyHeaders()` into:
  - `getKubeconfigToken()` — captures kubeconfig token at startup (fallback)
  - `getProxyHeaders()` — returns only static headers (`kubeflow-userid` for `internal` auth)
  - `onProxyReq` — dynamically forwards `Authorization` and `x-forwarded-access-token` headers per request
- Proxy config now uses both `headers: getProxyHeaders()` (static) and `onProxyReq` (dynamic)

## How Has This Been Tested?

Tested manually in the model-registry module (same fix pattern) against an ODH cluster:
1. Started the host backend with `DEV_IMPERSONATE_USER` and `DEV_IMPERSONATE_PASSWORD` set
2. Verified the bug: with static headers, the impersonated user's token was overwritten by the startup token
3. Verified the fix: with `onProxyReq`, the incoming auth header from the host proxy is forwarded correctly