### PR TITLE
fix: sync tensorboard container image on reconcile

### DIFF
--- a/components/tensorboard-controller/README.md
+++ b/components/tensorboard-controller/README.md
@@ -59,3 +59,7 @@ If you want to enable the scheduling functionality for Tensorboard servers that 
 2. Modify the `manager.yaml` file by navigating to the `deployment.spec.template.spec` field and manually setting the value of the `RWO_PVC_SCHEDULING` env var to `"true"` in the manager container.
 
 3. Run: `make deploy IMG=YOUR_IMAGE_NAME`
+
+## IMAGE UPGRADES
+
+The Tensorboard server image is configured via the `TENSORBOARD_IMAGE` env var on the controller (see `config/base/kustomization.yaml`). When this value changes and the controller rolls, the controller reconciles the image onto every existing `Tensorboard`'s managed Deployment, not just newly created ones. This means active users will see their Tensorboard pod briefly restart and their browser tab need a refresh; the underlying event logs (on the PVC or cloud bucket referenced by `spec.logspath`) are unaffected, so no data is lost.

--- a/components/tensorboard-controller/controllers/copy_deployment_test.go
+++ b/components/tensorboard-controller/controllers/copy_deployment_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func baseDeployment(image string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "tb", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: proto.Int32(1),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "tensorboard",
+						Image: image,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func TestCopyDeploymentSetFields_UpdatesChangedContainerImage(t *testing.T) {
+	from := baseDeployment("tensorflow/tensorboard:2.16.0")
+	to := baseDeployment("tensorflow/tensorboard:2.10.0")
+
+	if !CopyDeploymentSetFields(from, to) {
+		t.Fatalf("expected requireUpdate=true when container image differs")
+	}
+	got := to.Spec.Template.Spec.Containers[0].Image
+	if got != "tensorflow/tensorboard:2.16.0" {
+		t.Fatalf("expected image to be synced to %q, got %q", "tensorflow/tensorboard:2.16.0", got)
+	}
+}
+
+func TestCopyDeploymentSetFields_NoUpdateWhenImageMatches(t *testing.T) {
+	from := baseDeployment("tensorflow/tensorboard:2.16.0")
+	to := baseDeployment("tensorflow/tensorboard:2.16.0")
+
+	if CopyDeploymentSetFields(from, to) {
+		t.Fatalf("expected requireUpdate=false when nothing differs")
+	}
+}
+
+func TestCopyDeploymentSetFields_MatchesContainerByName(t *testing.T) {
+	from := baseDeployment("tensorflow/tensorboard:2.16.0")
+	to := baseDeployment("tensorflow/tensorboard:2.10.0")
+	// Add a sidecar that exists only on `to`; it must not be touched, and its
+	// presence must not prevent the tensorboard image from being synced.
+	to.Spec.Template.Spec.Containers = append(to.Spec.Template.Spec.Containers, corev1.Container{
+		Name:  "sidecar",
+		Image: "sidecar:v1",
+	})
+
+	if !CopyDeploymentSetFields(from, to) {
+		t.Fatalf("expected requireUpdate=true when tensorboard image differs")
+	}
+	if to.Spec.Template.Spec.Containers[0].Image != "tensorflow/tensorboard:2.16.0" {
+		t.Fatalf("tensorboard image was not synced")
+	}
+	if to.Spec.Template.Spec.Containers[1].Image != "sidecar:v1" {
+		t.Fatalf("sidecar image should not be touched, got %q", to.Spec.Template.Spec.Containers[1].Image)
+	}
+}

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -531,6 +531,24 @@ func CopyDeploymentSetFields(from, to *appsv1.Deployment) bool {
 	}
 	to.Spec.Template.Spec.Affinity = from.Spec.Template.Spec.Affinity
 
+	// Sync container images so existing Tensorboards pick up changes to the
+	// TENSORBOARD_IMAGE env var after a controller upgrade. Match by container
+	// name so reordering in generateDeployment can't silently swap images.
+	for i := range to.Spec.Template.Spec.Containers {
+		toContainer := &to.Spec.Template.Spec.Containers[i]
+		for j := range from.Spec.Template.Spec.Containers {
+			fromContainer := &from.Spec.Template.Spec.Containers[j]
+			if fromContainer.Name != toContainer.Name {
+				continue
+			}
+			if fromContainer.Image != toContainer.Image {
+				toContainer.Image = fromContainer.Image
+				requireUpdate = true
+			}
+			break
+		}
+	}
+
 	return requireUpdate
 }
 


### PR DESCRIPTION
## Summary
- `CopyDeploymentSetFields` only synced labels, replicas, and affinity, so any change to the `TENSORBOARD_IMAGE` env var only took effect on newly created Tensorboards. Existing Deployments drifted from the controller's desired spec indefinitely — including after security patches to the tensorboard image (see #781).
- Extend the helper to copy `Spec.Template.Spec.Containers[*].Image` when it differs. Containers are matched by name to avoid any cross-container assignment if ordering ever changes in `generateDeployment`.
- Other fields in the container spec (args, ports, volumes) are intentionally left alone: they derive from the immutable `Tensorboard` CR spec, so they cannot legitimately drift post-create. Narrowing the sync to image keeps the change minimal and avoids fighting with admission plugins that mutate container fields (context: #98).

## Why this matters
Today, operators rolling out a new `TENSORBOARD_IMAGE` (for CVE patches or feature upgrades) have no automated path to update running Tensorboards. The only workarounds are deleting and recreating each `Tensorboard` CR, or manually deleting the managed Deployments so the controller recreates them from the new template. With this change, a controller rollout is enough — the existing image-sync on reconcile will roll each Deployment to the new image.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make fmt vet` — clean
- [x] `go test -run '^TestCopyDeploymentSetFields_' ./controllers/ -v` — 3 new unit tests pass:
  - `TestCopyDeploymentSetFields_UpdatesChangedContainerImage`
  - `TestCopyDeploymentSetFields_NoUpdateWhenImageMatches`
  - `TestCopyDeploymentSetFields_MatchesContainerByName`
- [ ] Maintainers: run the existing `tb_controller_unit_test.yaml`, `tb_controller_integration_test.yaml`, and `tb_controller_multi_arch_test.yaml` workflows.
- [ ] Manual verification against `notebooks-v1`: roll the controller with a bumped `TENSORBOARD_IMAGE` and confirm existing Tensorboards' Deployments are updated and their pods roll.

## Notes
- Target branch: `notebooks-v1`.
- Scope is intentionally narrow — I noticed separately that the Deployment has no `readinessProbe` and an implicit rollout strategy, which combined with single-replica RWO-PVC backed Tensorboards means any image change incurs a brief outage per instance. Happy to open a follow-up PR for a `Recreate` strategy + readiness probe if maintainers want it; keeping it out of this change.