### PR TITLE
feat: Add tolerations to WorkspaceKind Form

### DIFF
--- a/workspaces/frontend/config/cspell-ignore-words.txt
+++ b/workspaces/frontend/config/cspell-ignore-words.txt
@@ -16,3 +16,5 @@ rwop
 persistentvolumeclaims
 unhover
 unhovering
+toleration
+tolerations

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -407,7 +407,7 @@ class EditWorkspaceKind {
   }
 
   findPodConfigsTableRows() {
-    return this.findPodConfigsTable().find('tbody tr');
+    return this.findPodConfigsTable().find('tbody');
   }
 
   assertPodConfigsTableVisible() {
@@ -958,6 +958,140 @@ class EditWorkspaceKind {
     } else {
       this.findDetachVolumeModal().should('not.exist');
     }
+  }
+
+  // Pod Config Row Expansion
+  findPodConfigRowExpand(rowIndex: number) {
+    return cy.findByTestId(`pod-configs-table-row-${rowIndex}-expand`);
+  }
+
+  expandPodConfigRow(rowIndex: number) {
+    this.findPodConfigRowExpand(rowIndex).find('button').click();
+  }
+
+  // Tolerations
+  findAddTolerationButton(globalIndex: number) {
+    return cy.findByTestId(`add-toleration-button-${globalIndex}`);
+  }
+
+  clickAddToleration(globalIndex: number) {
+    this.findAddTolerationButton(globalIndex).click();
+  }
+
+  findTolerationModal() {
+    return cy.findByTestId('toleration-modal');
+  }
+
+  assertTolerationModalVisible(visible: boolean) {
+    if (visible) {
+      this.findTolerationModal().should('be.visible');
+    } else {
+      this.findTolerationModal().should('not.exist');
+    }
+  }
+
+  findTolerationKeyInput() {
+    return cy.findByTestId('toleration-key-input');
+  }
+
+  typeTolerationKey(key: string) {
+    this.findTolerationKeyInput().clear().type(key);
+  }
+
+  findTolerationValueInput() {
+    return cy.findByTestId('toleration-value-input');
+  }
+
+  typeTolerationValue(value: string) {
+    this.findTolerationValueInput().clear().type(value);
+  }
+
+  findTolerationOperatorSelect() {
+    return cy.findByTestId('toleration-operator-select');
+  }
+
+  selectTolerationOperator(label: string) {
+    this.findTolerationOperatorSelect().click();
+    cy.findByTestId(`toleration-operator-option-${label}`).click();
+  }
+
+  findTolerationEffectSelect() {
+    return cy.findByTestId('toleration-effect-select');
+  }
+
+  selectTolerationEffect(label: string) {
+    this.findTolerationEffectSelect().click();
+    cy.findByTestId(`toleration-effect-option-${label}`).click();
+  }
+
+  findTolerationSecondsForever() {
+    return cy.findByTestId('toleration-seconds-forever');
+  }
+
+  findTolerationSecondsCustom() {
+    return cy.findByTestId('toleration-seconds-custom');
+  }
+
+  assertTolerationSecondsVisible(visible: boolean) {
+    if (visible) {
+      this.findTolerationSecondsForever().should('exist');
+      this.findTolerationSecondsCustom().should('exist');
+    } else {
+      cy.findByTestId('toleration-seconds-forever').should('not.exist');
+      cy.findByTestId('toleration-seconds-custom').should('not.exist');
+    }
+  }
+
+  findTolerationModalSubmitButton() {
+    return cy.findByTestId('toleration-modal-submit-button');
+  }
+
+  submitTolerationModal() {
+    this.findTolerationModalSubmitButton().click();
+  }
+
+  findTolerationModalCancelButton() {
+    return cy.findByTestId('toleration-modal-cancel-button');
+  }
+
+  cancelTolerationModal() {
+    this.findTolerationModalCancelButton().click();
+  }
+
+  findTolerationsTable() {
+    return cy.findByTestId('tolerations-table');
+  }
+
+  assertTolerationsTableVisible() {
+    this.findTolerationsTable().should('be.visible');
+  }
+
+  assertTolerationRowCount(count: number) {
+    if (count === 0) {
+      cy.findByTestId('tolerations-table').should('not.exist');
+    } else {
+      this.findTolerationsTable().find('tbody tr').should('have.length', count);
+    }
+  }
+
+  assertTolerationKeyCell(index: number, value: string) {
+    cy.findByTestId(`toleration-key-cell-${index}`).should('have.text', value);
+  }
+
+  assertTolerationValueCell(index: number, value: string) {
+    cy.findByTestId(`toleration-value-cell-${index}`).should('have.text', value);
+  }
+
+  assertTolerationOperatorCell(index: number, value: string) {
+    cy.findByTestId(`toleration-operator-cell-${index}`).should('have.text', value);
+  }
+
+  assertTolerationEffectCell(index: number, value: string) {
+    cy.findByTestId(`toleration-effect-cell-${index}`).should('have.text', value);
+  }
+
+  assertTolerationSecondsCell(index: number, value: string) {
+    cy.findByTestId(`toleration-seconds-cell-${index}`).should('have.text', value);
   }
 
   // Action Buttons

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -1032,13 +1032,13 @@ class EditWorkspaceKind {
     return cy.findByTestId('toleration-seconds-custom');
   }
 
-  assertTolerationSecondsVisible(visible: boolean) {
-    if (visible) {
-      this.findTolerationSecondsForever().should('exist');
-      this.findTolerationSecondsCustom().should('exist');
+  assertTolerationSecondsEnabled(enabled: boolean) {
+    if (enabled) {
+      this.findTolerationSecondsForever().should('not.be.disabled');
+      this.findTolerationSecondsCustom().should('not.be.disabled');
     } else {
-      cy.findByTestId('toleration-seconds-forever').should('not.exist');
-      cy.findByTestId('toleration-seconds-custom').should('not.exist');
+      this.findTolerationSecondsForever().should('be.disabled');
+      this.findTolerationSecondsCustom().should('be.disabled');
     }
   }
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
@@ -775,17 +775,90 @@ describe('Edit workspace kind', () => {
         editWorkspaceKind.assertPodConfigInTable('NS Test Config');
       });
 
-      it('should retain node selectors when editing a pod config', () => {
+      describe('Tolerations in expanded pod config row', () => {
+        it('should open toleration modal when clicking Add Toleration', () => {
+          const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+          visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+          editWorkspaceKind.expandPodConfigSection();
+          editWorkspaceKind.expandPodConfigRow(0);
+
+          editWorkspaceKind.assertTolerationModalVisible(false);
+
+          editWorkspaceKind.clickAddToleration(0);
+
+          editWorkspaceKind.assertTolerationModalVisible(true);
+          editWorkspaceKind.findTolerationKeyInput().should('be.visible');
+          editWorkspaceKind.findTolerationValueInput().should('be.visible');
+          editWorkspaceKind.findTolerationOperatorSelect().should('be.visible');
+          editWorkspaceKind.findTolerationEffectSelect().should('be.visible');
+        });
+
+        it('should render a new toleration in the table after adding one', () => {
+          const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+          visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+          editWorkspaceKind.expandPodConfigSection();
+          editWorkspaceKind.expandPodConfigRow(0);
+
+          editWorkspaceKind.assertTolerationRowCount(0);
+
+          editWorkspaceKind.clickAddToleration(0);
+
+          editWorkspaceKind.selectTolerationOperator('Equal');
+          editWorkspaceKind.selectTolerationEffect('NoSchedule');
+          editWorkspaceKind.typeTolerationKey('gpu');
+          editWorkspaceKind.typeTolerationValue('true');
+          editWorkspaceKind.submitTolerationModal();
+
+          editWorkspaceKind.assertTolerationModalVisible(false);
+          editWorkspaceKind.assertTolerationRowCount(1);
+          editWorkspaceKind.assertTolerationKeyCell(0, 'gpu');
+          editWorkspaceKind.assertTolerationValueCell(0, 'true');
+          editWorkspaceKind.assertTolerationOperatorCell(0, 'Equal');
+          editWorkspaceKind.assertTolerationEffectCell(0, 'NoSchedule');
+          editWorkspaceKind.assertTolerationSecondsCell(0, 'Forever');
+        });
+
+        it('should show toleration seconds only when effect is NoExecute', () => {
+          const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+          visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+          editWorkspaceKind.expandPodConfigSection();
+          editWorkspaceKind.expandPodConfigRow(0);
+
+          editWorkspaceKind.clickAddToleration(0);
+
+          editWorkspaceKind.assertTolerationSecondsVisible(false);
+
+          editWorkspaceKind.selectTolerationEffect('NoSchedule');
+          editWorkspaceKind.assertTolerationSecondsVisible(false);
+
+          editWorkspaceKind.selectTolerationEffect('PreferNoSchedule');
+          editWorkspaceKind.assertTolerationSecondsVisible(false);
+
+          editWorkspaceKind.selectTolerationEffect('NoExecute');
+          editWorkspaceKind.assertTolerationSecondsVisible(true);
+          editWorkspaceKind.findTolerationSecondsForever().should('be.checked');
+
+          editWorkspaceKind.selectTolerationEffect('None');
+          editWorkspaceKind.assertTolerationSecondsVisible(false);
+        });
+      });
+    });
+
+    describe('Pod lifecycle section', () => {
+      it('should expand pod lifecycle section', () => {
         const { mockWorkspaceKind } = setupEditWorkspaceKind();
 
         visitEditWorkspaceKind(mockWorkspaceKind.name);
 
-        editWorkspaceKind.expandPodConfigSection();
+        editWorkspaceKind.assertPodTemplateSectionExpanded(false);
 
-        // Create a pod config with node selectors
-        editWorkspaceKind.clickAddConfigButton();
-        editWorkspaceKind.typePodConfigId('ns-retain-config');
-        editWorkspaceKind.typePodConfigDisplayName('NS Retain Config');
+        editWorkspaceKind.expandPodTemplateSection();
 
         editWorkspaceKind.expandNodeSelectorSection();
         editWorkspaceKind.clickAddNodeSelector();
@@ -809,453 +882,428 @@ describe('Edit workspace kind', () => {
         editWorkspaceKind.assertNodeSelectorCount(1);
         editWorkspaceKind.assertNodeSelectorKey(0, 'zone');
         editWorkspaceKind.assertNodeSelectorValue(0, 'us-west-2a');
+        editWorkspaceKind.assertPodTemplateSectionExpanded(true);
       });
 
-      it('should start with no node selectors in a new pod config', () => {
+      it('should display pod metadata section when expanded', () => {
         const { mockWorkspaceKind } = setupEditWorkspaceKind();
 
         visitEditWorkspaceKind(mockWorkspaceKind.name);
 
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.assertPodMetadataSectionVisible();
+      });
+
+      it('should display additional volumes section when expanded', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.assertAdditionalVolumesSectionVisible();
+      });
+
+      it('should add a new label', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+        editWorkspaceKind.expandLabelsSection();
+
+        editWorkspaceKind.clickAddLabel();
+        editWorkspaceKind.typeLabelKey(0, 'test-key');
+        editWorkspaceKind.typeLabelValue(0, 'test-value');
+
+        editWorkspaceKind.assertLabelCount(1);
+        editWorkspaceKind.assertLabelKey(0, 'test-key');
+        editWorkspaceKind.assertLabelValue(0, 'test-value');
+      });
+
+      it('should delete a label', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+        editWorkspaceKind.expandLabelsSection();
+
+        editWorkspaceKind.clickAddLabel();
+        editWorkspaceKind.typeLabelKey(0, 'test-key');
+        editWorkspaceKind.typeLabelValue(0, 'test-value');
+
+        editWorkspaceKind.assertLabelCount(1);
+
+        editWorkspaceKind.clickDeleteLabel(0);
+
+        editWorkspaceKind.assertLabelCount(0);
+      });
+
+      it('should add multiple labels', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+        editWorkspaceKind.expandLabelsSection();
+
+        editWorkspaceKind.clickAddLabel();
+        editWorkspaceKind.typeLabelKey(0, 'label1');
+        editWorkspaceKind.typeLabelValue(0, 'value1');
+
+        editWorkspaceKind.clickAddLabel();
+        editWorkspaceKind.typeLabelKey(1, 'label2');
+        editWorkspaceKind.typeLabelValue(1, 'value2');
+
+        editWorkspaceKind.assertLabelCount(2);
+        editWorkspaceKind.assertLabelKey(0, 'label1');
+        editWorkspaceKind.assertLabelValue(0, 'value1');
+        editWorkspaceKind.assertLabelKey(1, 'label2');
+        editWorkspaceKind.assertLabelValue(1, 'value2');
+      });
+
+      it('should add a new annotation', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+        editWorkspaceKind.expandAnnotationsSection();
+
+        editWorkspaceKind.clickAddAnnotation();
+        editWorkspaceKind.typeAnnotationKey(0, 'annotation-key');
+        editWorkspaceKind.typeAnnotationValue(0, 'annotation-value');
+
+        editWorkspaceKind.assertAnnotationCount(1);
+        editWorkspaceKind.assertAnnotationKey(0, 'annotation-key');
+        editWorkspaceKind.assertAnnotationValue(0, 'annotation-value');
+      });
+
+      it('should delete an annotation', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+        editWorkspaceKind.expandAnnotationsSection();
+
+        editWorkspaceKind.clickAddAnnotation();
+        editWorkspaceKind.typeAnnotationKey(0, 'annotation-key');
+        editWorkspaceKind.typeAnnotationValue(0, 'annotation-value');
+
+        editWorkspaceKind.assertAnnotationCount(1);
+
+        editWorkspaceKind.clickDeleteAnnotation(0);
+
+        editWorkspaceKind.assertAnnotationCount(0);
+      });
+
+      it('should add multiple annotations', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+        editWorkspaceKind.expandAnnotationsSection();
+
+        editWorkspaceKind.clickAddAnnotation();
+        editWorkspaceKind.typeAnnotationKey(0, 'annotation1');
+        editWorkspaceKind.typeAnnotationValue(0, 'value1');
+
+        editWorkspaceKind.clickAddAnnotation();
+        editWorkspaceKind.typeAnnotationKey(1, 'annotation2');
+        editWorkspaceKind.typeAnnotationValue(1, 'value2');
+
+        editWorkspaceKind.assertAnnotationCount(2);
+        editWorkspaceKind.assertAnnotationKey(0, 'annotation1');
+        editWorkspaceKind.assertAnnotationValue(0, 'value1');
+        editWorkspaceKind.assertAnnotationKey(1, 'annotation2');
+        editWorkspaceKind.assertAnnotationValue(1, 'value2');
+      });
+
+      it('should open create volume modal when clicking Create Volume button', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+
+        editWorkspaceKind.assertVolumeModalVisible(true);
+        editWorkspaceKind.assertVolumeModalTitle('Create New Volume');
+      });
+
+      it('should create a new volume', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.assertVolumeCount(0);
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('my-pvc');
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.assertVolumeModalVisible(false);
+        editWorkspaceKind.assertVolumeCount(1);
+        editWorkspaceKind.assertVolumeInTable('my-pvc');
+      });
+
+      it('should create a volume with read-only access', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('readonly-pvc');
+        editWorkspaceKind.toggleReadOnly();
+        editWorkspaceKind.assertReadOnlyChecked(true);
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.assertVolumeCount(1);
+        editWorkspaceKind.assertVolumeInTable('readonly-pvc');
+      });
+
+      it('should cancel volume creation', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('cancelled-pvc');
+        editWorkspaceKind.cancelVolumeModal();
+
+        editWorkspaceKind.assertVolumeModalVisible(false);
+        editWorkspaceKind.assertVolumeCount(0);
+      });
+
+      it('should open edit volume modal when clicking edit from actions menu', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('edit-test-pvc');
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.clickVolumeRowKebab(0);
+        editWorkspaceKind.clickEditVolume('edit-test-pvc');
+
+        editWorkspaceKind.assertVolumeModalVisible(true);
+        editWorkspaceKind.assertVolumeModalTitle('Edit Volume');
+        editWorkspaceKind.assertMountPath('/data/edit-test-pvc');
+      });
+
+      it('should edit an existing volume mount path', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('original-pvc');
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.clickVolumeRowKebab(0);
+        editWorkspaceKind.clickEditVolume('original-pvc');
+
+        editWorkspaceKind.typeMountPath('/edited');
+        editWorkspaceKind.submitVolumeModal();
+
+        editWorkspaceKind.assertVolumeCount(1);
+        editWorkspaceKind.assertVolumeInTable('original-pvc');
+      });
+
+      it('should open detach modal when clicking detach from actions menu', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('detach-test-pvc');
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.clickVolumeRowKebab(0);
+        editWorkspaceKind.clickDetachVolume();
+
+        editWorkspaceKind.assertDetachVolumeModalVisible(true);
+      });
+
+      it('should cancel volume detachment', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('cancel-detach-pvc');
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.clickVolumeRowKebab(0);
+        editWorkspaceKind.clickDetachVolume();
+        editWorkspaceKind.cancelDetachVolume();
+
+        editWorkspaceKind.assertDetachVolumeModalVisible(false);
+        editWorkspaceKind.assertVolumeCount(1);
+        editWorkspaceKind.assertVolumeInTable('cancel-detach-pvc');
+      });
+
+      it('should detach a volume when confirming detachment', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPodTemplateSection();
+
+        editWorkspaceKind.clickCreateVolume();
+        editWorkspaceKind.typePvcName('detach-pvc');
+        editWorkspaceKind.submitVolumeModal();
+        cy.wait('@createPvc');
+
+        editWorkspaceKind.assertVolumeCount(1);
+
+        editWorkspaceKind.clickVolumeRowKebab(0);
+        editWorkspaceKind.clickDetachVolume();
+        editWorkspaceKind.confirmDetachVolume();
+
+        editWorkspaceKind.assertDetachVolumeModalVisible(false);
+        editWorkspaceKind.assertVolumeCount(0);
+      });
+    });
+
+    describe('Multiple sections', () => {
+      it('should allow multiple sections to be expanded simultaneously', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPropertiesSection();
+        editWorkspaceKind.expandImageConfigSection();
         editWorkspaceKind.expandPodConfigSection();
-        editWorkspaceKind.clickAddConfigButton();
-        editWorkspaceKind.expandNodeSelectorSection();
+        editWorkspaceKind.expandPodTemplateSection();
 
-        editWorkspaceKind.assertNodeSelectorCount(0);
+        editWorkspaceKind.assertPropertiesSectionExpanded(true);
+        editWorkspaceKind.assertImageConfigSectionExpanded(true);
+        editWorkspaceKind.assertPodConfigSectionExpanded(true);
+        editWorkspaceKind.assertPodTemplateSectionExpanded(true);
       });
     });
