### PR TITLE
fix: remove extra space in dashboard by conditionally hiding sidebar

### DIFF
--- a/workspaces/frontend/src/app/App.tsx
+++ b/workspaces/frontend/src/app/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import '@patternfly/patternfly/patternfly-addons.css';
 import '@patternfly/react-core/dist/styles/base.css';
 import '~/app/app.css';
-import { Page, PageSidebar } from '@patternfly/react-core/dist/esm/components/Page';
+import { Page } from '@patternfly/react-core/dist/esm/components/Page';
 import { DeploymentMode, logout, useModularArchContext } from 'mod-arch-core';
 import ErrorBoundary from '~/app/error/ErrorBoundary';
 import AppRoutes from '~/app/AppRoutes';
@@ -30,6 +30,7 @@ const App: React.FC = () => {
               <Page
                 mainContainerId="primary-app-container"
                 isContentFilled
+                className={!isStandalone ? 'pf-m-no-sidebar' : undefined}
                 masthead={
                   isStandalone ? (
                     <NavBar
@@ -38,12 +39,10 @@ const App: React.FC = () => {
                         logout().then(() => window.location.reload());
                       }}
                     />
-                  ) : (
-                    ''
-                  )
+                  ) : undefined
                 }
+                sidebar={isStandalone ? <NavSidebar /> : undefined}
                 isManagedSidebar={isStandalone}
-                sidebar={isStandalone ? <NavSidebar /> : <PageSidebar isSidebarOpen={false} />}
               >
                 <PreGABanner />
                 <AppRoutes />

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -206,3 +206,29 @@ body,
 .pvc-select-group-header--with-divider {
   border-top: 1px solid var(--pf-t--global--border--color--default);
 }
+
+/* In dashboard mode when sidebar is not there, the main container take the full width */
+.pf-v6-c-page.pf-m-no-sidebar {
+  --pf-v6-c-page__main-container--GridArea: main;
+}
+
+/* Increase specificity to beat the media query */
+@media screen and (min-width: 75rem) {
+  .pf-v6-c-page.pf-m-no-sidebar {
+    --pf-v6-c-page__main-container--GridArea: main;
+  }
+}
+
+/* In dashboard mode when sidebar is not there, the main container will not have any margin */
+.mui-theme .pf-v6-c-page__main-container {
+  overflow: visible;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.mui-theme .pf-v6-c-page__main {
+  margin-left: 0 !important;
+}

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -220,7 +220,7 @@ body,
 }
 
 /* In dashboard mode when sidebar is not there, the main container will not have any margin */
-.mui-theme .pf-v6-c-page__main-container {
+.mui-theme .pf-v6-c-page.pf-m-no-sidebar .pf-v6-c-page__main-container {
   overflow: visible;
   flex-grow: 1;
   display: flex;
@@ -229,6 +229,6 @@ body,
   margin-left: 0;
 }
 
-.mui-theme .pf-v6-c-page__main {
-  margin-left: 0 !important;
+.mui-theme .pf-v6-c-page.pf-m-no-sidebar .pf-v6-c-page__main {
+  margin-left: 0;
 }


### PR DESCRIPTION
 Summary
Fixes the unwanted white space in the Kubeflow Dashboard by ensuring the `sidebar` and `masthead` props are `undefined` when not in standalone mode. 

This prevents PatternFly 6's CSS Grid from reserving space for hidden elements.

Changes
- Updated `App.tsx` to conditionally pass `undefined` to the `sidebar` prop when the app is not in standalone mode. 
- Similarly updated the `masthead` prop to use `undefined` instead of an empty string for consistency and cleaner rendering.
- This ensures that PatternFly 6 does not reserve any grid space for these elements when they are not needed.

Verification
- Verified that the gap is removed in Dashboard mode.
- Verified that the sidebar still works in Standalone mode.

Fixes #999