### PR TITLE
fix: toolbar actions should be outside filter ToolbarGroup

### DIFF
--- a/workspaces/frontend/src/shared/components/ToolbarFilter.tsx
+++ b/workspaces/frontend/src/shared/components/ToolbarFilter.tsx
@@ -394,9 +394,9 @@ function ToolbarFilterInner<K extends string>(
                   {null}
                 </PFToolbarFilter>
               ))}
-            {toolbarActions}
           </ToolbarGroup>
         </ToolbarToggleGroup>
+        {toolbarActions}
       </ToolbarContent>
     </Toolbar>
   );


### PR DESCRIPTION
Before:
<img width="496" height="760" alt="image" src="https://github.com/user-attachments/assets/08d29880-b3f3-454e-9a45-5c5918720039" />

After:
<img width="496" height="760" alt="image" src="https://github.com/user-attachments/assets/563ad779-f134-4b5b-9fc8-feae2ae81c14" />


<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->