### PR TITLE
fix: align workspace path parameter name in OpenAPI annotations

### DIFF
--- a/workspaces/backend/api/workspace_actions_handler.go
+++ b/workspaces/backend/api/workspace_actions_handler.go
@@ -41,20 +41,20 @@ type WorkspaceActionPauseEnvelope Envelope[*models.WorkspaceActionPause]
 //	@ID				updateWorkspacePauseState
 //	@Accept			json
 //	@Produce		json
-//	@Param			namespace		path		string							true	"Namespace of the workspace"	extensions(x-example=default)
-//	@Param			workspaceName	path		string							true	"Name of the workspace"			extensions(x-example=my-workspace)
-//	@Param			body			body		WorkspaceActionPauseEnvelope	true	"Intended pause state of the workspace"
-//	@Success		200				{object}	WorkspaceActionPauseEnvelope	"Successful action. Returns the current pause state."
-//	@Failure		400				{object}	ErrorEnvelope					"Bad Request."
-//	@Failure		401				{object}	ErrorEnvelope					"Unauthorized. Authentication is required."
-//	@Failure		403				{object}	ErrorEnvelope					"Forbidden. User does not have permission to access the workspace."
-//	@Failure		404				{object}	ErrorEnvelope					"Not Found. Workspace does not exist."
-//	@Failure		409				{object}	ErrorEnvelope					"Conflict. Workspace not in valid state for action."
-//	@Failure		413				{object}	ErrorEnvelope					"Request Entity Too Large. The request body is too large."
-//	@Failure		415				{object}	ErrorEnvelope					"Unsupported Media Type. Content-Type header is not correct."
-//	@Failure		422				{object}	ErrorEnvelope					"Unprocessable Entity. Validation error."
-//	@Failure		500				{object}	ErrorEnvelope					"Internal server error. An unexpected error occurred on the server."
-//	@Router			/workspaces/{namespace}/{workspaceName}/actions/pause [post]
+//	@Param			namespace	path		string							true	"Namespace of the workspace"	extensions(x-example=default)
+//	@Param			name		path		string							true	"Name of the workspace"			extensions(x-example=my-workspace)
+//	@Param			body		body		WorkspaceActionPauseEnvelope	true	"Intended pause state of the workspace"
+//	@Success		200			{object}	WorkspaceActionPauseEnvelope	"Successful action. Returns the current pause state."
+//	@Failure		400			{object}	ErrorEnvelope					"Bad Request."
+//	@Failure		401			{object}	ErrorEnvelope					"Unauthorized. Authentication is required."
+//	@Failure		403			{object}	ErrorEnvelope					"Forbidden. User does not have permission to access the workspace."
+//	@Failure		404			{object}	ErrorEnvelope					"Not Found. Workspace does not exist."
+//	@Failure		409			{object}	ErrorEnvelope					"Conflict. Workspace not in valid state for action."
+//	@Failure		413			{object}	ErrorEnvelope					"Request Entity Too Large. The request body is too large."
+//	@Failure		415			{object}	ErrorEnvelope					"Unsupported Media Type. Content-Type header is not correct."
+//	@Failure		422			{object}	ErrorEnvelope					"Unprocessable Entity. Validation error."
+//	@Failure		500			{object}	ErrorEnvelope					"Internal server error. An unexpected error occurred on the server."
+//	@Router			/workspaces/{namespace}/{name}/actions/pause [post]
 func (a *App) PauseActionWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(NamespacePathParam)
 	workspaceName := ps.ByName(ResourceNamePathParam)

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -45,15 +45,15 @@ type WorkspaceListEnvelope Envelope[[]models.WorkspaceListItem]
 //	@ID				getWorkspace
 //	@Accept			json
 //	@Produce		json
