### PR TITLE
refactor: return `user.Info` from `requireAuth` to cleanup todos

### DIFF
--- a/workspaces/backend/api/auth.go
+++ b/workspaces/backend/api/auth.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
@@ -28,13 +29,14 @@ import (
 // requireAuth verifies that the request is authenticated and authorized to take the actions specified by the given policies.
 // If this method returns false, the request has been handled and the caller should return immediately.
 // If this method returns true, the request is authenticated and authorized to proceed.
+// user.Info is the authenticated user, or nil if auth is disabled.
 // This method should only be called once per request.
-func (a *App) requireAuth(w http.ResponseWriter, r *http.Request, policies []*auth.ResourcePolicy) bool {
+func (a *App) requireAuth(w http.ResponseWriter, r *http.Request, policies []*auth.ResourcePolicy) (user.Info, bool) {
 	ctx := r.Context()
 
-	// if auth is disabled, allow the request to proceed
+	// if auth is disabled, allow the request to proceed (no user information available)
 	if a.Config.DisableAuth {
-		return true
+		return nil, true
 	}
 
 	// authenticate the request (extract user and groups from the request headers)
@@ -42,11 +44,11 @@ func (a *App) requireAuth(w http.ResponseWriter, r *http.Request, policies []*au
 	if err != nil {
 		err = fmt.Errorf("failed to authenticate request: %w", err)
 		a.serverErrorResponse(w, r, err)
-		return false
+		return nil, false
 	}
 	if !ok {
 		a.unauthorizedResponse(w, r)
-		return false
+		return nil, false
 	}
 
 	// for each policy, check if the user is authorized to take the requested action
@@ -56,7 +58,7 @@ func (a *App) requireAuth(w http.ResponseWriter, r *http.Request, policies []*au
 		if err != nil {
 			err = fmt.Errorf("failed to authorize request for user %q: %w", res.User.GetName(), err)
 			a.serverErrorResponse(w, r, err)
-			return false
+			return nil, false
 		}
 
 		if authorized != authorizer.DecisionAllow {
@@ -65,9 +67,9 @@ func (a *App) requireAuth(w http.ResponseWriter, r *http.Request, policies []*au
 				msg = fmt.Sprintf("%s: %s", msg, reason)
 			}
 			a.forbiddenResponse(w, r, msg)
-			return false
+			return nil, false
 		}
 	}
 
-	return true
+	return res.User, true
 }

--- a/workspaces/backend/api/namespaces_handler.go
+++ b/workspaces/backend/api/namespaces_handler.go
@@ -45,7 +45,7 @@ func (a *App) GetNamespacesHandler(w http.ResponseWriter, r *http.Request, _ htt
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbList, auth.Namespaces, auth.ResourcePolicyResourceMeta{}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/pvcs_handler.go
+++ b/workspaces/backend/api/pvcs_handler.go
@@ -64,7 +64,7 @@ func (a *App) GetPVCsByNamespaceHandler(w http.ResponseWriter, r *http.Request, 
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbList, auth.PersistentVolumeClaims, auth.ResourcePolicyResourceMeta{Namespace: namespace}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -153,12 +153,13 @@ func (a *App) CreatePVCHandler(w http.ResponseWriter, r *http.Request, ps httpro
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbCreate, auth.PersistentVolumeClaims, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: pvcCreate.Name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
 
-	createdPVC, err := a.repositories.PVC.CreatePVC(r.Context(), pvcCreate, namespace)
+	createdPVC, err := a.repositories.PVC.CreatePVC(r.Context(), actor, pvcCreate, namespace)
 	if err != nil {
 		if helper.IsInternalValidationError(err) {
 			fieldErrs := helper.FieldErrorsFromInternalValidationError(err)
@@ -220,7 +221,7 @@ func (a *App) DeletePVCHandler(w http.ResponseWriter, r *http.Request, ps httpro
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbDelete, auth.PersistentVolumeClaims, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: pvcName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/pvcs_handler_test.go
+++ b/workspaces/backend/api/pvcs_handler_test.go
@@ -314,8 +314,12 @@ var _ = Describe("PVCs Handler", func() {
 			Expect(createdPVC.Labels[commonModels.LabelCanUpdate]).To(Equal("true"))
 
 			By("verifying the audit annotations were set")
-			Expect(createdPVC.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
-			Expect(createdPVC.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
+			Expect(createdPVC.Annotations).To(BeEquivalentTo(
+				map[string]string{
+					commonModels.AnnotationCreatedBy: adminUser,
+					commonModels.AnnotationUpdatedBy: adminUser,
+				},
+			))
 		})
 	})
 

--- a/workspaces/backend/api/pvcs_handler_test.go
+++ b/workspaces/backend/api/pvcs_handler_test.go
@@ -312,6 +312,10 @@ var _ = Describe("PVCs Handler", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-create-pvc", Namespace: namespaceName1}, createdPVC)).To(Succeed())
 			Expect(createdPVC.Labels[commonModels.LabelCanMount]).To(Equal("true"))
 			Expect(createdPVC.Labels[commonModels.LabelCanUpdate]).To(Equal("true"))
+
+			By("verifying the audit annotations were set")
+			Expect(createdPVC.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
+			Expect(createdPVC.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
 		})
 	})
 

--- a/workspaces/backend/api/secrets_handler.go
+++ b/workspaces/backend/api/secrets_handler.go
@@ -65,7 +65,7 @@ func (a *App) GetSecretsByNamespaceHandler(w http.ResponseWriter, r *http.Reques
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbList, auth.Secrets, auth.ResourcePolicyResourceMeta{Namespace: namespace}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -113,7 +113,7 @@ func (a *App) GetSecretHandler(w http.ResponseWriter, r *http.Request, ps httpro
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbGet, auth.Secrets, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: secretName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -207,13 +207,14 @@ func (a *App) CreateSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbCreate, auth.Secrets, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: secretCreate.Name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
 
 	// create the secret
-	secret, err := a.repositories.Secret.CreateSecret(r.Context(), secretCreate, namespace)
+	secret, err := a.repositories.Secret.CreateSecret(r.Context(), actor, secretCreate, namespace)
 	if err != nil {
 		if errors.Is(err, repository.ErrSecretAlreadyExists) {
 			causes := helper.StatusCausesFromAPIStatus(err)
@@ -270,7 +271,8 @@ func (a *App) UpdateSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbUpdate, auth.Secrets, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: secretName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
@@ -314,7 +316,7 @@ func (a *App) UpdateSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 	// give the request data a clear name
 	secretUpdate := bodyEnvelope.Data
 
-	secret, err := a.repositories.Secret.UpdateSecret(r.Context(), secretUpdate, namespace, secretName)
+	secret, err := a.repositories.Secret.UpdateSecret(r.Context(), actor, secretUpdate, namespace, secretName)
 	if err != nil {
 		if errors.Is(err, repository.ErrSecretNotFound) {
 			a.notFoundResponse(w, r)
@@ -360,7 +362,7 @@ func (a *App) DeleteSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbDelete, auth.Secrets, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: secretName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/storageclasses_handler.go
+++ b/workspaces/backend/api/storageclasses_handler.go
@@ -45,7 +45,7 @@ func (a *App) GetStorageClassesHandler(w http.ResponseWriter, r *http.Request, _
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbList, auth.StorageClasses, auth.ResourcePolicyResourceMeta{}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/workspace_actions_handler.go
+++ b/workspaces/backend/api/workspace_actions_handler.go
@@ -102,7 +102,7 @@ func (a *App) PauseActionWorkspaceHandler(w http.ResponseWriter, r *http.Request
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbUpdate, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: workspaceName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/workspacekind_assets_handler.go
+++ b/workspaces/backend/api/workspacekind_assets_handler.go
@@ -119,7 +119,7 @@ func (a *App) getWorkspaceKindAssetHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/workspacekind_podtemplate_options_handler.go
+++ b/workspaces/backend/api/workspacekind_podtemplate_options_handler.go
@@ -124,7 +124,7 @@ func (a *App) PodTemplateOptionsListValuesHandler(w http.ResponseWriter, r *http
 		}
 	}
 
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -277,7 +277,7 @@ func (a *App) CreateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 	}
 	// ============================================================
 
-	createdWorkspaceKind, err := a.repositories.WorkspaceKind.Create(r.Context(), actor, workspaceKind)
+	createdWorkspaceKind, err := a.repositories.WorkspaceKind.CreateWorkspaceKind(r.Context(), actor, workspaceKind)
 	if err != nil {
 		if errors.Is(err, repository.ErrWorkspaceKindAlreadyExists) {
 			causes := helper.StatusCausesFromAPIStatus(err)

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -271,12 +271,13 @@ func (a *App) CreateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbCreate, auth.WorkspaceKinds, auth.ResourcePolicyResourceMeta{Name: workspaceKind.Name}),
 	}
-	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
 
-	createdWorkspaceKind, err := a.repositories.WorkspaceKind.Create(r.Context(), workspaceKind)
+	createdWorkspaceKind, err := a.repositories.WorkspaceKind.Create(r.Context(), actor, workspaceKind)
 	if err != nil {
 		if errors.Is(err, repository.ErrWorkspaceKindAlreadyExists) {
 			causes := helper.StatusCausesFromAPIStatus(err)

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -71,7 +71,7 @@ func (a *App) GetWorkspaceKindHandler(w http.ResponseWriter, r *http.Request, ps
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbGet, auth.WorkspaceKinds, auth.ResourcePolicyResourceMeta{Name: name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -133,7 +133,7 @@ func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _
 		}
 	}
 
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -179,7 +179,7 @@ func (a *App) DeleteWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbDelete, auth.WorkspaceKinds, auth.ResourcePolicyResourceMeta{Name: name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -271,7 +271,7 @@ func (a *App) CreateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbCreate, auth.WorkspaceKinds, auth.ResourcePolicyResourceMeta{Name: workspaceKind.Name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -335,7 +335,8 @@ func (a *App) UpdateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbUpdate, auth.WorkspaceKinds, auth.ResourcePolicyResourceMeta{Name: name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
@@ -378,7 +379,7 @@ func (a *App) UpdateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 	// give the request data a clear name
 	workspaceKindUpdate := bodyEnvelope.Data
 
-	updatedWorkspaceKind, err := a.repositories.WorkspaceKind.UpdateWorkspaceKind(r.Context(), workspaceKindUpdate, name)
+	updatedWorkspaceKind, err := a.repositories.WorkspaceKind.UpdateWorkspaceKind(r.Context(), actor, workspaceKindUpdate, name)
 	if err != nil {
 		if errors.Is(err, repository.ErrWorkspaceKindNotFound) {
 			a.notFoundResponse(w, r)

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -428,8 +428,12 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the audit annotations were set")
-			Expect(createdWsk.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
-			Expect(createdWsk.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
+			Expect(createdWsk.Annotations).To(BeEquivalentTo(
+				map[string]string{
+					commonModels.AnnotationCreatedBy: adminUser,
+					commonModels.AnnotationUpdatedBy: adminUser,
+				},
+			))
 		})
 
 		It("should fail to create a WorkspaceKind with no name in the YAML", func() {
@@ -960,7 +964,7 @@ metadata:
 
 			By("verifying the audit annotations were updated")
 			Expect(updatedWsk.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
-			Expect(updatedWsk.Annotations[commonModels.AnnotationUpdatedAt]).NotTo(BeEmpty())
+			Expect(updatedWsk.Annotations).To(HaveKey(commonModels.AnnotationUpdatedAt))
 		})
 
 		It("should update spawner.deprecated and persist the change", func() {

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
+	commonModels "github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds"
 )
 
@@ -425,6 +426,10 @@ spec:
 			createdWsk := &kubefloworgv1beta1.WorkspaceKind{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: newWorkspaceKindName}, createdWsk)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the audit annotations were set")
+			Expect(createdWsk.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
+			Expect(createdWsk.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
 		})
 
 		It("should fail to create a WorkspaceKind with no name in the YAML", func() {
@@ -949,6 +954,13 @@ metadata:
 			Expect(response.Data).NotTo(BeNil())
 			Expect(response.Data.Revision).NotTo(BeEmpty())
 
+			By("getting the updated WorkspaceKind from the Kubernetes API")
+			updatedWsk := &kubefloworgv1beta1.WorkspaceKind{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wskName}, updatedWsk)).To(Succeed())
+
+			By("verifying the audit annotations were updated")
+			Expect(updatedWsk.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
+			Expect(updatedWsk.Annotations[commonModels.AnnotationUpdatedAt]).NotTo(BeEmpty())
 		})
 
 		It("should update spawner.deprecated and persist the change", func() {

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -72,7 +72,7 @@ func (a *App) GetWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps htt
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbGet, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: workspaceName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -146,7 +146,7 @@ func (a *App) getWorkspacesHandler(w http.ResponseWriter, r *http.Request, ps ht
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbList, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================
@@ -241,12 +241,13 @@ func (a *App) CreateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbCreate, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: workspaceCreate.Name}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
 
-	createdWorkspace, err := a.repositories.Workspace.CreateWorkspace(r.Context(), workspaceCreate, namespace)
+	createdWorkspace, err := a.repositories.Workspace.CreateWorkspace(r.Context(), actor, workspaceCreate, namespace)
 	if err != nil {
 		if helper.IsInternalValidationError(err) {
 			fieldErrs := helper.FieldErrorsFromInternalValidationError(err)
@@ -312,7 +313,8 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbUpdate, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: workspaceName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	actor, ok := a.requireAuth(w, r, authPolicies)
+	if !ok {
 		return
 	}
 	// ============================================================
@@ -355,7 +357,7 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 	// give the request data a clear name
 	workspaceUpdate := bodyEnvelope.Data
 
-	updatedWorkspace, err := a.repositories.Workspace.UpdateWorkspace(r.Context(), workspaceUpdate, namespace, workspaceName)
+	updatedWorkspace, err := a.repositories.Workspace.UpdateWorkspace(r.Context(), actor, workspaceUpdate, namespace, workspaceName)
 	if err != nil {
 		if errors.Is(err, repository.ErrWorkspaceNotFound) {
 			a.notFoundResponse(w, r)
@@ -419,7 +421,7 @@ func (a *App) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 	authPolicies := []*auth.ResourcePolicy{
 		auth.NewResourcePolicy(auth.VerbDelete, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: workspaceName}),
 	}
-	if success := a.requireAuth(w, r, authPolicies); !success {
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return
 	}
 	// ============================================================

--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -852,6 +852,10 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Data).To(Equal(expected))
 			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(BeEmpty())
 
+			By("verifying the audit annotations were set")
+			Expect(createdWorkspace.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
+			Expect(createdWorkspace.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
+
 			By("creating an HTTP request to delete the Workspace")
 			path = strings.Replace(constants.WorkspacesByNamePath, ":"+constants.NamespacePathParam, namespaceNameCrud, 1)
 			path = strings.Replace(path, ":"+constants.ResourceNamePathParam, workspaceName, 1)
@@ -1113,6 +1117,11 @@ var _ = Describe("Workspaces Handler", func() {
 			By("getting the updated Workspace from the Kubernetes API")
 			updatedWorkspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey, updatedWorkspace)).To(Succeed())
+
+			By("verifying the audit annotations were updated")
+			Expect(updatedWorkspace.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
+			Expect(updatedWorkspace.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
+			Expect(updatedWorkspace.Annotations[commonModels.AnnotationUpdatedAt]).NotTo(BeEmpty())
 
 			By("verifying all fields were applied")
 			Expect(ptr.Deref(updatedWorkspace.Spec.Paused, false)).To(BeTrue())

--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -853,8 +853,12 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(createdWorkspace.Spec.PodTemplate.Volumes.Secrets).To(BeEmpty())
 
 			By("verifying the audit annotations were set")
-			Expect(createdWorkspace.Annotations[commonModels.AnnotationCreatedBy]).To(Equal(adminUser))
-			Expect(createdWorkspace.Annotations[commonModels.AnnotationUpdatedBy]).To(Equal(adminUser))
+			Expect(createdWorkspace.Annotations).To(BeEquivalentTo(
+				map[string]string{
+					commonModels.AnnotationCreatedBy: adminUser,
+					commonModels.AnnotationUpdatedBy: adminUser,
+				},
+			))
 
 			By("creating an HTTP request to delete the Workspace")
 			path = strings.Replace(constants.WorkspacesByNamePath, ":"+constants.NamespacePathParam, namespaceNameCrud, 1)

--- a/workspaces/backend/internal/models/common/funcs.go
+++ b/workspaces/backend/internal/models/common/funcs.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 const (
@@ -62,7 +63,7 @@ func NewAuditFromObjectMeta(objectMeta *metav1.ObjectMeta) Audit {
 }
 
 // UpdateObjectMetaForCreate updates the ObjectMeta for a create operation.
-func UpdateObjectMetaForCreate(objectMeta *metav1.ObjectMeta, actor string) {
+func UpdateObjectMetaForCreate(objectMeta *metav1.ObjectMeta, actor user.Info) {
 	// we only use pointers to avoid copying the entire object
 	if objectMeta == nil {
 		panic("objectMeta cannot be nil")
@@ -71,13 +72,15 @@ func UpdateObjectMetaForCreate(objectMeta *metav1.ObjectMeta, actor string) {
 	if objectMeta.Annotations == nil {
 		objectMeta.Annotations = make(map[string]string)
 	}
-	objectMeta.Annotations[AnnotationCreatedBy] = actor
 	objectMeta.Annotations[AnnotationUpdatedAt] = objectMeta.CreationTimestamp.Format(time.RFC3339)
-	objectMeta.Annotations[AnnotationUpdatedBy] = actor
+	if actor != nil {
+		objectMeta.Annotations[AnnotationCreatedBy] = actor.GetName()
+		objectMeta.Annotations[AnnotationUpdatedBy] = actor.GetName()
+	}
 }
 
 // UpdateObjectMetaForUpdate updates the ObjectMeta for an update operation.
-func UpdateObjectMetaForUpdate(objectMeta *metav1.ObjectMeta, actor string, now time.Time) {
+func UpdateObjectMetaForUpdate(objectMeta *metav1.ObjectMeta, actor user.Info, now time.Time) {
 	// we only use pointers to avoid copying the entire object
 	if objectMeta == nil {
 		panic("objectMeta cannot be nil")
@@ -87,7 +90,9 @@ func UpdateObjectMetaForUpdate(objectMeta *metav1.ObjectMeta, actor string, now 
 		objectMeta.Annotations = make(map[string]string)
 	}
 	objectMeta.Annotations[AnnotationUpdatedAt] = now.Format(time.RFC3339)
-	objectMeta.Annotations[AnnotationUpdatedBy] = actor
+	if actor != nil {
+		objectMeta.Annotations[AnnotationUpdatedBy] = actor.GetName()
+	}
 }
 
 // GetDisplayNameFromObjectMeta retrieves the display name from ObjectMeta annotations, if it exists.

--- a/workspaces/backend/internal/models/common/funcs.go
+++ b/workspaces/backend/internal/models/common/funcs.go
@@ -72,10 +72,13 @@ func UpdateObjectMetaForCreate(objectMeta *metav1.ObjectMeta, actor user.Info) {
 	if objectMeta.Annotations == nil {
 		objectMeta.Annotations = make(map[string]string)
 	}
-	objectMeta.Annotations[AnnotationUpdatedAt] = objectMeta.CreationTimestamp.Format(time.RFC3339)
 	if actor != nil {
 		objectMeta.Annotations[AnnotationCreatedBy] = actor.GetName()
 		objectMeta.Annotations[AnnotationUpdatedBy] = actor.GetName()
+	} else {
+		delete(objectMeta.Annotations, AnnotationCreatedBy)
+		delete(objectMeta.Annotations, AnnotationUpdatedBy)
+		delete(objectMeta.Annotations, AnnotationUpdatedAt)
 	}
 }
 
@@ -92,6 +95,8 @@ func UpdateObjectMetaForUpdate(objectMeta *metav1.ObjectMeta, actor user.Info, n
 	objectMeta.Annotations[AnnotationUpdatedAt] = now.Format(time.RFC3339)
 	if actor != nil {
 		objectMeta.Annotations[AnnotationUpdatedBy] = actor.GetName()
+	} else {
+		delete(objectMeta.Annotations, AnnotationUpdatedBy)
 	}
 }
 

--- a/workspaces/backend/internal/models/common/funcs_test.go
+++ b/workspaces/backend/internal/models/common/funcs_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Models Suite")
+}
+
+var _ = Describe("UpdateObjectMetaForCreate", func() {
+	It("sets created-by and updated-by for a real user", func() {
+		meta := &metav1.ObjectMeta{}
+		UpdateObjectMetaForCreate(meta, &user.DefaultInfo{Name: "alice"})
+
+		Expect(meta.Annotations[AnnotationCreatedBy]).To(Equal("alice"))
+		Expect(meta.Annotations[AnnotationUpdatedBy]).To(Equal("alice"))
+	})
+
+	It("skips created-by and updated-by when actor is nil", func() {
+		meta := &metav1.ObjectMeta{}
+		UpdateObjectMetaForCreate(meta, nil)
+
+		Expect(meta.Annotations).NotTo(HaveKey(AnnotationCreatedBy))
+		Expect(meta.Annotations).NotTo(HaveKey(AnnotationUpdatedBy))
+	})
+
+	It("still sets updated-at when actor is nil", func() {
+		meta := &metav1.ObjectMeta{}
+		UpdateObjectMetaForCreate(meta, nil)
+
+		Expect(meta.Annotations).To(HaveKey(AnnotationUpdatedAt))
+	})
+
+	It("initializes annotations map when nil", func() {
+		meta := &metav1.ObjectMeta{Annotations: nil}
+		UpdateObjectMetaForCreate(meta, &user.DefaultInfo{Name: "alice"})
+
+		Expect(meta.Annotations).NotTo(BeNil())
+	})
+
+	It("panics when objectMeta is nil", func() {
+		Expect(func() {
+			UpdateObjectMetaForCreate(nil, &user.DefaultInfo{Name: "alice"})
+		}).To(Panic())
+	})
+})
+
+var _ = Describe("UpdateObjectMetaForUpdate", func() {
+	It("sets updated-by for a real user", func() {
+		meta := &metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationCreatedBy: "alice"},
+		}
+		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "bob"}, time.Now())
+
+		Expect(meta.Annotations[AnnotationUpdatedBy]).To(Equal("bob"))
+	})
+
+	It("does not overwrite created-by", func() {
+		meta := &metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationCreatedBy: "alice"},
+		}
+		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "bob"}, time.Now())
+
+		Expect(meta.Annotations[AnnotationCreatedBy]).To(Equal("alice"))
+	})
+
+	It("skips updated-by when actor is nil", func() {
+		meta := &metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationUpdatedBy: "alice"},
+		}
+		UpdateObjectMetaForUpdate(meta, nil, time.Now())
+
+		Expect(meta.Annotations[AnnotationUpdatedBy]).To(Equal("alice"))
+	})
+
+	It("sets updated-at in RFC3339 format", func() {
+		meta := &metav1.ObjectMeta{}
+		now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "alice"}, now)
+
+		Expect(meta.Annotations[AnnotationUpdatedAt]).To(Equal("2024-06-01T12:00:00Z"))
+	})
+
+	It("still sets updated-at when actor is nil", func() {
+		meta := &metav1.ObjectMeta{}
+		UpdateObjectMetaForUpdate(meta, nil, time.Now())
+
+		Expect(meta.Annotations).To(HaveKey(AnnotationUpdatedAt))
+	})
+
+	It("initializes annotations map when nil", func() {
+		meta := &metav1.ObjectMeta{Annotations: nil}
+		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "alice"}, time.Now())
+
+		Expect(meta.Annotations).NotTo(BeNil())
+	})
+
+	It("panics when objectMeta is nil", func() {
+		Expect(func() {
+			UpdateObjectMetaForUpdate(nil, &user.DefaultInfo{Name: "alice"}, time.Now())
+		}).To(Panic())
+	})
+})

--- a/workspaces/backend/internal/models/common/funcs_test.go
+++ b/workspaces/backend/internal/models/common/funcs_test.go
@@ -33,33 +33,34 @@ func TestCommon(t *testing.T) {
 
 var _ = Describe("UpdateObjectMetaForCreate", func() {
 	It("sets created-by and updated-by for a real user", func() {
-		meta := &metav1.ObjectMeta{}
+		meta := &metav1.ObjectMeta{
+			CreationTimestamp: metav1.Now(),
+		}
 		UpdateObjectMetaForCreate(meta, &user.DefaultInfo{Name: "alice"})
 
-		Expect(meta.Annotations[AnnotationCreatedBy]).To(Equal("alice"))
-		Expect(meta.Annotations[AnnotationUpdatedBy]).To(Equal("alice"))
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{
+			AnnotationCreatedBy: "alice",
+			AnnotationUpdatedBy: "alice",
+		}))
 	})
 
 	It("skips created-by and updated-by when actor is nil", func() {
-		meta := &metav1.ObjectMeta{}
+		meta := &metav1.ObjectMeta{
+			CreationTimestamp: metav1.Now(),
+		}
 		UpdateObjectMetaForCreate(meta, nil)
 
-		Expect(meta.Annotations).NotTo(HaveKey(AnnotationCreatedBy))
-		Expect(meta.Annotations).NotTo(HaveKey(AnnotationUpdatedBy))
-	})
-
-	It("still sets updated-at when actor is nil", func() {
-		meta := &metav1.ObjectMeta{}
-		UpdateObjectMetaForCreate(meta, nil)
-
-		Expect(meta.Annotations).To(HaveKey(AnnotationUpdatedAt))
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{}))
 	})
 
 	It("initializes annotations map when nil", func() {
-		meta := &metav1.ObjectMeta{Annotations: nil}
-		UpdateObjectMetaForCreate(meta, &user.DefaultInfo{Name: "alice"})
+		meta := &metav1.ObjectMeta{
+			Annotations:       nil,
+			CreationTimestamp: metav1.Now(),
+		}
+		UpdateObjectMetaForCreate(meta, nil)
 
-		Expect(meta.Annotations).NotTo(BeNil())
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{}))
 	})
 
 	It("panics when objectMeta is nil", func() {
@@ -70,53 +71,75 @@ var _ = Describe("UpdateObjectMetaForCreate", func() {
 })
 
 var _ = Describe("UpdateObjectMetaForUpdate", func() {
-	It("sets updated-by for a real user", func() {
+	It("correctly set updated-by for new user", func() {
+		createTime := metav1.Now()
 		meta := &metav1.ObjectMeta{
-			Annotations: map[string]string{AnnotationCreatedBy: "alice"},
+			Annotations: map[string]string{
+				AnnotationCreatedBy: "alice",
+				AnnotationUpdatedBy: "alice",
+				AnnotationUpdatedAt: createTime.Format(time.RFC3339),
+			},
+			CreationTimestamp: createTime,
 		}
-		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "bob"}, time.Now())
+		updateTime := createTime.Add(1 * time.Hour)
+		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "bob"}, updateTime)
 
-		Expect(meta.Annotations[AnnotationUpdatedBy]).To(Equal("bob"))
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{
+			AnnotationCreatedBy: "alice",
+			AnnotationUpdatedBy: "bob",
+			AnnotationUpdatedAt: updateTime.Format(time.RFC3339),
+		}))
 	})
 
-	It("does not overwrite created-by", func() {
+	It("remove updated-by when actor is nil", func() {
+		createTime := metav1.Now()
 		meta := &metav1.ObjectMeta{
-			Annotations: map[string]string{AnnotationCreatedBy: "alice"},
+			Annotations: map[string]string{
+				AnnotationCreatedBy: "alice",
+				AnnotationUpdatedBy: "alice",
+				AnnotationUpdatedAt: createTime.Format(time.RFC3339),
+			},
+			CreationTimestamp: createTime,
 		}
-		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "bob"}, time.Now())
+		updateTime := createTime.Add(1 * time.Hour)
+		UpdateObjectMetaForUpdate(meta, nil, updateTime)
 
-		Expect(meta.Annotations[AnnotationCreatedBy]).To(Equal("alice"))
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{
+			AnnotationCreatedBy: "alice",
+			AnnotationUpdatedAt: updateTime.Format(time.RFC3339),
+		}))
 	})
 
-	It("skips updated-by when actor is nil", func() {
+	It("remove updated-by when actor is nil, and dont set created-by", func() {
+		createTime := metav1.Now()
 		meta := &metav1.ObjectMeta{
-			Annotations: map[string]string{AnnotationUpdatedBy: "alice"},
+			Annotations: map[string]string{
+				AnnotationUpdatedBy: "alice",
+				AnnotationUpdatedAt: createTime.Format(time.RFC3339),
+			},
+			CreationTimestamp: createTime,
 		}
-		UpdateObjectMetaForUpdate(meta, nil, time.Now())
+		updateTime := createTime.Add(1 * time.Hour)
+		UpdateObjectMetaForUpdate(meta, nil, updateTime)
 
-		Expect(meta.Annotations[AnnotationUpdatedBy]).To(Equal("alice"))
-	})
-
-	It("sets updated-at in RFC3339 format", func() {
-		meta := &metav1.ObjectMeta{}
-		now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
-		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "alice"}, now)
-
-		Expect(meta.Annotations[AnnotationUpdatedAt]).To(Equal("2024-06-01T12:00:00Z"))
-	})
-
-	It("still sets updated-at when actor is nil", func() {
-		meta := &metav1.ObjectMeta{}
-		UpdateObjectMetaForUpdate(meta, nil, time.Now())
-
-		Expect(meta.Annotations).To(HaveKey(AnnotationUpdatedAt))
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{
+			AnnotationUpdatedAt: updateTime.Format(time.RFC3339),
+		}))
 	})
 
 	It("initializes annotations map when nil", func() {
-		meta := &metav1.ObjectMeta{Annotations: nil}
-		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "alice"}, time.Now())
+		createTime := metav1.Now()
+		meta := &metav1.ObjectMeta{
+			Annotations:       nil,
+			CreationTimestamp: createTime,
+		}
+		updateTime := createTime.Add(1 * time.Hour)
+		UpdateObjectMetaForUpdate(meta, &user.DefaultInfo{Name: "alice"}, updateTime)
 
-		Expect(meta.Annotations).NotTo(BeNil())
+		Expect(meta.Annotations).To(BeEquivalentTo(map[string]string{
+			AnnotationUpdatedBy: "alice",
+			AnnotationUpdatedAt: updateTime.Format(time.RFC3339),
+		}))
 	})
 
 	It("panics when objectMeta is nil", func() {

--- a/workspaces/backend/internal/repositories/pvcs/repo.go
+++ b/workspaces/backend/internal/repositories/pvcs/repo.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
@@ -191,10 +192,7 @@ func buildWorkspaceInfoMap(workspaceList *kubefloworgv1beta1.WorkspaceList) map[
 	return pvcToWsInfo
 }
 
-func (r *PVCRepository) CreatePVC(ctx context.Context, pvcCreate *models.PVCCreate, namespace string) (*models.PVCCreate, error) {
-	// TODO: get actual user email from request context
-	actor := "mock@example.com"
-
+func (r *PVCRepository) CreatePVC(ctx context.Context, actor user.Info, pvcCreate *models.PVCCreate, namespace string) (*models.PVCCreate, error) {
 	var allValErrs field.ErrorList
 
 	// get and validate the storage class

--- a/workspaces/backend/internal/repositories/secrets/repo.go
+++ b/workspaces/backend/internal/repositories/secrets/repo.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,10 +76,7 @@ func (r *SecretRepository) GetSecret(ctx context.Context, namespace string, secr
 }
 
 // CreateSecret creates a new secret in the specified namespace.
-func (r *SecretRepository) CreateSecret(ctx context.Context, secretCreate *models.SecretCreate, namespace string) (*models.SecretCreate, error) {
-	// TODO: get actual user email from request context
-	actor := "mock@example.com"
-
+func (r *SecretRepository) CreateSecret(ctx context.Context, actor user.Info, secretCreate *models.SecretCreate, namespace string) (*models.SecretCreate, error) {
 	secret := newSecretFromSecretCreateModel(secretCreate, namespace)
 	modelsCommon.UpdateObjectMetaForCreate(&secret.ObjectMeta, actor)
 
@@ -90,9 +88,7 @@ func (r *SecretRepository) CreateSecret(ctx context.Context, secretCreate *model
 }
 
 // UpdateSecret updates an existing secret in the specified namespace.
-func (r *SecretRepository) UpdateSecret(ctx context.Context, secretUpdate *models.SecretUpdate, namespace string, secretName string) (*models.SecretUpdate, error) {
-	// TODO: get actual user email from request context
-	actor := "mock@example.com"
+func (r *SecretRepository) UpdateSecret(ctx context.Context, actor user.Info, secretUpdate *models.SecretUpdate, namespace string, secretName string) (*models.SecretUpdate, error) {
 	now := time.Now()
 
 	// TODO: fetch the current secret from K8s

--- a/workspaces/backend/internal/repositories/secrets/repo.go
+++ b/workspaces/backend/internal/repositories/secrets/repo.go
@@ -78,6 +78,8 @@ func (r *SecretRepository) GetSecret(ctx context.Context, namespace string, secr
 // CreateSecret creates a new secret in the specified namespace.
 func (r *SecretRepository) CreateSecret(ctx context.Context, actor user.Info, secretCreate *models.SecretCreate, namespace string) (*models.SecretCreate, error) {
 	secret := newSecretFromSecretCreateModel(secretCreate, namespace)
+
+	// set audit annotations
 	modelsCommon.UpdateObjectMetaForCreate(&secret.ObjectMeta, actor)
 
 	// TODO: create the secret in K8s
@@ -98,6 +100,8 @@ func (r *SecretRepository) UpdateSecret(ctx context.Context, actor user.Info, se
 	}
 
 	secret := updateSecretFromSecretUpdateModel(secretUpdate, currentSecret)
+
+	// set audit annotations
 	modelsCommon.UpdateObjectMetaForUpdate(&secret.ObjectMeta, actor, now)
 
 	// TODO: update the secret in K8s

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -93,7 +93,10 @@ func (r *WorkspaceKindRepository) GetWorkspaceKinds(ctx context.Context) ([]mode
 	return workspaceKindsModels, nil
 }
 
-func (r *WorkspaceKindRepository) Create(ctx context.Context, workspaceKind *kubefloworgv1beta1.WorkspaceKind) (*models.WorkspaceKindCreate, error) {
+func (r *WorkspaceKindRepository) Create(ctx context.Context, actor user.Info, workspaceKind *kubefloworgv1beta1.WorkspaceKind) (*models.WorkspaceKindCreate, error) {
+	// set audit annotations
+	modelsCommon.UpdateObjectMetaForCreate(&workspaceKind.ObjectMeta, actor)
+
 	// create workspace kind
 	if err := r.client.Create(ctx, workspaceKind); err != nil {
 		if apierrors.IsAlreadyExists(err) {

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -93,7 +93,7 @@ func (r *WorkspaceKindRepository) GetWorkspaceKinds(ctx context.Context) ([]mode
 	return workspaceKindsModels, nil
 }
 
-func (r *WorkspaceKindRepository) Create(ctx context.Context, actor user.Info, workspaceKind *kubefloworgv1beta1.WorkspaceKind) (*models.WorkspaceKindCreate, error) {
+func (r *WorkspaceKindRepository) CreateWorkspaceKind(ctx context.Context, actor user.Info, workspaceKind *kubefloworgv1beta1.WorkspaceKind) (*models.WorkspaceKindCreate, error) {
 	// set audit annotations
 	modelsCommon.UpdateObjectMetaForCreate(&workspaceKind.ObjectMeta, actor)
 

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
@@ -110,9 +111,7 @@ func (r *WorkspaceKindRepository) Create(ctx context.Context, workspaceKind *kub
 	return createdWorkspaceKindModel, nil
 }
 
-func (r *WorkspaceKindRepository) UpdateWorkspaceKind(ctx context.Context, workspaceKindUpdate *models.WorkspaceKindUpdate, name string) (*models.WorkspaceKindUpdate, error) {
-	// TODO: get actual user email from request context
-	actor := "mock@example.com"
+func (r *WorkspaceKindRepository) UpdateWorkspaceKind(ctx context.Context, actor user.Info, workspaceKindUpdate *models.WorkspaceKindUpdate, name string) (*models.WorkspaceKindUpdate, error) {
 	now := time.Now()
 
 	// get workspace kind

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
@@ -104,10 +105,7 @@ func (r *WorkspaceRepository) getWorkspaceModels(ctx context.Context, listOption
 	return workspacesModels, nil
 }
 
-func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, workspaceCreate *models.WorkspaceCreate, namespace string) (*models.WorkspaceCreate, error) {
-	// TODO: get actual user email from request context
-	actor := "mock@example.com"
-
+func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, actor user.Info, workspaceCreate *models.WorkspaceCreate, namespace string) (*models.WorkspaceCreate, error) {
 	// create workspace object from model
 	workspace, err := models.NewWorkspaceFromWorkspaceCreateModel(ctx, r.client, workspaceCreate, namespace)
 	if err != nil {
@@ -134,9 +132,7 @@ func (r *WorkspaceRepository) CreateWorkspace(ctx context.Context, workspaceCrea
 	return createdWorkspaceModel, nil
 }
 
-func (r *WorkspaceRepository) UpdateWorkspace(ctx context.Context, workspaceUpdate *models.WorkspaceUpdate, namespace, workspaceName string) (*models.WorkspaceUpdate, error) {
-	// TODO: get actual user email from request context
-	actor := "mock@example.com"
+func (r *WorkspaceRepository) UpdateWorkspace(ctx context.Context, actor user.Info, workspaceUpdate *models.WorkspaceUpdate, namespace, workspaceName string) (*models.WorkspaceUpdate, error) {
 	now := time.Now()
 
 	// get workspace


### PR DESCRIPTION
- **refactor: add user info for authenticated users**
- **fix: add audit annotations on WorkspaceKind creation**
- **test: verify audit annotations are correctly set on create and update**
- **refactor: rename `WorkspaceKindRepository.Create` to `CreateWorkspaceKind`**