### PR TITLE
feat: filter workspaceKinds by uiHide 

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -584,6 +584,74 @@ describe('Create workspace', () => {
       createWorkspace.assertPodConfigSelected(mockPodConfig.id);
       createWorkspace.assertNextButtonEnabled();
     });
+
+    it('should hide workspace kinds with ruleEffects.uiHide set to true', () => {
+      const visibleKind = buildMockWorkspaceKind({
+        name: 'visible-kind',
+        displayName: 'Visible kind',
+        ruleEffects: { uiHide: false, aclDeny: false },
+      });
+      const hiddenKind = buildMockWorkspaceKind({
+        name: 'hidden-kind',
+        displayName: 'Hidden kind',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([visibleKind, hiddenKind]),
+      ).as('getWorkspaceKindsWithRuleEffects');
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsWithRuleEffects');
+
+      createWorkspace.assertCardVisible(visibleKind.name);
+      createWorkspace.assertCardNotVisible(hiddenKind.name);
+    });
+
+    it('should show all kinds when ruleEffects is missing', () => {
+      const kindWithoutRuleEffects = buildMockWorkspaceKind({
+        name: 'kind-without-rule-effects',
+        displayName: 'Kind without rule effects',
+        ruleEffects: undefined,
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kindWithoutRuleEffects]),
+      ).as('getWorkspaceKindsNoRuleEffects');
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsNoRuleEffects');
+
+      createWorkspace.assertCardVisible(kindWithoutRuleEffects.name);
+    });
+
+    it('should show empty state when all kinds are hidden by ruleEffects.uiHide set to true', () => {
+      const hiddenKind1 = buildMockWorkspaceKind({
+        name: 'hidden-kind-1',
+        displayName: 'Hidden kind 1',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+      const hiddenKind2 = buildMockWorkspaceKind({
+        name: 'hidden-kind-2',
+        displayName: 'Hidden kind 2',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([hiddenKind1, hiddenKind2]),
+      ).as('getWorkspaceKindsAllHidden');
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsAllHidden');
+
+      createWorkspace.assertNoResultsFound();
+    });
   });
 
   describe('Filter', () => {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
@@ -45,9 +45,14 @@ export const WorkspaceFormKindList: React.FunctionComponent<WorkspaceFormKindLis
   const { filterValues, setFilter, clearAllFilters } =
     useToolbarFilters<KindFilterKey>(filterConfig);
 
+  const visibleWorkspaceKinds = useMemo(
+    () => allWorkspaceKinds.filter((kind) => !kind.hidden && !kind.ruleEffects?.uiHide),
+    [allWorkspaceKinds],
+  );
+
   const filteredWorkspaceKinds = useMemo(
-    () => applyFilters(allWorkspaceKinds, filterValues, filterableProperties),
-    [allWorkspaceKinds, filterValues],
+    () => applyFilters(visibleWorkspaceKinds, filterValues, filterableProperties),
+    [visibleWorkspaceKinds, filterValues],
   );
 
   const onChange = useCallback(
@@ -107,67 +112,65 @@ export const WorkspaceFormKindList: React.FunctionComponent<WorkspaceFormKindLis
         )}
         {filteredWorkspaceKinds.length > 0 && (
           <Gallery hasGutter aria-label="Selectable card container">
-            {filteredWorkspaceKinds
-              .filter((kind) => !kind.hidden)
-              .map((kind) => (
-                <Card
-                  isCompact
-                  isSelectable
-                  key={kind.name}
-                  id={kind.name.replace(/ /g, '-')}
-                  isSelected={kind.name === selectedKind?.name}
-                  style={
-                    isSelectionDisabled && kind.name !== selectedKind?.name
-                      ? { opacity: 0.5, cursor: 'not-allowed' }
-                      : undefined
-                  }
-                  onClick={() => handleCardClick(kind)}
+            {filteredWorkspaceKinds.map((kind) => (
+              <Card
+                isCompact
+                isSelectable
+                key={kind.name}
+                id={kind.name.replace(/ /g, '-')}
+                isSelected={kind.name === selectedKind?.name}
+                style={
+                  isSelectionDisabled && kind.name !== selectedKind?.name
+                    ? { opacity: 0.5, cursor: 'not-allowed' }
+                    : undefined
+                }
+                onClick={() => handleCardClick(kind)}
+              >
+                <CardHeader
+                  selectableActions={{
+                    selectableActionId: `selectable-actions-item-${kind.name.replace(/ /g, '-')}`,
+                    selectableActionAriaLabelledby: kind.name.replace(/ /g, '-'),
+                    name: kind.name,
+                    variant: 'single',
+                    onChange,
+                  }}
                 >
-                  <CardHeader
-                    selectableActions={{
-                      selectableActionId: `selectable-actions-item-${kind.name.replace(/ /g, '-')}`,
-                      selectableActionAriaLabelledby: kind.name.replace(/ /g, '-'),
-                      name: kind.name,
-                      variant: 'single',
-                      onChange,
-                    }}
+                  <Flex
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    spaceItems={{ default: 'spaceItemsMd' }}
                   >
-                    <Flex
-                      alignItems={{ default: 'alignItemsCenter' }}
-                      spaceItems={{ default: 'spaceItemsMd' }}
-                    >
-                      <FlexItem>
-                        <WithValidImage
-                          imageSrc={kind.logo.url}
-                          skeletonWidth="60px"
-                          fallback={
-                            <ImageFallback
-                              imageSrc={kind.logo.url}
-                              extended
-                              message="Cannot load logo image"
-                            />
-                          }
-                        >
-                          {(validSrc) => (
-                            <img
-                              src={validSrc}
-                              alt={`${kind.name} logo`}
-                              className="workspace-kind-logo"
-                              data-testid={`kind-logo-${kind.name}`}
-                            />
-                          )}
-                        </WithValidImage>
-                      </FlexItem>
-                      <FlexItem>
-                        <CardTitle>{kind.displayName}</CardTitle>
-                      </FlexItem>
-                    </Flex>
-                  </CardHeader>
-                  <CardBody className="workspace-option-card__description">
-                    {kind.description}
-                  </CardBody>
-                </Card>
-              ))}
+                    <FlexItem>
+                      <WithValidImage
+                        imageSrc={kind.logo.url}
+                        skeletonWidth="60px"
+                        fallback={
+                          <ImageFallback
+                            imageSrc={kind.logo.url}
+                            extended
+                            message="Cannot load logo image"
+                          />
+                        }
+                      >
+                        {(validSrc) => (
+                          <img
+                            src={validSrc}
+                            alt={`${kind.name} logo`}
+                            className="workspace-kind-logo"
+                            data-testid={`kind-logo-${kind.name}`}
+                          />
+                        )}
+                      </WithValidImage>
+                    </FlexItem>
+                    <FlexItem>
+                      <CardTitle>{kind.displayName}</CardTitle>
+                    </FlexItem>
+                  </Flex>
+                </CardHeader>
+                <CardBody className="workspace-option-card__description">
+                  {kind.description}
+                </CardBody>
+              </Card>
+            ))}
           </Gallery>
         )}
       </PageSection>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/__tests__/WorkspaceFormKindList.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/__tests__/WorkspaceFormKindList.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WorkspaceFormKindList } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindList';
+import { buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+
+jest.mock('~/shared/components/WithValidImage', () => ({
+  __esModule: true,
+  default: ({ children }: { children: (src: string) => React.ReactNode }) =>
+    children('mocked-logo-src'),
+}));
+
+jest.mock('~/shared/components/ImageFallback', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('WorkspaceFormKindList', () => {
+  const mockOnSelect = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const defaultProps = {
+    selectedKind: undefined,
+    onSelect: mockOnSelect,
+    isSelectionDisabled: false,
+  };
+
+  describe('ruleEffects.uiHide filtering', () => {
+    it('shows kinds with uiHide: false', () => {
+      const kind = buildMockWorkspaceKind({
+        name: 'visible-kind',
+        displayName: 'Visible Kind',
+        ruleEffects: { uiHide: false, aclDeny: false },
+      });
+
+      render(<WorkspaceFormKindList {...defaultProps} allWorkspaceKinds={[kind]} />);
+
+      expect(screen.getByText('Visible Kind')).toBeInTheDocument();
+    });
+
+    it('hides kinds with uiHide set to true', () => {
+      const kind = buildMockWorkspaceKind({
+        name: 'hidden-kind',
+        displayName: 'Hidden Kind',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+
+      render(<WorkspaceFormKindList {...defaultProps} allWorkspaceKinds={[kind]} />);
+
+      expect(screen.queryByText('Hidden Kind')).not.toBeInTheDocument();
+    });
+
+    it('shows kinds when ruleEffects is undefined', () => {
+      const kind = buildMockWorkspaceKind({
+        name: 'no-rule-effects-kind',
+        displayName: 'No Rule Effects Kind',
+        ruleEffects: undefined,
+      });
+
+      render(<WorkspaceFormKindList {...defaultProps} allWorkspaceKinds={[kind]} />);
+
+      expect(screen.getByText('No Rule Effects Kind')).toBeInTheDocument();
+    });
+
+    it('shows visible kinds and hides uiHide kinds when both are present', () => {
+      const visibleKind = buildMockWorkspaceKind({
+        name: 'visible-kind',
+        displayName: 'Visible Kind',
+        ruleEffects: { uiHide: false, aclDeny: false },
+      });
+      const hiddenKind = buildMockWorkspaceKind({
+        name: 'hidden-kind',
+        displayName: 'Hidden Kind',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+
+      render(
+        <WorkspaceFormKindList {...defaultProps} allWorkspaceKinds={[visibleKind, hiddenKind]} />,
+      );
+
+      expect(screen.getByText('Visible Kind')).toBeInTheDocument();
+      expect(screen.queryByText('Hidden Kind')).not.toBeInTheDocument();
+    });
+
+    it('shows empty state when all kinds are hidden by uiHide', () => {
+      const hiddenKind1 = buildMockWorkspaceKind({
+        name: 'hidden-kind-1',
+        displayName: 'Hidden Kind 1',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+      const hiddenKind2 = buildMockWorkspaceKind({
+        name: 'hidden-kind-2',
+        displayName: 'Hidden Kind 2',
+        ruleEffects: { uiHide: true, aclDeny: false },
+      });
+
+      render(
+        <WorkspaceFormKindList {...defaultProps} allWorkspaceKinds={[hiddenKind1, hiddenKind2]} />,
+      );
+
+      expect(screen.queryByText('Hidden Kind 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Hidden Kind 2')).not.toBeInTheDocument();
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+  });
+});

--- a/workspaces/frontend/src/generated/data-contracts.ts
+++ b/workspaces/frontend/src/generated/data-contracts.ts
@@ -415,6 +415,14 @@ export interface WorkspacekindsRedirectMessage {
   text: string;
 }
 
+// TODO: this interface was added manually as a stub while the backend swagger spec is updated.
+// Once the backend exposes ruleEffects in swagger.json, regenerate this file using
+// `npm run generate:api` and remove this comment.
+export interface WorkspacekindsRuleEffects {
+  uiHide: boolean;
+  aclDeny: boolean;
+}
+
 export interface WorkspacekindsWorkspaceKind {
   clusterMetrics?: WorkspacekindsClusterMetrics;
   deprecated: boolean;
@@ -426,6 +434,7 @@ export interface WorkspacekindsWorkspaceKind {
   logo: WorkspacekindsImageRef;
   name: string;
   podTemplate: WorkspacekindsPodTemplate;
+  ruleEffects?: WorkspacekindsRuleEffects;
 }
 
 export interface WorkspacekindsClusterMetrics {

--- a/workspaces/frontend/src/shared/mock/mockBuilder.ts
+++ b/workspaces/frontend/src/shared/mock/mockBuilder.ts
@@ -447,6 +447,10 @@ export const buildMockWorkspaceKind = (
   logo: {
     url: 'https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg',
   },
+  ruleEffects: {
+    uiHide: false,
+    aclDeny: false,
+  },
   clusterMetrics: {
     workspacesCount: 10,
   },


### PR DESCRIPTION
closes: #860
related: #1010 
blocked by: #1043 

## Summary
Wire the workspace kind selection step to **hide** kinds when the API returns `ruleEffects.uiHide: true`, while keeping kinds visible when `ruleEffects` is missing . 
`GET /workspacekinds?namespaceFilter=…` is already used from the wizard via `useWorkspaceKinds(namespace)` (#1010)

## What changed

- **`WorkspaceFormKindList`**: filter kinds before the name filter — drop `hidden` and `ruleEffects.uiHide`, then apply the existing toolbar filters.
- **`data-contracts`**: optional `ruleEffects` on workspace kinds (`uiHide`, `aclDeny`). Stubbed in the generated contracts until swagger is updated; remove the TODO and run `npm run generate:api` once the spec includes it.
- **`mockBuilder`**: default `ruleEffects` on `buildMockWorkspaceKind` so mocks match the new shape.
- **Tests**: unit tests for `uiHide` / missing `ruleEffects` and Cypress tests.