### PR TITLE
fix: prevent duplicate volumes when same PVC is mounted to multiple paths

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -57,6 +57,7 @@ def post_pvc(namespace):
         api.create_pvc(pvc, namespace, dry_run=True)
 
     # create the new PVCs and set the Notebook volumes and mounts
+    added_volumes = set()
     for api_volume in api_volumes:
         pvc = volumes.get_new_pvc(api_volume)
         if pvc is not None:
@@ -66,7 +67,10 @@ def post_pvc(namespace):
         v1_volume = volumes.get_pod_volume(api_volume, pvc)
         mount = volumes.get_container_mount(api_volume, v1_volume["name"])
 
-        notebook = volumes.add_notebook_volume(notebook, v1_volume)
+        if v1_volume["name"] not in added_volumes:
+            notebook = volumes.add_notebook_volume(notebook, v1_volume)
+            added_volumes.add(v1_volume["name"])
+
         notebook = volumes.add_notebook_container_mount(notebook, mount)
 
     log.info("Creating Notebook: %s", notebook)


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

When the same PVC is mounted to multiple paths via the Jupyter Web App UI, `add_notebook_volume` appends a `V1Volume` with the same name for each mount. This causes a Kubernetes validation error (duplicate volume names in `spec.volumes`) and the Pod fails to start.

**Fix:** Track already-added volume names in the volume creation loop (`post.py`) to skip duplicate `add_notebook_volume` calls. `add_notebook_container_mount` is unchanged since multiple `volumeMounts` referencing the same volume is valid in Kubernetes.

**How to test:**
1. Create a new notebook with the same PVC mounted to two different paths (e.g. `/data` and `/backup`)
2. Verify the Pod starts successfully with one volume entry and two volume mounts