### PR TITLE
fix: preserve v-prefixed prerelease workspaces image tags

### DIFF
--- a/.github/workflows/ws-build-image.yml
+++ b/.github/workflows/ws-build-image.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
       tag_with_semver:
         default: false
-        description: "if true, image tags will include the version (from semver_raw), always adds 'v' prefix if not already provided in semver_raw"
+        description: "if true, image tags will include the raw version from semver_raw"
         type: boolean
       tag_with_sha:
         default: false
@@ -78,7 +78,7 @@ jobs:
           flavor: |
             latest=${{ inputs.tag_with_latest }}
           tags: |
-            type=semver,priority=1000,pattern=v{{version}},enable=${{ inputs.tag_with_semver }},value=${{ inputs.semver_raw }}
+            type=semver,priority=1000,pattern={{raw}},enable=${{ inputs.tag_with_semver }},value=${{ inputs.semver_raw }}
             type=sha,priority=200,prefix=sha-,format=short,enable=${{ inputs.tag_with_sha }}
             type=sha,priority=100,prefix=sha-,format=long,enable=${{ inputs.tag_with_sha }}
 


### PR DESCRIPTION
## Summary

This fixes the release-tag mismatch for workspaces prerelease images.

At the moment, `releasing/version/VERSION` and the generated manifests use `v`-prefixed versions such as `v2.0.0-alpha.1`, but the published GHCR workspaces images end up without the leading `v`. That makes downstream manifests reference image tags that do not exist and can lead to `ImagePullBackOff` in consumers such as `kubeflow/manifests`.

PR #1000 was a pragmatic workaround that aligned manifests to the currently published no-`v` tags. This PR fixes the underlying publishing behavior so future prerelease releases are consistent at the source.

## Root cause

`ws-build-image.yml` uses `docker/metadata-action` for semver tagging.

For prerelease versions (`alpha`, `beta`, `rc`), `docker/metadata-action` normalizes semver output to `{{version}}` unless `{{raw}}` is used. That strips the leading `v`, even when the workflow is given a value like `v2.0.0-alpha.1`.

In practice this creates the following mismatch:

- `VERSION` = `v2.0.0-alpha.1`
- generated manifests expect `v2.0.0-alpha.1`
- published GHCR image becomes `2.0.0-alpha.1`

## Fix

Use the raw prerelease version string when generating workspaces image tags, so the published image tag matches `VERSION` exactly.

This restores one canonical version string across:
- git tags / releases
- `releasing/version/VERSION`
- generated manifests
- published GHCR image tags

## Why this is preferable

This keeps the release contract simple and predictable:
- if the release version is `vX.Y.Z-*`, the published workspaces image tag is also `vX.Y.Z-*`