-  });
 
-  describe('Pod lifecycle section', () => {
-    it('should expand pod lifecycle section', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+    describe('Form validation', () => {
+      it('should display all required fields', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
 
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
 
-      editWorkspaceKind.assertPodTemplateSectionExpanded(false);
+        editWorkspaceKind.expandPropertiesSection();
 
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.assertPodTemplateSectionExpanded(true);
-    });
-
-    it('should display pod metadata section when expanded', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.assertPodMetadataSectionVisible();
-    });
-
-    it('should display additional volumes section when expanded', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.assertAdditionalVolumesSectionVisible();
-    });
-
-    it('should add a new label', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-      editWorkspaceKind.expandLabelsSection();
-
-      editWorkspaceKind.clickAddLabel();
-      editWorkspaceKind.typeLabelKey(0, 'test-key');
-      editWorkspaceKind.typeLabelValue(0, 'test-value');
-
-      editWorkspaceKind.assertLabelCount(1);
-      editWorkspaceKind.assertLabelKey(0, 'test-key');
-      editWorkspaceKind.assertLabelValue(0, 'test-value');
-    });
-
-    it('should delete a label', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-      editWorkspaceKind.expandLabelsSection();
-
-      editWorkspaceKind.clickAddLabel();
-      editWorkspaceKind.typeLabelKey(0, 'test-key');
-      editWorkspaceKind.typeLabelValue(0, 'test-value');
-
-      editWorkspaceKind.assertLabelCount(1);
-
-      editWorkspaceKind.clickDeleteLabel(0);
-
-      editWorkspaceKind.assertLabelCount(0);
-    });
-
-    it('should add multiple labels', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-      editWorkspaceKind.expandLabelsSection();
-
-      editWorkspaceKind.clickAddLabel();
-      editWorkspaceKind.typeLabelKey(0, 'label1');
-      editWorkspaceKind.typeLabelValue(0, 'value1');
-
-      editWorkspaceKind.clickAddLabel();
-      editWorkspaceKind.typeLabelKey(1, 'label2');
-      editWorkspaceKind.typeLabelValue(1, 'value2');
-
-      editWorkspaceKind.assertLabelCount(2);
-      editWorkspaceKind.assertLabelKey(0, 'label1');
-      editWorkspaceKind.assertLabelValue(0, 'value1');
-      editWorkspaceKind.assertLabelKey(1, 'label2');
-      editWorkspaceKind.assertLabelValue(1, 'value2');
-    });
-
-    it('should add a new annotation', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-      editWorkspaceKind.expandAnnotationsSection();
-
-      editWorkspaceKind.clickAddAnnotation();
-      editWorkspaceKind.typeAnnotationKey(0, 'annotation-key');
-      editWorkspaceKind.typeAnnotationValue(0, 'annotation-value');
-
-      editWorkspaceKind.assertAnnotationCount(1);
-      editWorkspaceKind.assertAnnotationKey(0, 'annotation-key');
-      editWorkspaceKind.assertAnnotationValue(0, 'annotation-value');
-    });
-
-    it('should delete an annotation', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-      editWorkspaceKind.expandAnnotationsSection();
-
-      editWorkspaceKind.clickAddAnnotation();
-      editWorkspaceKind.typeAnnotationKey(0, 'annotation-key');
-      editWorkspaceKind.typeAnnotationValue(0, 'annotation-value');
-
-      editWorkspaceKind.assertAnnotationCount(1);
-
-      editWorkspaceKind.clickDeleteAnnotation(0);
-
-      editWorkspaceKind.assertAnnotationCount(0);
-    });
-
-    it('should add multiple annotations', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-      editWorkspaceKind.expandAnnotationsSection();
-
-      editWorkspaceKind.clickAddAnnotation();
-      editWorkspaceKind.typeAnnotationKey(0, 'annotation1');
-      editWorkspaceKind.typeAnnotationValue(0, 'value1');
-
-      editWorkspaceKind.clickAddAnnotation();
-      editWorkspaceKind.typeAnnotationKey(1, 'annotation2');
-      editWorkspaceKind.typeAnnotationValue(1, 'value2');
-
-      editWorkspaceKind.assertAnnotationCount(2);
-      editWorkspaceKind.assertAnnotationKey(0, 'annotation1');
-      editWorkspaceKind.assertAnnotationValue(0, 'value1');
-      editWorkspaceKind.assertAnnotationKey(1, 'annotation2');
-      editWorkspaceKind.assertAnnotationValue(1, 'value2');
-    });
-
-    it('should open create volume modal when clicking Create Volume button', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-
-      editWorkspaceKind.assertVolumeModalVisible(true);
-      editWorkspaceKind.assertVolumeModalTitle('Create New Volume');
-    });
-
-    it('should create a new volume', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.assertVolumeCount(0);
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('my-pvc');
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.assertVolumeModalVisible(false);
-      editWorkspaceKind.assertVolumeCount(1);
-      editWorkspaceKind.assertVolumeInTable('my-pvc');
-    });
-
-    it('should create a volume with read-only access', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('readonly-pvc');
-      editWorkspaceKind.toggleReadOnly();
-      editWorkspaceKind.assertReadOnlyChecked(true);
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.assertVolumeCount(1);
-      editWorkspaceKind.assertVolumeInTable('readonly-pvc');
-    });
-
-    it('should cancel volume creation', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('cancelled-pvc');
-      editWorkspaceKind.cancelVolumeModal();
-
-      editWorkspaceKind.assertVolumeModalVisible(false);
-      editWorkspaceKind.assertVolumeCount(0);
-    });
-
-    it('should open edit volume modal when clicking edit from actions menu', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('edit-test-pvc');
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.clickVolumeRowKebab(0);
-      editWorkspaceKind.clickEditVolume('edit-test-pvc');
-
-      editWorkspaceKind.assertVolumeModalVisible(true);
-      editWorkspaceKind.assertVolumeModalTitle('Edit Volume');
-      editWorkspaceKind.assertMountPath('/data/edit-test-pvc');
-    });
-
-    it('should edit an existing volume mount path', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('original-pvc');
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.clickVolumeRowKebab(0);
-      editWorkspaceKind.clickEditVolume('original-pvc');
-
-      editWorkspaceKind.typeMountPath('/edited');
-      editWorkspaceKind.submitVolumeModal();
-
-      editWorkspaceKind.assertVolumeCount(1);
-      editWorkspaceKind.assertVolumeInTable('original-pvc');
-    });
-
-    it('should open detach modal when clicking detach from actions menu', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('detach-test-pvc');
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.clickVolumeRowKebab(0);
-      editWorkspaceKind.clickDetachVolume();
-
-      editWorkspaceKind.assertDetachVolumeModalVisible(true);
-    });
-
-    it('should cancel volume detachment', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('cancel-detach-pvc');
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.clickVolumeRowKebab(0);
-      editWorkspaceKind.clickDetachVolume();
-      editWorkspaceKind.cancelDetachVolume();
-
-      editWorkspaceKind.assertDetachVolumeModalVisible(false);
-      editWorkspaceKind.assertVolumeCount(1);
-      editWorkspaceKind.assertVolumeInTable('cancel-detach-pvc');
-    });
-
-    it('should detach a volume when confirming detachment', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.clickCreateVolume();
-      editWorkspaceKind.typePvcName('detach-pvc');
-      editWorkspaceKind.submitVolumeModal();
-      cy.wait('@createPvc');
-
-      editWorkspaceKind.assertVolumeCount(1);
-
-      editWorkspaceKind.clickVolumeRowKebab(0);
-      editWorkspaceKind.clickDetachVolume();
-      editWorkspaceKind.confirmDetachVolume();
-
-      editWorkspaceKind.assertDetachVolumeModalVisible(false);
-      editWorkspaceKind.assertVolumeCount(0);
-    });
-  });
-
-  describe('Multiple sections', () => {
-    it('should allow multiple sections to be expanded simultaneously', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-      editWorkspaceKind.expandImageConfigSection();
-      editWorkspaceKind.expandPodConfigSection();
-      editWorkspaceKind.expandPodTemplateSection();
-
-      editWorkspaceKind.assertPropertiesSectionExpanded(true);
-      editWorkspaceKind.assertImageConfigSectionExpanded(true);
-      editWorkspaceKind.assertPodConfigSectionExpanded(true);
-      editWorkspaceKind.assertPodTemplateSectionExpanded(true);
-    });
-  });
-
-  describe('Form validation', () => {
-    it('should display all required fields', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-
-      editWorkspaceKind.assertWorkspaceKindNameInputVisible();
-      editWorkspaceKind.assertIconUrlInputVisible();
-      editWorkspaceKind.assertLogoUrlInputVisible();
-    });
-
-    it('should allow editing workspace kind name', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-      const newName = 'Updated Workspace Kind Name';
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-
-      editWorkspaceKind.typeWorkspaceKindName(newName);
-
-      editWorkspaceKind.assertWorkspaceKindName(newName);
-    });
-
-    it('should allow editing description', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-      const newDescription = 'Updated description for workspace kind';
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-
-      editWorkspaceKind.typeDescription(newDescription);
-
-      editWorkspaceKind.assertDescription(newDescription);
-    });
-
-    it('should allow editing icon URL', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-      const newIconUrl = 'https://example.com/new-icon.png';
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-
-      editWorkspaceKind.typeIconUrl(newIconUrl);
-
-      editWorkspaceKind.assertIconUrl(newIconUrl);
-    });
-
-    it('should allow editing logo URL', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind();
-      const newLogoUrl = 'https://example.com/new-logo.png';
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-
-      editWorkspaceKind.typeLogoUrl(newLogoUrl);
-
-      editWorkspaceKind.assertLogoUrl(newLogoUrl);
-    });
-
-    it('should allow toggling hidden state', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind({ hidden: false });
-
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
-
-      editWorkspaceKind.expandPropertiesSection();
-
-      editWorkspaceKind.assertHiddenChecked(false);
-
-      editWorkspaceKind.toggleHidden();
-
-      editWorkspaceKind.assertHiddenChecked(true);
-    });
-
-    it('should allow editing deprecation message when deprecated', () => {
-      const { mockWorkspaceKind } = setupEditWorkspaceKind({
-        deprecated: true,
-        deprecationMessage: 'Original message',
+        editWorkspaceKind.assertWorkspaceKindNameInputVisible();
+        editWorkspaceKind.assertIconUrlInputVisible();
+        editWorkspaceKind.assertLogoUrlInputVisible();
       });
-      const newMessage = 'Updated deprecation message';
 
-      visitEditWorkspaceKind(mockWorkspaceKind.name);
+      it('should allow editing workspace kind name', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+        const newName = 'Updated Workspace Kind Name';
 
-      editWorkspaceKind.expandPropertiesSection();
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
 
-      editWorkspaceKind.typeDeprecationMessage(newMessage);
+        editWorkspaceKind.expandPropertiesSection();
 
-      editWorkspaceKind.assertDeprecationMessage(newMessage);
+        editWorkspaceKind.typeWorkspaceKindName(newName);
+
+        editWorkspaceKind.assertWorkspaceKindName(newName);
+      });
+
+      it('should allow editing description', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+        const newDescription = 'Updated description for workspace kind';
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPropertiesSection();
+
+        editWorkspaceKind.typeDescription(newDescription);
+
+        editWorkspaceKind.assertDescription(newDescription);
+      });
+
+      it('should allow editing icon URL', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+        const newIconUrl = 'https://example.com/new-icon.png';
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPropertiesSection();
+
+        editWorkspaceKind.typeIconUrl(newIconUrl);
+
+        editWorkspaceKind.assertIconUrl(newIconUrl);
+      });
+
+      it('should allow editing logo URL', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind();
+        const newLogoUrl = 'https://example.com/new-logo.png';
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPropertiesSection();
+
+        editWorkspaceKind.typeLogoUrl(newLogoUrl);
+
+        editWorkspaceKind.assertLogoUrl(newLogoUrl);
+      });
+
+      it('should allow toggling hidden state', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind({ hidden: false });
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPropertiesSection();
+
+        editWorkspaceKind.assertHiddenChecked(false);
+
+        editWorkspaceKind.toggleHidden();
+
+        editWorkspaceKind.assertHiddenChecked(true);
+      });
+
+      it('should allow editing deprecation message when deprecated', () => {
+        const { mockWorkspaceKind } = setupEditWorkspaceKind({
+          deprecated: true,
+          deprecationMessage: 'Original message',
+        });
+        const newMessage = 'Updated deprecation message';
+
+        visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+        editWorkspaceKind.expandPropertiesSection();
+
+        editWorkspaceKind.typeDeprecationMessage(newMessage);
+
+        editWorkspaceKind.assertDeprecationMessage(newMessage);
+      });
     });
   });
 });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