-//	@Param			namespace		path		string				true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
-//	@Param			workspace_name	path		string				true	"Name of the workspace"			extensions(x-example=my-workspace)
-//	@Success		200				{object}	WorkspaceEnvelope	"Successful operation. Returns the requested workspace details with new revision."
-//	@Failure		401				{object}	ErrorEnvelope		"Unauthorized. Authentication is required."
-//	@Failure		403				{object}	ErrorEnvelope		"Forbidden. User does not have permission to access the workspace."
-//	@Failure		404				{object}	ErrorEnvelope		"Not Found. Workspace does not exist."
-//	@Failure		422				{object}	ErrorEnvelope		"Unprocessable Entity. Validation error."
-//	@Failure		500				{object}	ErrorEnvelope		"Internal server error. An unexpected error occurred on the server."
-//	@Router			/workspaces/{namespace}/{workspace_name} [get]
+//	@Param			namespace	path		string				true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
+//	@Param			name		path		string				true	"Name of the workspace"			extensions(x-example=my-workspace)
+//	@Success		200			{object}	WorkspaceEnvelope	"Successful operation. Returns the requested workspace details with new revision."
+//	@Failure		401			{object}	ErrorEnvelope		"Unauthorized. Authentication is required."
+//	@Failure		403			{object}	ErrorEnvelope		"Forbidden. User does not have permission to access the workspace."
+//	@Failure		404			{object}	ErrorEnvelope		"Not Found. Workspace does not exist."
+//	@Failure		422			{object}	ErrorEnvelope		"Unprocessable Entity. Validation error."
+//	@Failure		500			{object}	ErrorEnvelope		"Internal server error. An unexpected error occurred on the server."
+//	@Router			/workspaces/{namespace}/{name} [get]
 func (a *App) GetWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl // TODO: Abstract common API patterns once implemented
 	namespace := ps.ByName(NamespacePathParam)
 	workspaceName := ps.ByName(ResourceNamePathParam)
@@ -391,16 +391,16 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 //	@ID				deleteWorkspace
 //	@Accept			json
 //	@Produce		json
