### PR TITLE
fix: correctly aggregate ClusterRole

### DIFF
--- a/workspaces/controller/manifests/kustomize/base/manager/user_cluster_roles.yaml
+++ b/workspaces/controller/manifests/kustomize/base/manager/user_cluster_roles.yaml
@@ -13,6 +13,25 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kubeflow-workspaces-base-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - workspaces
+  - workspaces/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kubeflow-workspaces-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
@@ -21,21 +40,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
-rules:
-- apiGroups:
-  - kubeflow.org
-  resources:
-  - workspaces
-  - workspaces/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/workspaces/controller/manifests/kustomize/base/manager/user_cluster_roles.yaml
+++ b/workspaces/controller/manifests/kustomize/base/manager/user_cluster_roles.yaml
@@ -13,7 +13,33 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubeflow-workspaces-base-edit
+  name: kubeflow-workspaces-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-workspaces-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-view: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-to-kubeflow-workspaces-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
 rules:
@@ -32,23 +58,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubeflow-workspaces-edit
+  name: aggregate-to-kubeflow-workspaces-view
   labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
-rules: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-workspaces-view
-  labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-view: "true"
 rules:
 - apiGroups:
   - kubeflow.org


### PR DESCRIPTION
kubeflow-workspaces-edit defined both an aggregationRule and explicit rules. Kubernetes' aggregation controller replaces the rules field with aggregated content rather than merging them:

> "The control plane overwrites any values that you manually specify in the rules field of an aggregate ClusterRole."

https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

This caused the explicit create/delete/patch/update permissions to be silently overwritten with only the view rules from kubeflow-workspaces-view.

As a fix we extract the write verbs into a new base ClusterRole carrying the aggregate label, and make kubeflow-workspaces-edit a pure aggregation role.