@@ -832,20 +832,20 @@ describe('Edit workspace kind', () => {
 
           editWorkspaceKind.clickAddToleration(0);
 
-          editWorkspaceKind.assertTolerationSecondsVisible(false);
+          editWorkspaceKind.assertTolerationSecondsEnabled(false);
 
           editWorkspaceKind.selectTolerationEffect('NoSchedule');
-          editWorkspaceKind.assertTolerationSecondsVisible(false);
+          editWorkspaceKind.assertTolerationSecondsEnabled(false);
 
           editWorkspaceKind.selectTolerationEffect('PreferNoSchedule');
-          editWorkspaceKind.assertTolerationSecondsVisible(false);
+          editWorkspaceKind.assertTolerationSecondsEnabled(false);
 
           editWorkspaceKind.selectTolerationEffect('NoExecute');
-          editWorkspaceKind.assertTolerationSecondsVisible(true);
+          editWorkspaceKind.assertTolerationSecondsEnabled(true);
           editWorkspaceKind.findTolerationSecondsForever().should('be.checked');
 
           editWorkspaceKind.selectTolerationEffect('None');
-          editWorkspaceKind.assertTolerationSecondsVisible(false);
+          editWorkspaceKind.assertTolerationSecondsEnabled(false);
         });
       });
     });
@@ -860,28 +860,6 @@ describe('Edit workspace kind', () => {
 
         editWorkspaceKind.expandPodTemplateSection();
 
-        editWorkspaceKind.expandNodeSelectorSection();
-        editWorkspaceKind.clickAddNodeSelector();
-        editWorkspaceKind.typeNodeSelectorKey(0, 'zone');
-        editWorkspaceKind.typeNodeSelectorValue(0, 'us-west-2a');
-
-        editWorkspaceKind.submitPodConfigModal();
-        editWorkspaceKind.assertPodConfigModalVisible(false);
-
-        // Find the newly added config (last row) and edit it
-        const newIndex = mockWorkspaceKind.podTemplate.options.podConfig.values!.length;
-        editWorkspaceKind.clickPodConfigTableRowKebab(newIndex);
-        editWorkspaceKind.clickEditPodConfig();
-
-        editWorkspaceKind.assertPodConfigModalVisible(true);
-        editWorkspaceKind.assertPodConfigModalTitle('Edit Pod Configuration');
-        editWorkspaceKind.assertPodConfigId('ns-retain-config');
-
-        // Verify node selectors are still present
-        editWorkspaceKind.expandNodeSelectorSection();
-        editWorkspaceKind.assertNodeSelectorCount(1);
-        editWorkspaceKind.assertNodeSelectorKey(0, 'zone');
-        editWorkspaceKind.assertNodeSelectorValue(0, 'us-west-2a');
         editWorkspaceKind.assertPodTemplateSectionExpanded(true);
       });
 

--- a/workspaces/frontend/src/__tests__/unit/TolerationModal.spec.tsx
+++ b/workspaces/frontend/src/__tests__/unit/TolerationModal.spec.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { TolerationModal } from '~/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal';
+import { TolerationEffect, TolerationEntry, TolerationOperator } from '~/app/types';
+
+jest.mock('mod-arch-kubeflow', () => ({
+  useThemeContext: () => ({ isMUITheme: false }),
+}));
+
+const baseToleration: TolerationEntry = {
+  id: 'test-id-1',
+  operator: TolerationOperator.Equal,
+  effect: TolerationEffect.NoSchedule,
+  key: 'gpu',
+  value: 'true',
+  tolerationSeconds: null,
+};
+
+describe('TolerationModal', () => {
+  const onClose = jest.fn();
+  const onSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders in add mode with empty fields', () => {
+    render(
+      <TolerationModal isOpen onClose={onClose} onSubmit={onSubmit} existingToleration={null} />,
+    );
+    expect(screen.getByText('Add Toleration')).toBeInTheDocument();
+    expect(screen.getByTestId('toleration-modal-submit-button')).toHaveTextContent('Add');
+  });
+
+  it('renders in edit mode with pre-filled fields', () => {
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={baseToleration}
+      />,
+    );
+    expect(screen.getByText('Edit Toleration')).toBeInTheDocument();
+    expect(screen.getByTestId('toleration-modal-submit-button')).toHaveTextContent('Save');
+    expect(screen.getByTestId('toleration-key-input')).toHaveValue('gpu');
+    expect(screen.getByTestId('toleration-value-input')).toHaveValue('true');
+  });
+
+  it('disables submit when key is empty', () => {
+    render(
+      <TolerationModal isOpen onClose={onClose} onSubmit={onSubmit} existingToleration={null} />,
+    );
+    expect(screen.getByTestId('toleration-modal-submit-button')).toBeDisabled();
+  });
+
+  it('enables submit when key is provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <TolerationModal isOpen onClose={onClose} onSubmit={onSubmit} existingToleration={null} />,
+    );
+    await user.type(screen.getByTestId('toleration-key-input'), 'my-key');
+    expect(screen.getByTestId('toleration-modal-submit-button')).toBeEnabled();
+  });
+
+  it('disables value field when operator is Exists', async () => {
+    const existsToleration: TolerationEntry = {
+      ...baseToleration,
+      operator: TolerationOperator.Exists,
+    };
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={existsToleration}
+      />,
+    );
+    expect(screen.getByTestId('toleration-value-input')).toBeDisabled();
+  });
+
+  it('clears value when submitting with Exists operator', async () => {
+    const user = userEvent.setup();
+    const existsToleration: TolerationEntry = {
+      ...baseToleration,
+      operator: TolerationOperator.Exists,
+      value: 'should-be-cleared',
+    };
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={existsToleration}
+      />,
+    );
+    await user.click(screen.getByTestId('toleration-modal-submit-button'));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operator: TolerationOperator.Exists,
+        value: '',
+      }),
+    );
+  });
+
+  it('shows toleration seconds only when effect is NoExecute', () => {
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={{
+          ...baseToleration,
+          effect: TolerationEffect.NoExecute,
+          tolerationSeconds: 300,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('toleration-seconds-forever')).toBeInTheDocument();
+    expect(screen.getByTestId('toleration-seconds-custom')).toBeInTheDocument();
+  });
+
+  it('hides toleration seconds when effect is not NoExecute', () => {
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={baseToleration}
+      />,
+    );
+    expect(screen.queryByTestId('toleration-seconds-forever')).not.toBeInTheDocument();
+  });
+
+  it('submits with tolerationSeconds=null when effect is NoExecute and forever is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={{
+          ...baseToleration,
+          effect: TolerationEffect.NoExecute,
+          tolerationSeconds: null,
+        }}
+      />,
+    );
+    await user.click(screen.getByTestId('toleration-modal-submit-button'));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tolerationSeconds: null,
+      }),
+    );
+  });
+
+  it('calls onClose when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <TolerationModal isOpen onClose={onClose} onSubmit={onSubmit} existingToleration={null} />,
+    );
+    await user.click(screen.getByTestId('toleration-modal-cancel-button'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('preserves existing id when editing', async () => {
+    const user = userEvent.setup();
+    render(
+      <TolerationModal
+        isOpen
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={baseToleration}
+      />,
+    );
+    await user.click(screen.getByTestId('toleration-modal-submit-button'));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'test-id-1',
+      }),
+    );
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <TolerationModal
+        isOpen={false}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        existingToleration={null}
+      />,
+    );
+    expect(screen.queryByText('Add Toleration')).not.toBeInTheDocument();
+  });
+});

