### PR TITLE
fix: add `min-width` to wsk logo card

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -29,6 +29,7 @@
 }
 
 .workspace-kind-logo {
+  min-width: 50px;
   max-width: 60px;
 }
 


### PR DESCRIPTION
Previously the logo for VSCode was not shown as it's SVG did not specify a minimum size which caused it to not be rendered at all.

Before:

<img width="2255" height="1329" alt="image" src="https://github.com/user-attachments/assets/d0cbf9b7-1ffa-42f7-b2bc-09681193bc9f" />


After:
<img width="2255" height="1329" alt="image" src="https://github.com/user-attachments/assets/3f35b423-d2bf-4d45-a788-bb527b8931a5" />
