### PR TITLE
fix: timestamp should display unknown for epoc 0

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaces.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaces.cy.ts
@@ -194,6 +194,33 @@ describe('Workspaces', () => {
         });
       });
     });
+
+    it('should display "unknown" for last activity when epoch is 0', () => {
+      const mockNamespace = buildMockNamespace({ name: DEFAULT_NAMESPACE });
+      const mockWorkspace = buildMockWorkspace({
+        name: 'zero-activity-workspace',
+        activity: {
+          lastActivity: 0,
+          lastUpdate: 0,
+        },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/namespaces',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([mockNamespace]),
+      ).as('getNamespaces');
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspaces/:namespace',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
+        mockModArchResponse([mockWorkspace]),
+      ).as('getWorkspaces');
+
+      navigateToNamespace(mockNamespace.name);
+
+      workspaces.assertWorkspaceRowLastActivity(0, 'unknown');
+    });
   });
 
   describe('Empty state', () => {

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -513,16 +513,19 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                           )}
                           {columnKey === 'gpu' && formatResourceFromWorkspace(workspace, 'gpu')}
                           {columnKey === 'idleGpu' && formatWorkspaceIdleState(workspace)}
-                          {columnKey === 'lastActivity' && (
-                            <Timestamp
-                              date={new Date(workspace.activity.lastActivity)}
-                              tooltip={{ variant: TimestampTooltipVariant.default }}
-                            >
-                              {formatDistanceToNow(new Date(workspace.activity.lastActivity), {
-                                addSuffix: true,
-                              })}
-                            </Timestamp>
-                          )}
+                          {columnKey === 'lastActivity' &&
+                            (workspace.activity.lastActivity === 0 ? (
+                              <span className="pf-v6-c-timestamp pf-m-help-text">unknown</span>
+                            ) : (
+                              <Timestamp
+                                date={new Date(workspace.activity.lastActivity)}
+                                tooltip={{ variant: TimestampTooltipVariant.default }}
+                              >
+                                {formatDistanceToNow(new Date(workspace.activity.lastActivity), {
+                                  addSuffix: true,
+                                })}
+                              </Timestamp>
+                            ))}
                         </Td>
                       );
                     })}

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
@@ -25,21 +25,21 @@ export const WorkspaceDetailsActivity: React.FunctionComponent<WorkspaceDetailsA
       <DescriptionListGroup>
         <DescriptionListTerm>Last activity</DescriptionListTerm>
         <DescriptionListDescription data-testid="lastActivity">
-          {format(activity.lastActivity, DATE_FORMAT)}
+          {activity.lastActivity === 0 ? 'unknown' : format(activity.lastActivity, DATE_FORMAT)}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />
       <DescriptionListGroup>
         <DescriptionListTerm>Last update</DescriptionListTerm>
         <DescriptionListDescription data-testid="lastUpdate">
-          {format(activity.lastUpdate, DATE_FORMAT)}
+          {activity.lastUpdate === 0 ? 'unknown' : format(activity.lastUpdate, DATE_FORMAT)}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />
       <DescriptionListGroup>
         <DescriptionListTerm>Pause time</DescriptionListTerm>
         <DescriptionListDescription data-testid="pauseTime">
-          {format(pausedTime, DATE_FORMAT)}
+          {pausedTime === 0 ? 'unknown' : format(pausedTime, DATE_FORMAT)}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />


### PR DESCRIPTION
closes: #1008

Add condition to display Last Activity timestamp more accurately

Before:
<img width="2559" height="570" alt="screenshot-localhost-9000-2026-04-24-12-10-38" src="https://github.com/user-attachments/assets/9a5a46d6-5ae8-4137-b015-806d8317f8b3" />

After:
<img width="1307" height="729" alt="Screenshot 2026-04-24 at 12 05 54 PM" src="https://github.com/user-attachments/assets/5c6ef0f6-263b-4490-8787-5e9552765204" />