--- a/workspaces/frontend/src/__tests__/unit/TolerationModal.spec.tsx
+++ b/workspaces/frontend/src/__tests__/unit/TolerationModal.spec.tsx
@@ -3,7 +3,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { TolerationModal } from '~/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal';
-import { TolerationEffect, TolerationEntry, TolerationOperator } from '~/app/types';
+import { V1TaintEffect, V1TolerationOperator } from '~/generated/data-contracts';
+import { TolerationEntry } from '~/app/types';
 
 jest.mock('mod-arch-kubeflow', () => ({
   useThemeContext: () => ({ isMUITheme: false }),
@@ -11,11 +12,10 @@ jest.mock('mod-arch-kubeflow', () => ({
 
 const baseToleration: TolerationEntry = {
   id: 'test-id-1',
-  operator: TolerationOperator.Equal,
-  effect: TolerationEffect.NoSchedule,
+  operator: V1TolerationOperator.TolerationOpEqual,
+  effect: V1TaintEffect.TaintEffectNoSchedule,
   key: 'gpu',
   value: 'true',
-  tolerationSeconds: null,
 };
 
 describe('TolerationModal', () => {
@@ -68,7 +68,7 @@ describe('TolerationModal', () => {
   it('disables value field when operator is Exists', async () => {
     const existsToleration: TolerationEntry = {
       ...baseToleration,
-      operator: TolerationOperator.Exists,
+      operator: V1TolerationOperator.TolerationOpExists,
     };
     render(
       <TolerationModal
@@ -85,7 +85,7 @@ describe('TolerationModal', () => {
     const user = userEvent.setup();
     const existsToleration: TolerationEntry = {
       ...baseToleration,
-      operator: TolerationOperator.Exists,
+      operator: V1TolerationOperator.TolerationOpExists,
       value: 'should-be-cleared',
     };
     render(
@@ -99,7 +99,7 @@ describe('TolerationModal', () => {
     await user.click(screen.getByTestId('toleration-modal-submit-button'));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        operator: TolerationOperator.Exists,
+        operator: V1TolerationOperator.TolerationOpExists,
         value: '',
       }),
     );
@@ -113,7 +113,7 @@ describe('TolerationModal', () => {
         onSubmit={onSubmit}
         existingToleration={{
           ...baseToleration,
-          effect: TolerationEffect.NoExecute,
+          effect: V1TaintEffect.TaintEffectNoExecute,
           tolerationSeconds: 300,
         }}
       />,
@@ -144,15 +144,14 @@ describe('TolerationModal', () => {
         onSubmit={onSubmit}
         existingToleration={{
           ...baseToleration,
-          effect: TolerationEffect.NoExecute,
-          tolerationSeconds: null,
+          effect: V1TaintEffect.TaintEffectNoExecute,
         }}
       />,
     );
     await user.click(screen.getByTestId('toleration-modal-submit-button'));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        tolerationSeconds: null,
+        tolerationSeconds: undefined,
       }),
     );
   });

--- a/workspaces/frontend/src/__tests__/unit/TolerationModal.spec.tsx
+++ b/workspaces/frontend/src/__tests__/unit/TolerationModal.spec.tsx
@@ -122,7 +122,7 @@ describe('TolerationModal', () => {
     expect(screen.getByTestId('toleration-seconds-custom')).toBeInTheDocument();
   });
 
-  it('hides toleration seconds when effect is not NoExecute', () => {
+  it('disables toleration seconds when effect is not NoExecute', () => {
     render(
       <TolerationModal
         isOpen
@@ -131,7 +131,8 @@ describe('TolerationModal', () => {
         existingToleration={baseToleration}
       />,
     );
-    expect(screen.queryByTestId('toleration-seconds-forever')).not.toBeInTheDocument();
+    expect(screen.getByTestId('toleration-seconds-forever')).toBeDisabled();
+    expect(screen.getByTestId('toleration-seconds-custom')).toBeDisabled();
   });
 
   it('submits with tolerationSeconds=null when effect is NoExecute and forever is selected', async () => {

--- a/workspaces/frontend/src/__tests__/unit/WorkspaceKindFormTolerations.spec.tsx
+++ b/workspaces/frontend/src/__tests__/unit/WorkspaceKindFormTolerations.spec.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { WorkspaceKindFormTolerations } from '~/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations';
+import { TolerationEffect, TolerationEntry, TolerationOperator } from '~/app/types';
+
+jest.mock('mod-arch-kubeflow', () => ({
+  useThemeContext: () => ({ isMUITheme: false }),
+}));
+
+const makeToleration = (overrides: Partial<TolerationEntry> = {}): TolerationEntry => ({
+  id: 'tol-1',
+  operator: TolerationOperator.Equal,
+  effect: TolerationEffect.NoSchedule,
+  key: 'gpu',
+  value: 'true',
+  tolerationSeconds: null,
+  ...overrides,
+});
+
+describe('WorkspaceKindFormTolerations', () => {
+  const setTolerations = jest.fn();
+  const setIsTolerationModalOpen = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when tolerations list is empty', () => {
+    const { container } = render(
+      <WorkspaceKindFormTolerations
+        tolerations={[]}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    expect(container.querySelector('table')).not.toBeInTheDocument();
+  });
+
+  it('renders a table row for each toleration', () => {
+    const tolerations = [
+      makeToleration({ id: 'tol-1', key: 'gpu' }),
+      makeToleration({ id: 'tol-2', key: 'disk', effect: TolerationEffect.NoExecute }),
+    ];
+    render(
+      <WorkspaceKindFormTolerations
+        tolerations={tolerations}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    const rows = screen.getAllByRole('row');
+    // 1 header row + 2 data rows
+    expect(rows).toHaveLength(3);
+  });
+
+  it('displays dash for value when operator is Exists', () => {
+    const tolerations = [makeToleration({ operator: TolerationOperator.Exists, value: 'ignored' })];
+    render(
+      <WorkspaceKindFormTolerations
+        tolerations={tolerations}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    const row = screen.getAllByRole('row')[1];
+    expect(within(row).getByText('-')).toBeInTheDocument();
+  });
+
+  it('displays Forever when tolerationSeconds is null', () => {
+    const tolerations = [makeToleration({ tolerationSeconds: null })];
+    render(
+      <WorkspaceKindFormTolerations
+        tolerations={tolerations}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    expect(screen.getByText('Forever')).toBeInTheDocument();
+  });
+
+  it('displays seconds value when tolerationSeconds is set', () => {
+    const tolerations = [makeToleration({ tolerationSeconds: 300 })];
+    render(
+      <WorkspaceKindFormTolerations
+        tolerations={tolerations}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    expect(screen.getByText('300s')).toBeInTheDocument();
+  });
+
+  it('calls setTolerations to remove a toleration when remove button is clicked', async () => {
+    const user = userEvent.setup();
+    const tolerations = [
+      makeToleration({ id: 'tol-1', key: 'gpu' }),
+      makeToleration({ id: 'tol-2', key: 'disk' }),
+    ];
+    render(
+      <WorkspaceKindFormTolerations
+        tolerations={tolerations}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    await user.click(screen.getByTestId('toleration-remove-0'));
+    expect(setTolerations).toHaveBeenCalledWith(expect.any(Function));
+    const updater = setTolerations.mock.calls[0][0];
+    const result = updater(tolerations);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('tol-2');
+  });
+
+  it('opens modal in edit mode when edit button is clicked', async () => {
+    const user = userEvent.setup();
+    const tolerations = [makeToleration()];
+    render(
+      <WorkspaceKindFormTolerations
+        tolerations={tolerations}
+        setTolerations={setTolerations}
+        isTolerationModalOpen={false}
+        setIsTolerationModalOpen={setIsTolerationModalOpen}
+      />,
+    );
+    await user.click(screen.getByTestId('toleration-edit-0'));
+    expect(setIsTolerationModalOpen).toHaveBeenCalledWith(true);
+  });
+});

--- a/workspaces/frontend/src/__tests__/unit/WorkspaceKindFormTolerations.spec.tsx
+++ b/workspaces/frontend/src/__tests__/unit/WorkspaceKindFormTolerations.spec.tsx
@@ -3,7 +3,8 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { WorkspaceKindFormTolerations } from '~/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations';
-import { TolerationEffect, TolerationEntry, TolerationOperator } from '~/app/types';
+import { V1TaintEffect, V1TolerationOperator } from '~/generated/data-contracts';
+import { TolerationEntry } from '~/app/types';
 
 jest.mock('mod-arch-kubeflow', () => ({
   useThemeContext: () => ({ isMUITheme: false }),
@@ -11,11 +12,10 @@ jest.mock('mod-arch-kubeflow', () => ({
 
 const makeToleration = (overrides: Partial<TolerationEntry> = {}): TolerationEntry => ({
   id: 'tol-1',
-  operator: TolerationOperator.Equal,
-  effect: TolerationEffect.NoSchedule,
+  operator: V1TolerationOperator.TolerationOpEqual,
+  effect: V1TaintEffect.TaintEffectNoSchedule,
   key: 'gpu',
   value: 'true',
-  tolerationSeconds: null,
   ...overrides,
 });
 
@@ -42,7 +42,7 @@ describe('WorkspaceKindFormTolerations', () => {
   it('renders a table row for each toleration', () => {
     const tolerations = [
       makeToleration({ id: 'tol-1', key: 'gpu' }),
-      makeToleration({ id: 'tol-2', key: 'disk', effect: TolerationEffect.NoExecute }),
+      makeToleration({ id: 'tol-2', key: 'disk', effect: V1TaintEffect.TaintEffectNoExecute }),
     ];
     render(
       <WorkspaceKindFormTolerations
@@ -58,7 +58,9 @@ describe('WorkspaceKindFormTolerations', () => {
   });
 
   it('displays dash for value when operator is Exists', () => {
-    const tolerations = [makeToleration({ operator: TolerationOperator.Exists, value: 'ignored' })];
+    const tolerations = [
+      makeToleration({ operator: V1TolerationOperator.TolerationOpExists, value: 'ignored' }),
+    ];
     render(
       <WorkspaceKindFormTolerations
         tolerations={tolerations}
@@ -71,8 +73,8 @@ describe('WorkspaceKindFormTolerations', () => {
     expect(within(row).getByText('-')).toBeInTheDocument();
   });
 
-  it('displays Forever when tolerationSeconds is null', () => {
-    const tolerations = [makeToleration({ tolerationSeconds: null })];
+  it('displays Forever when tolerationSeconds is undefined', () => {
+    const tolerations = [makeToleration({ tolerationSeconds: undefined })];
     render(
       <WorkspaceKindFormTolerations
         tolerations={tolerations}

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -202,6 +202,11 @@ body,
   flex-direction: row;
 }
 
+/* Grey out disabled radio button circles */
+.mui-theme .pf-v6-c-radio__label.pf-m-disabled:not(.pf-v6-c-card .pf-v6-c-radio__label)::before {
+  border-color: var(--pf-t--global--color--disabled--default);
+}
+
 /* Top border separator for non-first storage class group headers in the PVC typeahead select */
 .pvc-select-group-header--with-divider {
   border-top: 1px solid var(--pf-t--global--border--color--default);

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
@@ -1,5 +1,13 @@
-import React, { useMemo, useState } from 'react';
-import { Table, Thead, Tr, Td, Tbody, Th } from '@patternfly/react-table/dist/esm/components/Table';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Table,
+  Thead,
+  Tr,
+  Td,
+  Tbody,
+  Th,
+  ExpandableRowContent,
+} from '@patternfly/react-table/dist/esm/components/Table';
 import { getUniqueId } from '@patternfly/react-core/helpers';
 import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
@@ -21,8 +29,15 @@ interface PaginatedTableProps {
   handleEdit: (index: number) => void;
   openDeleteModal: (index: number) => void;
   ariaLabel: string;
+  paginated?: boolean;
   dataTestId?: string;
+  expandedContent?: (
+    row: WorkspaceKindImageConfigValue | WorkspacekindsPodConfigValue,
+    globalIndex: number,
+  ) => React.ReactNode;
 }
+
+const NUM_BASE_COLUMNS = 5;
 
 export const WorkspaceKindFormPaginatedTable: React.FC<PaginatedTableProps> = ({
   rows,
@@ -32,17 +47,35 @@ export const WorkspaceKindFormPaginatedTable: React.FC<PaginatedTableProps> = ({
   openDeleteModal,
   ariaLabel,
   dataTestId,
+  expandedContent,
+  paginated = true,
 }) => {
   const [dropdownOpen, setDropdownOpen] = useState<number | null>(null);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
+  const effectivePerPage = paginated ? perPage : rows.length || 1;
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  const isExpandable = !!expandedContent;
+
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
   const rowPages = useMemo(() => {
     const pages = [];
-    for (let i = 0; i < rows.length; i += perPage) {
-      pages.push(rows.slice(i, i + perPage));
+    for (let i = 0; i < rows.length; i += effectivePerPage) {
+      pages.push(rows.slice(i, i + effectivePerPage));
     }
     return pages;
-  }, [perPage, rows]);
+  }, [effectivePerPage, rows]);
 
   const onSetPage = (
     _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
@@ -64,6 +97,7 @@ export const WorkspaceKindFormPaginatedTable: React.FC<PaginatedTableProps> = ({
       <Table aria-label={ariaLabel} data-testid={dataTestId}>
         <Thead>
           <Tr>
+            {isExpandable && <Th screenReaderText="Expand" />}
             <Th>Display Name</Th>
             <Th>ID</Th>
             <Th screenReaderText="Row select">Default</Th>
@@ -71,19 +105,29 @@ export const WorkspaceKindFormPaginatedTable: React.FC<PaginatedTableProps> = ({
             <Th aria-label="Actions" />
           </Tr>
         </Thead>
-        <Tbody>
-          {rowPages[page - 1].map((row, index) => (
+        {rowPages[page - 1].map((row, pageIndex) => {
+          const globalIndex = effectivePerPage * (page - 1) + pageIndex;
+          const isExpanded = expandedRows.has(row.id);
+          const rowContent = (
             <Tr key={row.id}>
+              {isExpandable && (
+                <Td
+                  expand={{
+                    rowIndex: globalIndex,
+                    isExpanded,
+                    onToggle: () => handleToggleExpand(row.id),
+                  }}
+                />
+              )}
               <Td>{row.displayName}</Td>
               <Td>{row.id}</Td>
               <Td>
                 <Radio
                   className="workspace-kind-form-radio"
-                  id={`default-${ariaLabel}-${index}`}
-                  name={`default-${ariaLabel}-${index}-radio`}
+                  id={`default-${ariaLabel}-${pageIndex}`}
+                  name={`default-${ariaLabel}-${pageIndex}-radio`}
                   isChecked={defaultId === row.id}
                   onChange={() => {
-                    console.log(row.id);
                     setDefaultId(row.id);
                   }}
                   aria-label={`Select ${row.id} as default`}
@@ -103,41 +147,58 @@ export const WorkspaceKindFormPaginatedTable: React.FC<PaginatedTableProps> = ({
                   toggle={(toggleRef) => (
                     <MenuToggle
                       ref={toggleRef}
-                      isExpanded={dropdownOpen === index}
-                      onClick={() => setDropdownOpen(dropdownOpen === index ? null : index)}
+                      isExpanded={dropdownOpen === globalIndex}
+                      onClick={() =>
+                        setDropdownOpen(dropdownOpen === globalIndex ? null : globalIndex)
+                      }
                       variant="plain"
                       aria-label="plain kebab"
-                      data-testid={`${dataTestId}-row-${index}-kebab`}
+                      data-testid={`${dataTestId}-row-${pageIndex}-kebab`}
                     >
                       <EllipsisVIcon />
                     </MenuToggle>
                   )}
-                  isOpen={dropdownOpen === index}
+                  isOpen={dropdownOpen === globalIndex}
                   onSelect={() => setDropdownOpen(null)}
                   popperProps={{ position: 'right' }}
                 >
-                  <DropdownItem onClick={() => handleEdit(perPage * (page - 1) + index)}>
-                    Edit
-                  </DropdownItem>
-                  <DropdownItem onClick={() => openDeleteModal(perPage * (page - 1) + index)}>
-                    Remove
-                  </DropdownItem>
+                  <DropdownItem onClick={() => handleEdit(globalIndex)}>Edit</DropdownItem>
+                  <DropdownItem onClick={() => openDeleteModal(globalIndex)}>Remove</DropdownItem>
                 </Dropdown>
               </Td>
             </Tr>
-          ))}
-        </Tbody>
+          );
+
+          if (isExpandable) {
+            return (
+              <Tbody key={row.id} isExpanded={isExpanded}>
+                {rowContent}
+                <Tr isExpanded={isExpanded}>
+                  <Td colSpan={NUM_BASE_COLUMNS + 1}>
+                    <ExpandableRowContent>
+                      {expandedContent!(row, globalIndex)}
+                    </ExpandableRowContent>
+                  </Td>
+                </Tr>
+              </Tbody>
+            );
+          }
+
+          return <Tbody key={row.id}>{rowContent}</Tbody>;
+        })}
       </Table>
-      <Pagination
-        itemCount={rows.length}
-        widgetId="pagination-bottom"
-        perPage={perPage}
-        page={page}
-        variant={PaginationVariant.bottom}
-        isCompact
-        onSetPage={onSetPage}
-        onPerPageSelect={onPerPageSelect}
-      />
+      {paginated && (
+        <Pagination
+          itemCount={rows.length}
+          widgetId="pagination-bottom"
+          perPage={perPage}
+          page={page}
+          variant={PaginationVariant.bottom}
+          isCompact
+          onSetPage={onSetPage}
+          onPerPageSelect={onPerPageSelect}
+        />
+      )}
     </PageSection>
   );
 };

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
@@ -32,7 +32,7 @@ interface PaginatedTableProps {
   paginated?: boolean;
   dataTestId?: string;
   expandedContent?: (
-    row: WorkspaceKindImageConfigValue | WorkspacekindsPodConfigValue,
+    row: WorkspaceKindImageConfigValue | OptionsPodConfigValue,
     globalIndex: number,
   ) => React.ReactNode;
 }

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable.tsx
@@ -112,6 +112,7 @@ export const WorkspaceKindFormPaginatedTable: React.FC<PaginatedTableProps> = ({
             <Tr key={row.id}>
               {isExpandable && (
                 <Td
+                  data-testid={`${dataTestId}-row-${pageIndex}-expand`}
                   expand={{
                     rowIndex: globalIndex,
                     isExpanded,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -153,7 +153,7 @@ export const EMPTY_WORKSPACE_KIND_FORM_DATA = {
 export const emptyToleration = (): TolerationEntry => ({
   id: generateUniqueId(),
   operator: TolerationOperator.Equal,
-  effect: TolerationEffect.NoExecute,
+  effect: TolerationEffect.None,
   key: '',
   value: '',
   tolerationSeconds: null,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -1,4 +1,11 @@
-import { ImagePullPolicy, WorkspaceKindImagePort, WorkspaceKindPodConfigValue } from '~/app/types';
+import {
+  ImagePullPolicy,
+  TolerationEffect,
+  TolerationEntry,
+  TolerationOperator,
+  WorkspaceKindImagePort,
+  WorkspaceKindPodConfigValue,
+} from '~/app/types';
 import { OptionsOptionLabel, OptionsPodConfigValue } from '~/generated/data-contracts';
 import { PodResourceEntry } from './podConfig/WorkspaceKindFormResource';
 
@@ -143,6 +150,15 @@ export const EMPTY_WORKSPACE_KIND_FORM_DATA = {
     },
   },
 };
+export const emptyToleration = (): TolerationEntry => ({
+  id: generateUniqueId(),
+  operator: TolerationOperator.Equal,
+  effect: TolerationEffect.NoExecute,
+  key: '',
+  value: '',
+  tolerationSeconds: null,
+});
+
 // convert from k8s resource object {limits: {}, requests{}} to array of {type: '', limit: '', request: ''} for each type of resource (e.g. CPU, memory, nvidia.com/gpu)
 export const getResources = (currConfig: WorkspaceKindPodConfigValue): PodResourceEntry[] => {
   const grouped = new Map<string, { request: string; limit: string }>([

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -1,12 +1,14 @@
 import {
   ImagePullPolicy,
-  TolerationEffect,
   TolerationEntry,
-  TolerationOperator,
   WorkspaceKindImagePort,
   WorkspaceKindPodConfigValue,
 } from '~/app/types';
-import { OptionsOptionLabel, OptionsPodConfigValue } from '~/generated/data-contracts';
+import {
+  OptionsOptionLabel,
+  OptionsPodConfigValue,
+  V1TolerationOperator,
+} from '~/generated/data-contracts';
 import { PodResourceEntry } from './podConfig/WorkspaceKindFormResource';
 
 // Simple ID generator to avoid PatternFly dependency in tests
@@ -152,11 +154,9 @@ export const EMPTY_WORKSPACE_KIND_FORM_DATA = {
 };
 export const emptyToleration = (): TolerationEntry => ({
   id: generateUniqueId(),
-  operator: TolerationOperator.Equal,
-  effect: TolerationEffect.None,
+  operator: V1TolerationOperator.TolerationOpEqual,
   key: '',
   value: '',
-  tolerationSeconds: null,
 });
 
 // convert from k8s resource object {limits: {}, requests{}} to array of {type: '', limit: '', request: ''} for each type of resource (e.g. CPU, memory, nvidia.com/gpu)

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal.tsx
@@ -20,48 +20,55 @@ import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput'
 import { Popover } from '@patternfly/react-core/dist/esm/components/Popover';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
-import { TolerationEffect, TolerationEntry, TolerationOperator } from '~/app/types';
+import { V1TaintEffect, V1TolerationOperator } from '~/generated/data-contracts';
+import { TolerationEntry } from '~/app/types';
 import { emptyToleration, generateUniqueId } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
 import { ResourceInputWrapper } from '~/shared/components/ResourceInputWrapper';
 
 const OPERATOR_OPTIONS = [
   {
-    value: TolerationOperator.Equal,
+    value: V1TolerationOperator.TolerationOpEqual,
     label: 'Equal',
     description:
       'A toleration "matches" a taint if the keys are the same, the effects are the same, and the values are equal.',
   },
   {
-    value: TolerationOperator.Exists,
+    value: V1TolerationOperator.TolerationOpExists,
     label: 'Exists',
     description:
       'A toleration "matches" a taint if the keys are the same and the effects are the same. No value should be specified.',
   },
 ] as const;
 
-const EFFECT_OPTIONS = [
+type EffectSelectValue = V1TaintEffect | '';
+
+const EFFECT_OPTIONS: ReadonlyArray<{
+  value: EffectSelectValue;
+  label: string;
+  description: string;
+}> = [
   {
-    value: TolerationEffect.None,
+    value: '',
     label: 'None',
     description: 'An empty effect matches all effects with key and value.',
   },
   {
-    value: TolerationEffect.NoSchedule,
+    value: V1TaintEffect.TaintEffectNoSchedule,
     label: 'NoSchedule',
     description: 'Prevents scheduling of new pods on the node with the matching taint.',
   },
   {
-    value: TolerationEffect.PreferNoSchedule,
+    value: V1TaintEffect.TaintEffectPreferNoSchedule,
     label: 'PreferNoSchedule',
     description: 'Scheduler will try to avoid placing a pod on the node but it is not guaranteed.',
   },
   {
-    value: TolerationEffect.NoExecute,
+    value: V1TaintEffect.TaintEffectNoExecute,
     label: 'NoExecute',
     description: 'Pods will be evicted from the node if they do not tolerate the taint.',
   },
-] as const;
+];
 
 interface TolerationModalProps {
   isOpen: boolean;
@@ -76,8 +83,10 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
   onSubmit,
   existingToleration,
 }) => {
-  const [operator, setOperator] = useState<TolerationOperator>(TolerationOperator.Equal);
-  const [effect, setEffect] = useState<TolerationEffect>(TolerationEffect.None);
+  const [operator, setOperator] = useState<V1TolerationOperator>(
+    V1TolerationOperator.TolerationOpEqual,
+  );
+  const [effect, setEffect] = useState<EffectSelectValue>('');
   const [key, setKey] = useState('');
   const [value, setValue] = useState('');
   const [isForever, setIsForever] = useState(true);
@@ -88,18 +97,18 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       if (existingToleration) {
-        setOperator(existingToleration.operator);
-        setEffect(existingToleration.effect ?? TolerationEffect.None);
-        setKey(existingToleration.key);
-        setValue(existingToleration.value);
-        setIsForever(existingToleration.tolerationSeconds === null);
+        setOperator(existingToleration.operator ?? V1TolerationOperator.TolerationOpEqual);
+        setEffect(existingToleration.effect ?? '');
+        setKey(existingToleration.key ?? '');
+        setValue(existingToleration.value ?? '');
+        setIsForever(existingToleration.tolerationSeconds == null);
         setTolerationSeconds(existingToleration.tolerationSeconds ?? 0);
       } else {
         const empty = emptyToleration();
-        setOperator(empty.operator);
-        setEffect(empty.effect ?? TolerationEffect.None);
-        setKey(empty.key);
-        setValue(empty.value);
+        setOperator(empty.operator ?? V1TolerationOperator.TolerationOpEqual);
+        setEffect(empty.effect ?? '');
+        setKey(empty.key ?? '');
+        setValue(empty.value ?? '');
         setIsForever(true);
         setTolerationSeconds(0);
       }
@@ -112,11 +121,11 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
     const toleration: TolerationEntry = {
       id: existingToleration?.id ?? generateUniqueId(),
       operator,
-      effect: effect === TolerationEffect.None ? undefined : effect,
+      effect: effect === '' ? undefined : effect,
       key,
-      value: operator === TolerationOperator.Exists ? '' : value,
+      value: operator === V1TolerationOperator.TolerationOpExists ? '' : value,
       tolerationSeconds:
-        effect === TolerationEffect.NoExecute && !isForever ? tolerationSeconds : null,
+        effect === V1TaintEffect.TaintEffectNoExecute && !isForever ? tolerationSeconds : undefined,
     };
     onSubmit(toleration);
   }, [existingToleration, operator, effect, key, value, isForever, tolerationSeconds, onSubmit]);
@@ -144,7 +153,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
               isOpen={isOperatorOpen}
               selected={operator}
               onSelect={(_ev, val) => {
-                setOperator(val as TolerationOperator);
+                setOperator(val as V1TolerationOperator);
                 setIsOperatorOpen(false);
               }}
               onOpenChange={setIsOperatorOpen}
@@ -181,7 +190,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
               isOpen={isEffectOpen}
               selected={effect}
               onSelect={(_ev, val) => {
-                setEffect(val as TolerationEffect);
+                setEffect(val as EffectSelectValue);
                 setIsEffectOpen(false);
               }}
               onOpenChange={setIsEffectOpen}
@@ -200,7 +209,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
               <SelectList>
                 {EFFECT_OPTIONS.map((opt) => (
                   <SelectOption
-                    key={opt.value}
+                    key={opt.label}
                     value={opt.value}
                     description={opt.description}
                     data-testid={`toleration-effect-option-${opt.label}`}
@@ -227,7 +236,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
             label="Value"
             fieldId="toleration-value"
             helperTextNode={
-              operator === TolerationOperator.Exists ? (
+              operator === V1TolerationOperator.TolerationOpExists ? (
                 <HelperText>
                   <HelperTextItem icon={<ExclamationCircleIcon />}>
                     Value is not allowed for Exists operator.
@@ -239,7 +248,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
             <TextInput
               id="toleration-value"
               data-testid="toleration-value-input"
-              isDisabled={operator === TolerationOperator.Exists} // Value is not allowed for Exists operator
+              isDisabled={operator === V1TolerationOperator.TolerationOpExists} // Value is not allowed for Exists operator
               type="text"
               value={value}
               onChange={(_, val) => setValue(val)}
@@ -260,7 +269,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
               </Popover>
             }
             helperTextNode={
-              effect !== TolerationEffect.NoExecute && (
+              effect !== V1TaintEffect.TaintEffectNoExecute && (
                 <HelperText>
                   <HelperTextItem icon={<ExclamationCircleIcon />}>
                     Toleration seconds is only available for NoExecute effect.
@@ -276,12 +285,12 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
                   data-testid="toleration-seconds-forever"
                   name="toleration-seconds-type"
                   label="Forever"
-                  isChecked={effect === TolerationEffect.NoExecute ? isForever : false}
+                  isChecked={effect === V1TaintEffect.TaintEffectNoExecute ? isForever : false}
                   onChange={() => {
                     setIsForever(true);
                     setTolerationSeconds(0);
                   }}
-                  isDisabled={effect !== TolerationEffect.NoExecute}
+                  isDisabled={effect !== V1TaintEffect.TaintEffectNoExecute}
                 />
               </FlexItem>
               <FlexItem>
@@ -290,17 +299,17 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
                   data-testid="toleration-seconds-custom"
                   name="toleration-seconds-type"
                   label="Custom value (in seconds)"
-                  isChecked={effect === TolerationEffect.NoExecute ? !isForever : false}
+                  isChecked={effect === V1TaintEffect.TaintEffectNoExecute ? !isForever : false}
                   onChange={() => {
                     setIsForever(false);
                   }}
-                  isDisabled={effect !== TolerationEffect.NoExecute}
+                  isDisabled={effect !== V1TaintEffect.TaintEffectNoExecute}
                 />
               </FlexItem>
             </Flex>
             {!isForever && (
               <ResourceInputWrapper
-                isDisabled={effect !== TolerationEffect.NoExecute}
+                isDisabled={effect !== V1TaintEffect.TaintEffectNoExecute}
                 type="custom"
                 value={String(tolerationSeconds)}
                 onChange={(v) => setTolerationSeconds(parseInt(v, 10) || 0)}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal.tsx
@@ -14,6 +14,8 @@ import {
   SelectList,
   SelectOption,
 } from '@patternfly/react-core/dist/esm/components/Select';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { Popover } from '@patternfly/react-core/dist/esm/components/Popover';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
@@ -24,7 +26,6 @@ import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupW
 import { ResourceInputWrapper } from '~/shared/components/ResourceInputWrapper';
 
 const OPERATOR_OPTIONS = [
-  { value: TolerationOperator.None, label: 'None', description: undefined },
   {
     value: TolerationOperator.Equal,
     label: 'Equal',
@@ -40,7 +41,11 @@ const OPERATOR_OPTIONS = [
 ] as const;
 
 const EFFECT_OPTIONS = [
-  { value: TolerationEffect.None, label: 'None', description: undefined },
+  {
+    value: TolerationEffect.None,
+    label: 'None',
+    description: 'An empty effect matches all effects with key and value.',
+  },
   {
     value: TolerationEffect.NoSchedule,
     label: 'NoSchedule',
@@ -71,7 +76,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
   onSubmit,
   existingToleration,
 }) => {
-  const [operator, setOperator] = useState<TolerationOperator>(TolerationOperator.None);
+  const [operator, setOperator] = useState<TolerationOperator>(TolerationOperator.Equal);
   const [effect, setEffect] = useState<TolerationEffect>(TolerationEffect.None);
   const [key, setKey] = useState('');
   const [value, setValue] = useState('');
@@ -84,7 +89,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
     if (isOpen) {
       if (existingToleration) {
         setOperator(existingToleration.operator);
-        setEffect(existingToleration.effect);
+        setEffect(existingToleration.effect ?? TolerationEffect.None);
         setKey(existingToleration.key);
         setValue(existingToleration.value);
         setIsForever(existingToleration.tolerationSeconds === null);
@@ -92,7 +97,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
       } else {
         const empty = emptyToleration();
         setOperator(empty.operator);
-        setEffect(empty.effect);
+        setEffect(empty.effect ?? TolerationEffect.None);
         setKey(empty.key);
         setValue(empty.value);
         setIsForever(true);
@@ -107,7 +112,7 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
     const toleration: TolerationEntry = {
       id: existingToleration?.id ?? generateUniqueId(),
       operator,
-      effect,
+      effect: effect === TolerationEffect.None ? undefined : effect,
       key,
       value: operator === TolerationOperator.Exists ? '' : value,
       tolerationSeconds:
@@ -116,8 +121,8 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
     onSubmit(toleration);
   }, [existingToleration, operator, effect, key, value, isForever, tolerationSeconds, onSubmit]);
 
-  const operatorLabel = OPERATOR_OPTIONS.find((o) => o.value === operator)?.label ?? 'None';
-  const effectLabel = EFFECT_OPTIONS.find((o) => o.value === effect)?.label ?? 'None';
+  const operatorLabel = OPERATOR_OPTIONS.find((o) => o.value === operator)?.label ?? 'Equal';
+  const effectLabel = EFFECT_OPTIONS.find((o) => o.value === effect)?.label ?? 'NoExecute';
 
   return (
     <Modal
@@ -218,70 +223,92 @@ export const TolerationModal: React.FC<TolerationModalProps> = ({
             />
           </ThemeAwareFormGroupWrapper>
 
-          <ThemeAwareFormGroupWrapper label="Value" fieldId="toleration-value">
+          <ThemeAwareFormGroupWrapper
+            label="Value"
+            fieldId="toleration-value"
+            helperTextNode={
+              operator === TolerationOperator.Exists ? (
+                <HelperText>
+                  <HelperTextItem icon={<ExclamationCircleIcon />}>
+                    Value is not allowed for Exists operator.
+                  </HelperTextItem>
+                </HelperText>
+              ) : undefined
+            }
+          >
             <TextInput
               id="toleration-value"
               data-testid="toleration-value-input"
+              isDisabled={operator === TolerationOperator.Exists} // Value is not allowed for Exists operator
               type="text"
-              value={operator === TolerationOperator.Exists ? '' : value}
+              value={value}
               onChange={(_, val) => setValue(val)}
-              isDisabled={operator === TolerationOperator.Exists}
             />
           </ThemeAwareFormGroupWrapper>
 
-          {effect === TolerationEffect.NoExecute && (
-            <ThemeAwareFormGroupWrapper
-              label="Toleration Seconds"
-              fieldId="toleration-seconds"
-              role="radiogroup"
-              skipFieldset
-              labelHelp={
-                <Popover
-                  headerContent="Toleration seconds"
-                  bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted."
-                >
-                  <OutlinedQuestionCircleIcon />
-                </Popover>
-              }
-            >
-              <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                <FlexItem>
-                  <Radio
-                    id="toleration-seconds-forever"
-                    data-testid="toleration-seconds-forever"
-                    name="toleration-seconds-type"
-                    label="Forever"
-                    isChecked={isForever}
-                    onChange={() => {
-                      setIsForever(true);
-                      setTolerationSeconds(0);
-                    }}
-                  />
-                </FlexItem>
-                <FlexItem>
-                  <Radio
-                    id="toleration-seconds-custom"
-                    data-testid="toleration-seconds-custom"
-                    name="toleration-seconds-type"
-                    label="Custom value (in seconds)"
-                    isChecked={!isForever}
-                    onChange={() => {
-                      setIsForever(false);
-                    }}
-                  />
-                </FlexItem>
-              </Flex>
-              {!isForever && (
-                <ResourceInputWrapper
-                  type="custom"
-                  value={String(tolerationSeconds)}
-                  onChange={(v) => setTolerationSeconds(parseInt(v, 10) || 0)}
-                  min={0}
-                  aria-label="toleration-seconds-input"
+          <ThemeAwareFormGroupWrapper
+            label="Toleration Seconds"
+            fieldId="toleration-seconds"
+            role="radiogroup"
+            skipFieldset
+            labelHelp={
+              <Popover
+                headerContent="Toleration seconds"
+                bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted."
+              >
+                <OutlinedQuestionCircleIcon />
+              </Popover>
+            }
+            helperTextNode={
+              effect !== TolerationEffect.NoExecute && (
+                <HelperText>
+                  <HelperTextItem icon={<ExclamationCircleIcon />}>
+                    Toleration seconds is only available for NoExecute effect.
+                  </HelperTextItem>
+                </HelperText>
+              )
+            }
+          >
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <Radio
+                  id="toleration-seconds-forever"
+                  data-testid="toleration-seconds-forever"
+                  name="toleration-seconds-type"
+                  label="Forever"
+                  isChecked={effect === TolerationEffect.NoExecute ? isForever : false}
+                  onChange={() => {
+                    setIsForever(true);
+                    setTolerationSeconds(0);
+                  }}
+                  isDisabled={effect !== TolerationEffect.NoExecute}
                 />
-              )}
-            </ThemeAwareFormGroupWrapper>
-          )}
+              </FlexItem>
+              <FlexItem>
+                <Radio
+                  id="toleration-seconds-custom"
+                  data-testid="toleration-seconds-custom"
+                  name="toleration-seconds-type"
+                  label="Custom value (in seconds)"
+                  isChecked={effect === TolerationEffect.NoExecute ? !isForever : false}
+                  onChange={() => {
+                    setIsForever(false);
+                  }}
+                  isDisabled={effect !== TolerationEffect.NoExecute}
+                />
+              </FlexItem>
+            </Flex>
+            {!isForever && (
+              <ResourceInputWrapper
+                isDisabled={effect !== TolerationEffect.NoExecute}
+                type="custom"
+                value={String(tolerationSeconds)}
+                onChange={(v) => setTolerationSeconds(parseInt(v, 10) || 0)}
+                min={0}
+                aria-label="toleration-seconds-input"
+              />
+            )}
+          </ThemeAwareFormGroupWrapper>
         </Form>
       </ModalBody>
       <ModalFooter>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/TolerationModal.tsx
@@ -1,0 +1,302 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Form } from '@patternfly/react-core/dist/esm/components/Form';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Radio } from '@patternfly/react-core/dist/esm/components/Radio';
+import {
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core/dist/esm/components/Select';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Popover } from '@patternfly/react-core/dist/esm/components/Popover';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { TolerationEffect, TolerationEntry, TolerationOperator } from '~/app/types';
+import { emptyToleration, generateUniqueId } from '~/app/pages/WorkspaceKinds/Form/helpers';
+import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
+import { ResourceInputWrapper } from '~/shared/components/ResourceInputWrapper';
+
+const OPERATOR_OPTIONS = [
+  { value: TolerationOperator.None, label: 'None', description: undefined },
+  {
+    value: TolerationOperator.Equal,
+    label: 'Equal',
+    description:
+      'A toleration "matches" a taint if the keys are the same, the effects are the same, and the values are equal.',
+  },
+  {
+    value: TolerationOperator.Exists,
+    label: 'Exists',
+    description:
+      'A toleration "matches" a taint if the keys are the same and the effects are the same. No value should be specified.',
+  },
+] as const;
+
+const EFFECT_OPTIONS = [
+  { value: TolerationEffect.None, label: 'None', description: undefined },
+  {
+    value: TolerationEffect.NoSchedule,
+    label: 'NoSchedule',
+    description: 'Prevents scheduling of new pods on the node with the matching taint.',
+  },
+  {
+    value: TolerationEffect.PreferNoSchedule,
+    label: 'PreferNoSchedule',
+    description: 'Scheduler will try to avoid placing a pod on the node but it is not guaranteed.',
+  },
+  {
+    value: TolerationEffect.NoExecute,
+    label: 'NoExecute',
+    description: 'Pods will be evicted from the node if they do not tolerate the taint.',
+  },
+] as const;
+
+interface TolerationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (toleration: TolerationEntry) => void;
+  existingToleration: TolerationEntry | null;
+}
+
+export const TolerationModal: React.FC<TolerationModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  existingToleration,
+}) => {
+  const [operator, setOperator] = useState<TolerationOperator>(TolerationOperator.None);
+  const [effect, setEffect] = useState<TolerationEffect>(TolerationEffect.None);
+  const [key, setKey] = useState('');
+  const [value, setValue] = useState('');
+  const [isForever, setIsForever] = useState(true);
+  const [tolerationSeconds, setTolerationSeconds] = useState<number>(0);
+  const [isOperatorOpen, setIsOperatorOpen] = useState(false);
+  const [isEffectOpen, setIsEffectOpen] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (existingToleration) {
+        setOperator(existingToleration.operator);
+        setEffect(existingToleration.effect);
+        setKey(existingToleration.key);
+        setValue(existingToleration.value);
+        setIsForever(existingToleration.tolerationSeconds === null);
+        setTolerationSeconds(existingToleration.tolerationSeconds ?? 0);
+      } else {
+        const empty = emptyToleration();
+        setOperator(empty.operator);
+        setEffect(empty.effect);
+        setKey(empty.key);
+        setValue(empty.value);
+        setIsForever(true);
+        setTolerationSeconds(0);
+      }
+      setIsOperatorOpen(false);
+      setIsEffectOpen(false);
+    }
+  }, [isOpen, existingToleration]);
+
+  const handleSubmit = useCallback(() => {
+    const toleration: TolerationEntry = {
+      id: existingToleration?.id ?? generateUniqueId(),
+      operator,
+      effect,
+      key,
+      value: operator === TolerationOperator.Exists ? '' : value,
+      tolerationSeconds:
+        effect === TolerationEffect.NoExecute && !isForever ? tolerationSeconds : null,
+    };
+    onSubmit(toleration);
+  }, [existingToleration, operator, effect, key, value, isForever, tolerationSeconds, onSubmit]);
+
+  const operatorLabel = OPERATOR_OPTIONS.find((o) => o.value === operator)?.label ?? 'None';
+  const effectLabel = EFFECT_OPTIONS.find((o) => o.value === effect)?.label ?? 'None';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      variant="large"
+      data-testid="toleration-modal"
+      aria-labelledby="toleration-modal-title"
+    >
+      <ModalHeader
+        title={existingToleration ? 'Edit Toleration' : 'Add Toleration'}
+        labelId="toleration-modal-title"
+      />
+      <ModalBody>
+        <Form>
+          <ThemeAwareFormGroupWrapper label="Operator" fieldId="toleration-operator">
+            <Select
+              id="toleration-operator"
+              isOpen={isOperatorOpen}
+              selected={operator}
+              onSelect={(_ev, val) => {
+                setOperator(val as TolerationOperator);
+                setIsOperatorOpen(false);
+              }}
+              onOpenChange={setIsOperatorOpen}
+              toggle={(toggleRef) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsOperatorOpen((prev) => !prev)}
+                  isExpanded={isOperatorOpen}
+                  isFullWidth
+                  data-testid="toleration-operator-select"
+                >
+                  {operatorLabel}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                {OPERATOR_OPTIONS.map((opt) => (
+                  <SelectOption
+                    key={opt.value}
+                    value={opt.value}
+                    description={opt.description}
+                    data-testid={`toleration-operator-option-${opt.label}`}
+                  >
+                    {opt.label}
+                  </SelectOption>
+                ))}
+              </SelectList>
+            </Select>
+          </ThemeAwareFormGroupWrapper>
+
+          <ThemeAwareFormGroupWrapper label="Effect" fieldId="toleration-effect">
+            <Select
+              id="toleration-effect"
+              isOpen={isEffectOpen}
+              selected={effect}
+              onSelect={(_ev, val) => {
+                setEffect(val as TolerationEffect);
+                setIsEffectOpen(false);
+              }}
+              onOpenChange={setIsEffectOpen}
+              toggle={(toggleRef) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsEffectOpen((prev) => !prev)}
+                  isExpanded={isEffectOpen}
+                  isFullWidth
+                  data-testid="toleration-effect-select"
+                >
+                  {effectLabel}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                {EFFECT_OPTIONS.map((opt) => (
+                  <SelectOption
+                    key={opt.value}
+                    value={opt.value}
+                    description={opt.description}
+                    data-testid={`toleration-effect-option-${opt.label}`}
+                  >
+                    {opt.label}
+                  </SelectOption>
+                ))}
+              </SelectList>
+            </Select>
+          </ThemeAwareFormGroupWrapper>
+
+          <ThemeAwareFormGroupWrapper label="Key" isRequired fieldId="toleration-key">
+            <TextInput
+              id="toleration-key"
+              data-testid="toleration-key-input"
+              isRequired
+              type="text"
+              value={key}
+              onChange={(_, val) => setKey(val)}
+            />
+          </ThemeAwareFormGroupWrapper>
+
+          <ThemeAwareFormGroupWrapper label="Value" fieldId="toleration-value">
+            <TextInput
+              id="toleration-value"
+              data-testid="toleration-value-input"
+              type="text"
+              value={operator === TolerationOperator.Exists ? '' : value}
+              onChange={(_, val) => setValue(val)}
+              isDisabled={operator === TolerationOperator.Exists}
+            />
+          </ThemeAwareFormGroupWrapper>
+
+          {effect === TolerationEffect.NoExecute && (
+            <ThemeAwareFormGroupWrapper
+              label="Toleration Seconds"
+              fieldId="toleration-seconds"
+              role="radiogroup"
+              skipFieldset
+              labelHelp={
+                <Popover
+                  headerContent="Toleration seconds"
+                  bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted."
+                >
+                  <OutlinedQuestionCircleIcon />
+                </Popover>
+              }
+            >
+              <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                <FlexItem>
+                  <Radio
+                    id="toleration-seconds-forever"
+                    data-testid="toleration-seconds-forever"
+                    name="toleration-seconds-type"
+                    label="Forever"
+                    isChecked={isForever}
+                    onChange={() => {
+                      setIsForever(true);
+                      setTolerationSeconds(0);
+                    }}
+                  />
+                </FlexItem>
+                <FlexItem>
+                  <Radio
+                    id="toleration-seconds-custom"
+                    data-testid="toleration-seconds-custom"
+                    name="toleration-seconds-type"
+                    label="Custom value (in seconds)"
+                    isChecked={!isForever}
+                    onChange={() => {
+                      setIsForever(false);
+                    }}
+                  />
+                </FlexItem>
+              </Flex>
+              {!isForever && (
+                <ResourceInputWrapper
+                  type="custom"
+                  value={String(tolerationSeconds)}
+                  onChange={(v) => setTolerationSeconds(parseInt(v, 10) || 0)}
+                  min={0}
+                  aria-label="toleration-seconds-input"
+                />
+              )}
+            </ThemeAwareFormGroupWrapper>
+          )}
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          isDisabled={!key}
+          data-testid="toleration-modal-submit-button"
+        >
+          {existingToleration ? 'Save' : 'Add'}
+        </Button>
+        <Button variant="link" onClick={onClose} data-testid="toleration-modal-cancel-button">
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
@@ -197,8 +197,9 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
           <>
             <div className="pf-v6-u-pl-xl pf-v6-u-pt-sm pf-v6-u-pb-sm">
               <div>
-                Pod configurations allow specifying resource allocation for Workspace Kinds. Expand
-                each configuration to view and manage its tolerations.
+                Pod configurations define the hardware resource options available to a Workspace.
+                Expand each configuration to access nodeSelector and tolerations, allowing you to
+                constrain pods to specific node groups.
               </div>
             </div>
             <WorkspaceKindFormPaginatedTable

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
@@ -43,7 +43,7 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [currConfig, setCurrConfig] = useState<WorkspaceKindPodConfigValue>({ ...emptyPodConfig });
-  const [tolerationModalOpenFor, setTolerationModalOpenFor] = useState<number | null>(null);
+  const [tolerationModalOpenFor, setTolerationModalOpenFor] = useState<string | null>(null);
 
   const clearForm = useCallback(() => {
     setCurrConfig({ ...emptyPodConfig });
@@ -85,6 +85,9 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
       return;
     }
     const currentValues = podConfig.values ?? [];
+    const removedId = currentValues[deleteIndex].id;
+    tolerationSettersCache.current.delete(removedId);
+    modalSettersCache.current.delete(removedId);
     updatePodConfig({
       default: currentValues[deleteIndex].id === defaultId ? '' : defaultId,
       values: currentValues.filter((_, i) => i !== deleteIndex),
@@ -102,25 +105,29 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
   updatePodConfigRef.current = updatePodConfig;
 
   const tolerationSettersCache = useRef(
-    new Map<number, React.Dispatch<React.SetStateAction<TolerationEntry[]>>>(),
+    new Map<string, React.Dispatch<React.SetStateAction<TolerationEntry[]>>>(),
   );
   const modalSettersCache = useRef(
-    new Map<number, React.Dispatch<React.SetStateAction<boolean>>>(),
+    new Map<string, React.Dispatch<React.SetStateAction<boolean>>>(),
   );
 
   const getTolerationsForConfig = useCallback(
-    (globalIndex: number): React.Dispatch<React.SetStateAction<TolerationEntry[]>> => {
-      let setter = tolerationSettersCache.current.get(globalIndex);
+    (configId: string): React.Dispatch<React.SetStateAction<TolerationEntry[]>> => {
+      let setter = tolerationSettersCache.current.get(configId);
       if (!setter) {
         setter = (action) => {
           const config = podConfigRef.current;
-          const updated = [...config.values];
-          const current = updated[globalIndex].tolerations ?? [];
+          const currentIndex = (config.values ?? []).findIndex((v) => v.id === configId);
+          if (currentIndex === -1) {
+            return;
+          }
+          const updated = [...(config.values ?? [])];
+          const current = updated[currentIndex].tolerations ?? [];
           const next = typeof action === 'function' ? action(current) : action;
-          updated[globalIndex] = { ...updated[globalIndex], tolerations: next };
+          updated[currentIndex] = { ...updated[currentIndex], tolerations: next };
           updatePodConfigRef.current({ ...config, values: updated });
         };
-        tolerationSettersCache.current.set(globalIndex, setter);
+        tolerationSettersCache.current.set(configId, setter);
       }
       return setter;
     },
@@ -128,22 +135,22 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
   );
 
   const getIsTolerationModalOpen = useCallback(
-    (globalIndex: number) => tolerationModalOpenFor === globalIndex,
+    (configId: string) => tolerationModalOpenFor === configId,
     [tolerationModalOpenFor],
   );
 
   const getSetIsTolerationModalOpen = useCallback(
-    (globalIndex: number): React.Dispatch<React.SetStateAction<boolean>> => {
-      let setter = modalSettersCache.current.get(globalIndex);
+    (configId: string): React.Dispatch<React.SetStateAction<boolean>> => {
+      let setter = modalSettersCache.current.get(configId);
       if (!setter) {
         setter = (action) => {
           setTolerationModalOpenFor((prev) => {
-            const isCurrentlyOpen = prev === globalIndex;
+            const isCurrentlyOpen = prev === configId;
             const next = typeof action === 'function' ? action(isCurrentlyOpen) : action;
-            return next ? globalIndex : null;
+            return next ? configId : null;
           });
         };
-        modalSettersCache.current.set(globalIndex, setter);
+        modalSettersCache.current.set(configId, setter);
       }
       return setter;
     },
@@ -152,10 +159,15 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
 
   const tolerationDispatchers = useMemo(
     () =>
-      podConfig.values.map((_, i) => ({
-        setTolerations: getTolerationsForConfig(i),
-        setIsTolerationModalOpen: getSetIsTolerationModalOpen(i),
-      })),
+      new Map(
+        (podConfig.values ?? []).map((config) => [
+          config.id,
+          {
+            setTolerations: getTolerationsForConfig(config.id),
+            setIsTolerationModalOpen: getSetIsTolerationModalOpen(config.id),
+          },
+        ]),
+      ),
     [podConfig.values, getTolerationsForConfig, getSetIsTolerationModalOpen],
   );
 
@@ -195,13 +207,11 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
         )}
         {(podConfig.values ?? []).length > 0 && (
           <>
-            <div className="pf-v6-u-pl-xl pf-v6-u-pt-sm pf-v6-u-pb-sm">
-              <div>
-                Pod configurations define the hardware resource options available to a Workspace.
-                Expand each configuration to access nodeSelector and tolerations, allowing you to
-                constrain pods to specific node groups.
-              </div>
-            </div>
+            <Content component="p">
+              Pod configurations define the hardware resource options available to a Workspace.
+              Expand each configuration to access nodeSelector and tolerations, allowing you to
+              constrain pods to specific node groups.
+            </Content>
             <WorkspaceKindFormPaginatedTable
               ariaLabel="Pod Configs Table"
               dataTestId="pod-configs-table"
@@ -213,7 +223,7 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
               }}
               handleEdit={handleEdit}
               openDeleteModal={openDeleteModal}
-              expandedContent={(_row, globalIndex) => (
+              expandedContent={(row, globalIndex) => (
                 <>
                   <Title headingLevel="h4" className="pf-v6-u-mb-sm">
                     Tolerations
@@ -225,17 +235,17 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
                   <Button
                     variant="secondary"
                     className="pf-v6-u-mb-md"
-                    onClick={() => setTolerationModalOpenFor(globalIndex)}
+                    onClick={() => setTolerationModalOpenFor(row.id)}
                     data-testid={`add-toleration-button-${globalIndex}`}
                   >
                     Add Toleration
                   </Button>
                   <WorkspaceKindFormTolerations
-                    tolerations={podConfig.values[globalIndex]?.tolerations ?? []}
-                    setTolerations={tolerationDispatchers[globalIndex].setTolerations}
-                    isTolerationModalOpen={getIsTolerationModalOpen(globalIndex)}
+                    tolerations={(podConfig.values ?? [])[globalIndex]?.tolerations ?? []}
+                    setTolerations={tolerationDispatchers.get(row.id)!.setTolerations}
+                    isTolerationModalOpen={getIsTolerationModalOpen(row.id)}
                     setIsTolerationModalOpen={
-                      tolerationDispatchers[globalIndex].setIsTolerationModalOpen
+                      tolerationDispatchers.get(row.id)!.setIsTolerationModalOpen
                     }
                   />
                 </>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { Title } from '@patternfly/react-core/dist/esm/components/Title';
 import {
   Modal,
   ModalHeader,
@@ -17,9 +18,14 @@ import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/Ex
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import { emptyPodConfig } from '~/app/pages/WorkspaceKinds/Form/helpers';
-import { WorkspaceKindPodConfigValue, WorkspaceKindPodConfigData } from '~/app/types';
+import {
+  TolerationEntry,
+  WorkspaceKindPodConfigValue,
+  WorkspaceKindPodConfigData,
+} from '~/app/types';
 import { WorkspaceKindFormPaginatedTable } from '~/app/pages/WorkspaceKinds/Form/WorkspaceKindFormPaginatedTable';
 import { WorkspaceKindFormPodConfigModal } from './WorkspaceKindFormPodConfigModal';
+import { WorkspaceKindFormTolerations } from './WorkspaceKindFormTolerations';
 
 interface WorkspaceKindFormPodConfigProps {
   podConfig: WorkspaceKindPodConfigData;
@@ -37,6 +43,7 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [currConfig, setCurrConfig] = useState<WorkspaceKindPodConfigValue>({ ...emptyPodConfig });
+  const [tolerationModalOpenFor, setTolerationModalOpenFor] = useState<number | null>(null);
 
   const clearForm = useCallback(() => {
     setCurrConfig({ ...emptyPodConfig });
@@ -89,6 +96,69 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
     setIsDeleteModalOpen(false);
   }, [deleteIndex, podConfig, updatePodConfig, setDefaultId, defaultId]);
 
+  const podConfigRef = useRef(podConfig);
+  podConfigRef.current = podConfig;
+  const updatePodConfigRef = useRef(updatePodConfig);
+  updatePodConfigRef.current = updatePodConfig;
+
+  const tolerationSettersCache = useRef(
+    new Map<number, React.Dispatch<React.SetStateAction<TolerationEntry[]>>>(),
+  );
+  const modalSettersCache = useRef(
+    new Map<number, React.Dispatch<React.SetStateAction<boolean>>>(),
+  );
+
+  const getTolerationsForConfig = useCallback(
+    (globalIndex: number): React.Dispatch<React.SetStateAction<TolerationEntry[]>> => {
+      let setter = tolerationSettersCache.current.get(globalIndex);
+      if (!setter) {
+        setter = (action) => {
+          const config = podConfigRef.current;
+          const updated = [...config.values];
+          const current = updated[globalIndex].tolerations ?? [];
+          const next = typeof action === 'function' ? action(current) : action;
+          updated[globalIndex] = { ...updated[globalIndex], tolerations: next };
+          updatePodConfigRef.current({ ...config, values: updated });
+        };
+        tolerationSettersCache.current.set(globalIndex, setter);
+      }
+      return setter;
+    },
+    [],
+  );
+
+  const getIsTolerationModalOpen = useCallback(
+    (globalIndex: number) => tolerationModalOpenFor === globalIndex,
+    [tolerationModalOpenFor],
+  );
+
+  const getSetIsTolerationModalOpen = useCallback(
+    (globalIndex: number): React.Dispatch<React.SetStateAction<boolean>> => {
+      let setter = modalSettersCache.current.get(globalIndex);
+      if (!setter) {
+        setter = (action) => {
+          setTolerationModalOpenFor((prev) => {
+            const isCurrentlyOpen = prev === globalIndex;
+            const next = typeof action === 'function' ? action(isCurrentlyOpen) : action;
+            return next ? globalIndex : null;
+          });
+        };
+        modalSettersCache.current.set(globalIndex, setter);
+      }
+      return setter;
+    },
+    [],
+  );
+
+  const tolerationDispatchers = useMemo(
+    () =>
+      podConfig.values.map((_, i) => ({
+        setTolerations: getTolerationsForConfig(i),
+        setIsTolerationModalOpen: getSetIsTolerationModalOpen(i),
+      })),
+    [podConfig.values, getTolerationsForConfig, getSetIsTolerationModalOpen],
+  );
+
   const addConfigBtn = (
     <Button
       variant="link"
@@ -125,6 +195,12 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
         )}
         {(podConfig.values ?? []).length > 0 && (
           <>
+            <div className="pf-v6-u-pl-xl pf-v6-u-pt-sm pf-v6-u-pb-sm">
+              <div>
+                Pod configurations allow specifying resource allocation for Workspace Kinds. Expand
+                each configuration to view and manage its tolerations.
+              </div>
+            </div>
             <WorkspaceKindFormPaginatedTable
               ariaLabel="Pod Configs Table"
               dataTestId="pod-configs-table"
@@ -136,6 +212,33 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
               }}
               handleEdit={handleEdit}
               openDeleteModal={openDeleteModal}
+              expandedContent={(_row, globalIndex) => (
+                <>
+                  <Title headingLevel="h4" className="pf-v6-u-mb-sm">
+                    Tolerations
+                  </Title>
+                  <p className="pf-v6-u-mb-md pf-v6-u-color-200">
+                    Tolerations are applied to pods and allow the scheduler to schedule pods on
+                    nodes with matching taints
+                  </p>
+                  <Button
+                    variant="secondary"
+                    className="pf-v6-u-mb-md"
+                    onClick={() => setTolerationModalOpenFor(globalIndex)}
+                    data-testid={`add-toleration-button-${globalIndex}`}
+                  >
+                    Add Toleration
+                  </Button>
+                  <WorkspaceKindFormTolerations
+                    tolerations={podConfig.values[globalIndex]?.tolerations ?? []}
+                    setTolerations={tolerationDispatchers[globalIndex].setTolerations}
+                    isTolerationModalOpen={getIsTolerationModalOpen(globalIndex)}
+                    setIsTolerationModalOpen={
+                      tolerationDispatchers[globalIndex].setIsTolerationModalOpen
+                    }
+                  />
+                </>
+              )}
             />
             {addConfigBtn}
           </>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
@@ -71,16 +71,22 @@ export const WorkspaceKindFormTolerations: React.FC<WorkspaceKindFormTolerations
           </Thead>
           <Tbody>
             {tolerations.map((toleration, index) => (
-              <Tr key={toleration.id}>
-                <Td dataLabel="Key">{toleration.key || '-'}</Td>
-                <Td dataLabel="Value">
+              <Tr key={toleration.id} data-testid={`toleration-row-${index}`}>
+                <Td dataLabel="Key" data-testid={`toleration-key-cell-${index}`}>
+                  {toleration.key || '-'}
+                </Td>
+                <Td dataLabel="Value" data-testid={`toleration-value-cell-${index}`}>
                   {toleration.operator === TolerationOperator.Exists
                     ? '-'
                     : toleration.value || '-'}
                 </Td>
-                <Td dataLabel="Operator">{toleration.operator || 'None'}</Td>
-                <Td dataLabel="Effect">{toleration.effect || 'None'}</Td>
-                <Td dataLabel="Toleration Seconds">
+                <Td dataLabel="Operator" data-testid={`toleration-operator-cell-${index}`}>
+                  {toleration.operator || 'None'}
+                </Td>
+                <Td dataLabel="Effect" data-testid={`toleration-effect-cell-${index}`}>
+                  {toleration.effect || 'None'}
+                </Td>
+                <Td dataLabel="Toleration Seconds" data-testid={`toleration-seconds-cell-${index}`}>
                   {toleration.tolerationSeconds === null
                     ? 'Forever'
                     : `${toleration.tolerationSeconds}s`}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
@@ -1,0 +1,123 @@
+import React, { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table/dist/esm/components/Table';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
+import { TrashAltIcon } from '@patternfly/react-icons/dist/esm/icons/trash-alt-icon';
+import { TolerationEntry, TolerationOperator } from '~/app/types';
+import { TolerationModal } from './TolerationModal';
+
+interface WorkspaceKindFormTolerationsProps {
+  tolerations: TolerationEntry[];
+  setTolerations: Dispatch<SetStateAction<TolerationEntry[]>>;
+  isTolerationModalOpen: boolean;
+  setIsTolerationModalOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export const WorkspaceKindFormTolerations: React.FC<WorkspaceKindFormTolerationsProps> = ({
+  tolerations,
+  setTolerations,
+  isTolerationModalOpen,
+  setIsTolerationModalOpen,
+}) => {
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+
+  const handleEdit = useCallback(
+    (index: number) => {
+      setEditIndex(index);
+      setIsTolerationModalOpen(true);
+    },
+    [setIsTolerationModalOpen],
+  );
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      setTolerations((prev) => prev.filter((_, i) => i !== index));
+    },
+    [setTolerations],
+  );
+
+  const handleModalClose = useCallback(() => {
+    setIsTolerationModalOpen(false);
+    setEditIndex(null);
+  }, [setIsTolerationModalOpen]);
+
+  const handleModalSubmit = useCallback(
+    (toleration: TolerationEntry) => {
+      if (editIndex !== null) {
+        setTolerations((prev) => prev.map((t, i) => (i === editIndex ? toleration : t)));
+      } else {
+        setTolerations((prev) => [...prev, toleration]);
+      }
+      setIsTolerationModalOpen(false);
+      setEditIndex(null);
+    },
+    [editIndex, setTolerations, setIsTolerationModalOpen],
+  );
+
+  return (
+    <>
+      {tolerations.length > 0 && (
+        <Table aria-label="Tolerations table" data-testid="tolerations-table">
+          <Thead>
+            <Tr>
+              <Th>Key</Th>
+              <Th>Value</Th>
+              <Th>Operator</Th>
+              <Th>Effect</Th>
+              <Th>Toleration Seconds</Th>
+              <Th screenReaderText="Actions" />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {tolerations.map((toleration, index) => (
+              <Tr key={toleration.id}>
+                <Td dataLabel="Key">{toleration.key || '-'}</Td>
+                <Td dataLabel="Value">
+                  {toleration.operator === TolerationOperator.Exists
+                    ? '-'
+                    : toleration.value || '-'}
+                </Td>
+                <Td dataLabel="Operator">{toleration.operator || 'None'}</Td>
+                <Td dataLabel="Effect">{toleration.effect || 'None'}</Td>
+                <Td dataLabel="Toleration Seconds">
+                  {toleration.tolerationSeconds === null
+                    ? 'Forever'
+                    : `${toleration.tolerationSeconds}s`}
+                </Td>
+                <Td isActionCell>
+                  <Flex spaceItems={{ default: 'spaceItemsXs' }} flexWrap={{ default: 'nowrap' }}>
+                    <FlexItem>
+                      <Button
+                        onClick={() => handleEdit(index)}
+                        data-testid={`toleration-edit-${index}`}
+                        variant="plain"
+                        aria-label="Edit toleration"
+                        icon={<PencilAltIcon />}
+                      />
+                    </FlexItem>
+                    <FlexItem>
+                      <Button
+                        onClick={() => handleRemove(index)}
+                        data-testid={`toleration-remove-${index}`}
+                        variant="plain"
+                        aria-label="Remove toleration"
+                        icon={<TrashAltIcon />}
+                      />
+                    </FlexItem>
+                  </Flex>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+      <TolerationModal
+        isOpen={isTolerationModalOpen}
+        onClose={handleModalClose}
+        onSubmit={handleModalSubmit}
+        existingToleration={editIndex !== null ? tolerations[editIndex] : null}
+      />
+    </>
+  );
+};

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
@@ -81,7 +81,7 @@ export const WorkspaceKindFormTolerations: React.FC<WorkspaceKindFormTolerations
                     : toleration.value || '-'}
                 </Td>
                 <Td dataLabel="Operator" data-testid={`toleration-operator-cell-${index}`}>
-                  {toleration.operator || 'None'}
+                  {toleration.operator}
                 </Td>
                 <Td dataLabel="Effect" data-testid={`toleration-effect-cell-${index}`}>
                   {toleration.effect || 'None'}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormTolerations.tsx
@@ -4,7 +4,8 @@ import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import { TrashAltIcon } from '@patternfly/react-icons/dist/esm/icons/trash-alt-icon';
-import { TolerationEntry, TolerationOperator } from '~/app/types';
+import { V1TolerationOperator } from '~/generated/data-contracts';
+import { TolerationEntry } from '~/app/types';
 import { TolerationModal } from './TolerationModal';
 
 interface WorkspaceKindFormTolerationsProps {
@@ -76,7 +77,7 @@ export const WorkspaceKindFormTolerations: React.FC<WorkspaceKindFormTolerations
                   {toleration.key || '-'}
                 </Td>
                 <Td dataLabel="Value" data-testid={`toleration-value-cell-${index}`}>
-                  {toleration.operator === TolerationOperator.Exists
+                  {toleration.operator === V1TolerationOperator.TolerationOpExists
                     ? '-'
                     : toleration.value || '-'}
                 </Td>
@@ -87,7 +88,7 @@ export const WorkspaceKindFormTolerations: React.FC<WorkspaceKindFormTolerations
                   {toleration.effect || 'None'}
                 </Td>
                 <Td dataLabel="Toleration Seconds" data-testid={`toleration-seconds-cell-${index}`}>
-                  {toleration.tolerationSeconds === null
+                  {toleration.tolerationSeconds == null
                     ? 'Forever'
                     : `${toleration.tolerationSeconds}s`}
                 </Td>

--- a/workspaces/frontend/src/app/types.ts
+++ b/workspaces/frontend/src/app/types.ts
@@ -8,6 +8,7 @@ import {
   WorkspacesPodSecretMount,
   WorkspacesPodTemplateOptionsMutate,
   WorkspacesPodVolumeMount,
+  V1Toleration,
   WorkspacesWorkspaceListItem,
 } from '~/generated/data-contracts';
 
@@ -81,25 +82,8 @@ export interface WorkspaceKindImagePort {
   port: number;
   protocol: 'HTTP'; // ONLY HTTP is supported at the moment, per https://github.com/thesuperzapper/kubeflow-notebooks-v2-design/blob/main/crds/workspace-kind.yaml#L275
 }
-export enum TolerationOperator {
-  Equal = 'Equal',
-  Exists = 'Exists',
-}
-
-export enum TolerationEffect {
-  None = '',
-  NoSchedule = 'NoSchedule',
-  PreferNoSchedule = 'PreferNoSchedule',
-  NoExecute = 'NoExecute',
-}
-
-export interface TolerationEntry {
+export interface TolerationEntry extends V1Toleration {
   id: string;
-  operator: TolerationOperator;
-  effect?: TolerationEffect;
-  key: string;
-  value: string;
-  tolerationSeconds: number | null;
 }
 
 export interface WorkspaceKindPodConfigValue extends OptionsPodConfigValue {

--- a/workspaces/frontend/src/app/types.ts
+++ b/workspaces/frontend/src/app/types.ts
@@ -82,7 +82,6 @@ export interface WorkspaceKindImagePort {
   protocol: 'HTTP'; // ONLY HTTP is supported at the moment, per https://github.com/thesuperzapper/kubeflow-notebooks-v2-design/blob/main/crds/workspace-kind.yaml#L275
 }
 export enum TolerationOperator {
-  None = '',
   Equal = 'Equal',
   Exists = 'Exists',
 }
@@ -97,7 +96,7 @@ export enum TolerationEffect {
 export interface TolerationEntry {
   id: string;
   operator: TolerationOperator;
-  effect: TolerationEffect;
+  effect?: TolerationEffect;
   key: string;
   value: string;
   tolerationSeconds: number | null;

--- a/workspaces/frontend/src/app/types.ts
+++ b/workspaces/frontend/src/app/types.ts
@@ -81,6 +81,27 @@ export interface WorkspaceKindImagePort {
   port: number;
   protocol: 'HTTP'; // ONLY HTTP is supported at the moment, per https://github.com/thesuperzapper/kubeflow-notebooks-v2-design/blob/main/crds/workspace-kind.yaml#L275
 }
+export enum TolerationOperator {
+  None = '',
+  Equal = 'Equal',
+  Exists = 'Exists',
+}
+
+export enum TolerationEffect {
+  None = '',
+  NoSchedule = 'NoSchedule',
+  PreferNoSchedule = 'PreferNoSchedule',
+  NoExecute = 'NoExecute',
+}
+
+export interface TolerationEntry {
+  id: string;
+  operator: TolerationOperator;
+  effect: TolerationEffect;
+  key: string;
+  value: string;
+  tolerationSeconds: number | null;
+}
 
 export interface WorkspaceKindPodConfigValue extends OptionsPodConfigValue {
   resources?: {
@@ -92,6 +113,7 @@ export interface WorkspaceKindPodConfigValue extends OptionsPodConfigValue {
     };
   };
   nodeSelector?: Record<string, string>;
+  tolerations?: TolerationEntry[];
 }
 
 export interface WorkspaceKindImageConfigData {


### PR DESCRIPTION

 closes: #1019

Added:
- Custom types
- Refactored WorkspaceKind PodConfig Tables to have expandable rows
- Add Toleration Modal and Table to PodConfig expanded section: The modal will automatically hide `Value` input if the operator is `Exists` and only render Toleration seconds field if the effect is `NoExecute`
- Add tests

Before: 
<img width="1259" height="442" alt="Screenshot 2026-04-30 at 1 47 07 PM" src="https://github.com/user-attachments/assets/7dc48e31-b816-4dc7-a364-3231e13952e1" />

After:
<img width="1085" height="278" alt="Screenshot 2026-04-30 at 1 47 33 PM" src="https://github.com/user-attachments/assets/9e011d04-332f-4686-baab-58072c25185c" />
<img width="1338" height="767" alt="Screenshot 2026-04-30 at 1 51 07 PM" src="https://github.com/user-attachments/assets/f2cfa59f-8148-4812-9f6f-5247d10a9a9a" />
