### PR TITLE
feat: setup Dependabot for `kubeflow/notebooks`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,165 @@
+version: 2
+
+updates:
+
+  ########################
+  # --> notebooks-v2 <-- #
+  ########################
+
+  # - package-ecosystem: "gomod"
+  #   target-branch: "notebooks-v2"
+  #   open-pull-requests-limit: 5
+  #   cooldown:
+  #     default-days: 7
+  #   directories:
+  #     - "/workspaces/backend"
+  #     - "/workspaces/controller"
+  #   schedule:
+  #     interval: "daily"
+  #   commit-message:
+  #     prefix: "chore"
+  #   ignore:
+  #     # k8s upgrades are expected to be breaking changes and should be handled
+  #     # manually
+  #     - dependency-name: "k8s.io/*"
+  #       update-types:
+  #         - "version-update:semver-major"
+  #         - "version-update:semver-minor"
+  #     - dependency-name: "sigs.k8s.io/*"
+  #       update-types:
+  #         - "version-update:semver-major"
+  #         - "version-update:semver-minor"
+  #   groups:
+  #     k8s-packages:
+  #       patterns:
+  #         - "k8s.io/*"
+  #         - "sigs.k8s.io/*"
+  #     go-test-packages:
+  #       patterns:
+  #         - "github.com/onsi/*"
+
+  - package-ecosystem: "npm"
+    target-branch: "notebooks-v2"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    directory: "/workspaces/frontend"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    # Group mod-arch-* packages together for easier review
+    groups:
+      mod-arch-packages:
+        patterns:
+          - "mod-arch-*"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "notebooks-v2"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"
+
+  ########################
+  # --> notebooks-v1 <-- #
+  ########################
+
+  # - package-ecosystem: "gomod"
+  #   target-branch: "notebooks-v1"
+  #   open-pull-requests-limit: 5
+  #   cooldown:
+  #     default-days: 7
+  #   # find . -name "go.mod" | xargs -i dirname {}
+  #   directories:
+  #     - "/components/notebook-controller"
+  #     - "/components/pvcviewer-controller"
+  #     - "/components/tensorboard-controller"
+  #   schedule:
+  #     interval: "daily"
+  #   commit-message:
+  #     prefix: "chore"
+  #   ignore:
+  #     - dependency-name: "k8s.io/*"
+  #       update-types:
+  #         - "version-update:semver-major"
+  #         - "version-update:semver-minor"
+  #     - dependency-name: "sigs.k8s.io/*"
+  #       update-types:
+  #         - "version-update:semver-major"
+  #         - "version-update:semver-minor"
+  #   groups:
+  #     k8s-packages:
+  #       patterns:
+  #         - "k8s.io/*"
+  #         - "sigs.k8s.io/*"
+  #     go-test-packages:
+  #       patterns:
+  #         - "github.com/onsi/*"
+
+  # - package-ecosystem: "npm"
+  #   target-branch: "notebooks-v1"
+  #   open-pull-requests-limit: 5
+  #   cooldown:
+  #     default-days: 7
+  #   ignore:
+  #     - dependency-name: "*"
+  #       update-types:
+  #         - "version-update:semver-major"
+  #   # find . -name "package.json" | xargs -i dirname {}
+  #   directories:
+  #     - "/components/crud-web-apps/common/frontend/kubeflow-common-lib"
+  #     - "/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow"
+  #     - "/components/crud-web-apps/jupyter/frontend"
+  #     - "/components/crud-web-apps/tensorboards/frontend"
+  #     - "/components/crud-web-apps/volumes/frontend"
+  #   schedule:
+  #     interval: "daily"
+  #   commit-message:
+  #     prefix: "chore"
+  #   groups:
+  #     angular-packages:
+  #       patterns:
+  #         - "@angular/*"
+  #         - "@angular-eslint/*"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "notebooks-v1"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"
+
+  ########################
+  # -->     main     <-- #
+  ########################
+
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"


### PR DESCRIPTION
Main things to note about this setup are the following ones:

- We target three different branches (`main`, `notebooks-v1`,  `notebooks-v2`) via the `target-branch` directive
- The `cooldown` option delays updates a little to as a prevention mechanism for supply-chain attacks, similar to the `min-release-age` in NPM (see #1003)
- We try to group dependencies where sensible, however this will most likely need a bit of iteration
- Only allow non-breaking upgrades for things like the k8s packges and angular
- Part of the configuration for `notebooks-v1` is disabled to keep a good signal-to-noise ratio when starting out

Fixes https://github.com/kubeflow/notebooks/issues/818

cc @jenny-s51 who did the initial version of this in #819 
cc @andyatmiami who also gave a lot of input during development

---

I have already used this in a separate repository to evaluate it, checkout https://github.com/christian-heusel/notebooks-playground if you want to have a look!

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
