### PR TITLE
chore: drop scoped example from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please see the [Contributing to Kubeflow](https://www.kubeflow.org/docs/about/co
 To certify you agree to the [Developer Certificate of Origin](https://developercertificate.org/) you must sign-off each commit message using `git commit --signoff`, or manually write the following:
 
 ```text
-feat(ws): my commit message`
+feat: my commit message
 
 Signed-off-by: John Smith <john-smith@users.noreply.github.com>
 ```


### PR DESCRIPTION
## Summary

The DCO example in `CONTRIBUTING.md` showed `feat(ws): my commit message` as the canonical commit template, but the semantic-prs CI check was updated to disallow all scopes in PR titles (`.github/workflows/semantic-prs.yaml`, `disallowScopes: \".*\"`, added in #772 with the rationale that Prow OWNERS-based labels now cover what scopes used to signal).

A new contributor copying the example verbatim will hit a confusing `Validate Title` failure on their first PR.

This PR drops the `(ws)` scope from the example so the guide matches what CI enforces. It also removes a stray trailing backtick that was on the same line.

## Test plan

- [x] `CONTRIBUTING.md` renders correctly (no dangling backtick, code fence still closes)
- [x] Example now matches the rule enforced by `.github/workflows/semantic-prs.yaml`