-//	@Param			namespace		path		string			true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
-//	@Param			workspace_name	path		string			true	"Name of the workspace"			extensions(x-example=my-workspace)
-//	@Success		204				{object}	nil				"Workspace deleted successfully"
-//	@Failure		401				{object}	ErrorEnvelope	"Unauthorized. Authentication is required."
-//	@Failure		403				{object}	ErrorEnvelope	"Forbidden. User does not have permission to delete the workspace."
-//	@Failure		404				{object}	ErrorEnvelope	"Not Found. Workspace does not exist."
-//	@Failure		409				{object}	ErrorEnvelope	"Conflict"
-//	@Failure		422				{object}	ErrorEnvelope	"Unprocessable Entity. Validation error."
-//	@Failure		500				{object}	ErrorEnvelope	"Internal server error. An unexpected error occurred on the server."
-//	@Router			/workspaces/{namespace}/{workspace_name} [delete]
+//	@Param			namespace	path		string			true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
+//	@Param			name		path		string			true	"Name of the workspace"			extensions(x-example=my-workspace)
+//	@Success		204			{object}	nil				"Workspace deleted successfully"
+//	@Failure		401			{object}	ErrorEnvelope	"Unauthorized. Authentication is required."
+//	@Failure		403			{object}	ErrorEnvelope	"Forbidden. User does not have permission to delete the workspace."
+//	@Failure		404			{object}	ErrorEnvelope	"Not Found. Workspace does not exist."
+//	@Failure		409			{object}	ErrorEnvelope	"Conflict"
+//	@Failure		422			{object}	ErrorEnvelope	"Unprocessable Entity. Validation error."
+//	@Failure		500			{object}	ErrorEnvelope	"Internal server error. An unexpected error occurred on the server."
+//	@Router			/workspaces/{namespace}/{name} [delete]
 func (a *App) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl
 	namespace := ps.ByName(NamespacePathParam)
 	workspaceName := ps.ByName(ResourceNamePathParam)

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -1580,7 +1580,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaces/{namespace}/{workspaceName}/actions/pause": {
+        "/workspaces/{namespace}/{name}/actions/pause": {
             "post": {
                 "description": "Pauses or unpauses a workspace, stopping or resuming all associated pods.",
                 "consumes": [
@@ -1607,7 +1607,7 @@ const docTemplate = `{
                         "type": "string",
                         "x-example": "my-workspace",
                         "description": "Name of the workspace",
-                        "name": "workspaceName",
+                        "name": "name",
                         "in": "path",
                         "required": true
                     },

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -1339,6 +1339,76 @@ const docTemplate = `{
             }
         },
         "/workspaces/{namespace}/{name}": {
+            "get": {
+                "description": "Returns the current state of a specific workspace identified by namespace and workspace name, including the revision for optimistic locking. This endpoint is intended for retrieving the workspace state before updating it.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Get workspace",
+                "operationId": "getWorkspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace of the workspace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "x-example": "my-workspace",
+                        "description": "Name of the workspace",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation. Returns the requested workspace details with new revision.",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkspaceEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to access the workspace.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found. Workspace does not exist.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error. An unexpected error occurred on the server.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
+            },
             "put": {
                 "description": "Updates an existing workspace.",
                 "consumes": [
@@ -1418,6 +1488,79 @@ const docTemplate = `{
                     },
                     "415": {
                         "description": "Unsupported Media Type. Content-Type header is not correct.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error. An unexpected error occurred on the server.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes a specific workspace identified by namespace and name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Delete workspace",
+                "operationId": "deleteWorkspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace of the workspace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "x-example": "my-workspace",
+                        "description": "Name of the workspace",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Workspace deleted successfully"
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to delete the workspace.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found. Workspace does not exist.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -1523,151 +1666,6 @@ const docTemplate = `{
                     },
                     "415": {
                         "description": "Unsupported Media Type. Content-Type header is not correct.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity. Validation error.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error. An unexpected error occurred on the server.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces/{namespace}/{workspace_name}": {
-            "get": {
-                "description": "Returns the current state of a specific workspace identified by namespace and workspace name, including the revision for optimistic locking. This endpoint is intended for retrieving the workspace state before updating it.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "workspaces"
-                ],
-                "summary": "Get workspace",
-                "operationId": "getWorkspace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "x-example": "kubeflow-user-example-com",
-                        "description": "Namespace of the workspace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "x-example": "my-workspace",
-                        "description": "Name of the workspace",
-                        "name": "workspace_name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation. Returns the requested workspace details with new revision.",
-                        "schema": {
-                            "$ref": "#/definitions/api.WorkspaceEnvelope"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized. Authentication is required.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden. User does not have permission to access the workspace.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. Workspace does not exist.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity. Validation error.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error. An unexpected error occurred on the server.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Deletes a specific workspace identified by namespace and name.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "workspaces"
-                ],
-                "summary": "Delete workspace",
-                "operationId": "deleteWorkspace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "x-example": "kubeflow-user-example-com",
-                        "description": "Namespace of the workspace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "x-example": "my-workspace",
-                        "description": "Name of the workspace",
-                        "name": "workspace_name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Workspace deleted successfully"
-                    },
-                    "401": {
-                        "description": "Unauthorized. Authentication is required.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden. User does not have permission to delete the workspace.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. Workspace does not exist.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -1578,7 +1578,7 @@
                 }
             }
         },
-        "/workspaces/{namespace}/{workspaceName}/actions/pause": {
+        "/workspaces/{namespace}/{name}/actions/pause": {
             "post": {
                 "description": "Pauses or unpauses a workspace, stopping or resuming all associated pods.",
                 "consumes": [
@@ -1605,7 +1605,7 @@
                         "type": "string",
                         "x-example": "my-workspace",
                         "description": "Name of the workspace",
-                        "name": "workspaceName",
+                        "name": "name",
                         "in": "path",
                         "required": true
                     },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -1337,6 +1337,76 @@
             }
         },
         "/workspaces/{namespace}/{name}": {
+            "get": {
+                "description": "Returns the current state of a specific workspace identified by namespace and workspace name, including the revision for optimistic locking. This endpoint is intended for retrieving the workspace state before updating it.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Get workspace",
+                "operationId": "getWorkspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace of the workspace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "x-example": "my-workspace",
+                        "description": "Name of the workspace",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation. Returns the requested workspace details with new revision.",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkspaceEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to access the workspace.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found. Workspace does not exist.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error. An unexpected error occurred on the server.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
+            },
             "put": {
                 "description": "Updates an existing workspace.",
                 "consumes": [
@@ -1416,6 +1486,79 @@
                     },
                     "415": {
                         "description": "Unsupported Media Type. Content-Type header is not correct.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error. An unexpected error occurred on the server.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes a specific workspace identified by namespace and name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Delete workspace",
+                "operationId": "deleteWorkspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace of the workspace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "x-example": "my-workspace",
+                        "description": "Name of the workspace",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Workspace deleted successfully"
+                    },
+                    "401": {
+                        "description": "Unauthorized. Authentication is required.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden. User does not have permission to delete the workspace.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found. Workspace does not exist.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -1521,151 +1664,6 @@
                     },
                     "415": {
                         "description": "Unsupported Media Type. Content-Type header is not correct.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity. Validation error.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error. An unexpected error occurred on the server.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces/{namespace}/{workspace_name}": {
-            "get": {
-                "description": "Returns the current state of a specific workspace identified by namespace and workspace name, including the revision for optimistic locking. This endpoint is intended for retrieving the workspace state before updating it.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "workspaces"
-                ],
-                "summary": "Get workspace",
-                "operationId": "getWorkspace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "x-example": "kubeflow-user-example-com",
-                        "description": "Namespace of the workspace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "x-example": "my-workspace",
-                        "description": "Name of the workspace",
-                        "name": "workspace_name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation. Returns the requested workspace details with new revision.",
-                        "schema": {
-                            "$ref": "#/definitions/api.WorkspaceEnvelope"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized. Authentication is required.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden. User does not have permission to access the workspace.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. Workspace does not exist.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity. Validation error.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error. An unexpected error occurred on the server.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Deletes a specific workspace identified by namespace and name.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "workspaces"
-                ],
-                "summary": "Delete workspace",
-                "operationId": "deleteWorkspace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "x-example": "kubeflow-user-example-com",
-                        "description": "Namespace of the workspace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "x-example": "my-workspace",
-                        "description": "Name of the workspace",
-                        "name": "workspace_name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Workspace deleted successfully"
-                    },
-                    "401": {
-                        "description": "Unauthorized. Authentication is required.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden. User does not have permission to delete the workspace.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. Workspace does not exist.",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorEnvelope"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }


### PR DESCRIPTION
`GetWorkspaceHandler` and `DeleteWorkspaceHandler` used `{workspace_name}` in their Swag `@Param`/`@Router` annotations while `UpdateWorkspaceHandler` used `{name}`, matching `ResourceNamePathParam`. This caused swagger to emit two separate path entries for the same route template, which OpenAPI linters flag as "Equivalent paths are not allowed".

Align all three handlers to `{name}` and regenerate the spec.

Link: https://editor.swagger.io?url=https://raw.githubusercontent.com/kubeflow/notebooks/e091ea3a398e008e988056c2d5ac6da07bc04719/workspaces/backend/openapi/swagger.json

I have noticed this issue while reviewing https://github.com/kubeflow/notebooks/pull/1081.

It can also be reproduced on the commandline with spectral or vacuum:
```
$ npx @stoplight/spectral-cli lint workspaces/backend/openapi/swagger.json
 1543:52    error  path-params            Paths "/workspaces/{namespace}/{name}" and "/workspaces/{namespace}/{workspace_name}" must not be equivalent.  paths./workspaces/{namespace}/{workspace_name}
```

## [vacuum](https://quobix.com/vacuum/) OpenAPI quality report

### `Operations` violations
<details><summary>🔴 Errors: 1</summary>
🔴 no-ambiguous-paths : 1

| location | JSONPath                                            |
| -------- | --------------------------------------------------- |
| `1543:9` | $.paths['/workspaces/{namespace}/{workspace_name}'] |

</details>

<details><summary>⚠ Warnings: 1</summary>
⚠ no-http-verbs-in-path: 1

| location  | JSONPath                                                         |
| --------- | ---------------------------------------------------------------- |
| `1059:66` | $.paths['/workspacekinds/{name}/podtemplate/options/listvalues'] |

</details>

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
