### PR TITLE
fix: return HTTP 422 with field-level errors for JSON type mismatches

### DIFF
--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -24,7 +24,10 @@ import (
 	"maps"
 	"mime"
 	"net/http"
+	"reflect"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 )
@@ -81,6 +84,11 @@ func (a *App) DecodeJSON(r *http.Request, v any) error {
 			return err
 		}
 
+		// NOTE: we don't wrap this error so we can unpack it in the caller
+		if a.IsUnmarshalTypeError(err) {
+			return err
+		}
+
 		// provide better error message for the case where the body is empty
 		// NOTE: io.EOF is only returned when the body is completely empty or contains only whitespace.
 		//       If there's any actual JSON content (even malformed), json.Decoder returns different errors.
@@ -104,6 +112,72 @@ func (a *App) IsMaxBytesError(err error) bool {
 // - The body stream ends immediately without any data (io.EOF)
 func (a *App) IsEOFError(err error) bool {
 	return errors.Is(err, io.EOF)
+}
+
+// IsUnmarshalTypeError checks if the error is an instance of json.UnmarshalTypeError.
+func (a *App) IsUnmarshalTypeError(err error) bool {
+	var unmarshalTypeError *json.UnmarshalTypeError
+	return errors.As(err, &unmarshalTypeError)
+}
+
+// FieldErrorsFromUnmarshalTypeError converts a json.UnmarshalTypeError into a field.ErrorList
+// with a single entry describing the type mismatch using user-friendly type names.
+func FieldErrorsFromUnmarshalTypeError(err error) field.ErrorList {
+	var unmarshalTypeError *json.UnmarshalTypeError
+	if !errors.As(err, &unmarshalTypeError) {
+		return nil
+	}
+
+	expectedType := goTypeToJSONTypeName(unmarshalTypeError.Type)
+	detail := fmt.Sprintf("got JSON %s, but field requires %s", unmarshalTypeError.Value, expectedType)
+
+	if unmarshalTypeError.Field == "" {
+		return field.ErrorList{
+			{Type: field.ErrorTypeTypeInvalid, BadValue: unmarshalTypeError.Value, Detail: detail},
+		}
+	}
+
+	fieldPath := fieldPathFromJSONPath(unmarshalTypeError.Field)
+	return field.ErrorList{
+		field.TypeInvalid(fieldPath, unmarshalTypeError.Value, detail),
+	}
+}
+
+// fieldPathFromJSONPath converts a dot-separated JSON field path (e.g., "data.podTemplate.paused")
+// into a field.Path.
+func fieldPathFromJSONPath(jsonPath string) *field.Path {
+	parts := strings.Split(jsonPath, ".")
+	path := field.NewPath(parts[0])
+	for _, part := range parts[1:] {
+		path = path.Child(part)
+	}
+	return path
+}
+
+// goTypeToJSONTypeName maps a Go reflect.Type to a user-friendly JSON type name.
+func goTypeToJSONTypeName(t reflect.Type) string {
+	if t == nil {
+		return "unknown"
+	}
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	switch t.Kind() { //nolint:exhaustive
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.String:
+		return "string"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	case reflect.Map, reflect.Struct:
+		return "object"
+	default:
+		return t.String()
+	}
 }
 
 // ValidateContentType validates the Content-Type header of the request.

--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -131,6 +131,9 @@ func FieldErrorsFromUnmarshalTypeError(err error) field.ErrorList {
 	expectedType := goTypeToJSONTypeName(unmarshalTypeError.Type)
 	detail := fmt.Sprintf("got JSON %s, but field requires %s", unmarshalTypeError.Value, expectedType)
 
+	// Field is empty when the type mismatch occurs at the top level of the JSON
+	// (e.g., decoding `"hello"` into a struct), because the stdlib only populates
+	// Field when the decoder has an active struct field context.
 	if unmarshalTypeError.Field == "" {
 		return field.ErrorList{
 			{Type: field.ErrorTypeTypeInvalid, BadValue: unmarshalTypeError.Value, Detail: detail},
@@ -144,35 +147,46 @@ func FieldErrorsFromUnmarshalTypeError(err error) field.ErrorList {
 	}
 }
 
+const (
+	jsonTypeUnknown = "unknown"
+	jsonTypeBoolean = "boolean"
+	jsonTypeNumber  = "number"
+	jsonTypeString  = "string"
+	jsonTypeArray   = "array"
+	jsonTypeObject  = "object"
+)
+
 // goTypeToJSONTypeName maps a Go reflect.Type to a user-friendly JSON type name.
 func goTypeToJSONTypeName(t reflect.Type) string {
-	if t == nil {
-		return "unknown"
+	var kind reflect.Kind
+	if t != nil {
+		kind = t.Kind()
 	}
-	// Keep calling .Elem() to peel off pointer indirections until we reach the underlying concrete type, i.e. **int -> *int -> int.
-	for t.Kind() == reflect.Ptr {
-		next := t.Elem()
-		// guard against self-referential pointer types (e.g., `type A *A`) which would loop infinitely.
-		// this should never occur in practice because json.UnmarshalTypeError.Type is populated by the stdlib JSON decoder,
-		// which rejects self-referential pointer types.
-		if next == t {
-			break
-		}
-		t = next
+
+	// guard against self-referential pointer types (e.g., `type A *A`) which would loop infinitely.
+	// this should never occur in practice because json.UnmarshalTypeError.Type is populated by the
+	// stdlib JSON decoder, which rejects self-referential pointer types.
+	if kind == reflect.Ptr && t.Elem() == t {
+		panic(fmt.Sprintf("goTypeToJSONTypeName: self-referential pointer type: %s", t))
 	}
-	switch t.Kind() { //nolint:exhaustive
+
+	switch kind { //nolint:exhaustive
+	case reflect.Invalid:
+		return jsonTypeUnknown
+	case reflect.Ptr:
+		return goTypeToJSONTypeName(t.Elem())
 	case reflect.Bool:
-		return "boolean"
+		return jsonTypeBoolean
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 		reflect.Float32, reflect.Float64:
-		return "number"
+		return jsonTypeNumber
 	case reflect.String:
-		return "string"
+		return jsonTypeString
 	case reflect.Slice, reflect.Array:
-		return "array"
+		return jsonTypeArray
 	case reflect.Map, reflect.Struct:
-		return "object"
+		return jsonTypeObject
 	default:
 		return t.String()
 	}

--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -137,21 +137,11 @@ func FieldErrorsFromUnmarshalTypeError(err error) field.ErrorList {
 		}
 	}
 
-	fieldPath := fieldPathFromJSONPath(unmarshalTypeError.Field)
+	parts := strings.Split(unmarshalTypeError.Field, ".")
+	fieldPath := field.NewPath(parts[0], parts[1:]...)
 	return field.ErrorList{
 		field.TypeInvalid(fieldPath, unmarshalTypeError.Value, detail),
 	}
-}
-
-// fieldPathFromJSONPath converts a dot-separated JSON field path (e.g., "data.podTemplate.paused")
-// into a field.Path.
-func fieldPathFromJSONPath(jsonPath string) *field.Path {
-	parts := strings.Split(jsonPath, ".")
-	path := field.NewPath(parts[0])
-	for _, part := range parts[1:] {
-		path = path.Child(part)
-	}
-	return path
 }
 
 // goTypeToJSONTypeName maps a Go reflect.Type to a user-friendly JSON type name.
@@ -159,8 +149,16 @@ func goTypeToJSONTypeName(t reflect.Type) string {
 	if t == nil {
 		return "unknown"
 	}
+	// Keep calling .Elem() to peel off pointer indirections until we reach the underlying concrete type, i.e. **int -> *int -> int.
 	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
+		next := t.Elem()
+		// guard against self-referential pointer types (e.g., `type A *A`) which would loop infinitely.
+		// this should never occur in practice because json.UnmarshalTypeError.Type is populated by the stdlib JSON decoder,
+		// which rejects self-referential pointer types.
+		if next == t {
+			break
+		}
+		t = next
 	}
 	switch t.Kind() { //nolint:exhaustive
 	case reflect.Bool:

--- a/workspaces/backend/api/helpers_test.go
+++ b/workspaces/backend/api/helpers_test.go
@@ -152,21 +152,4 @@ var _ = Describe("Helper Functions", func() {
 		})
 	})
 
-	Describe("fieldPathFromJSONPath", func() {
-
-		It("should convert a dot-separated path", func() {
-			path := fieldPathFromJSONPath("data.paused")
-			Expect(path.String()).To(Equal("data.paused"))
-		})
-
-		It("should handle a single-segment path", func() {
-			path := fieldPathFromJSONPath("name")
-			Expect(path.String()).To(Equal("name"))
-		})
-
-		It("should handle a deeply nested path", func() {
-			path := fieldPathFromJSONPath("data.podTemplate.options.imageConfig")
-			Expect(path.String()).To(Equal("data.podTemplate.options.imageConfig"))
-		})
-	})
 })

--- a/workspaces/backend/api/helpers_test.go
+++ b/workspaces/backend/api/helpers_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var _ = Describe("Helper Functions", func() {
+
+	Describe("IsUnmarshalTypeError", func() {
+		app := &App{}
+
+		DescribeTable("should correctly identify UnmarshalTypeError",
+			func(err error, expected bool) {
+				Expect(app.IsUnmarshalTypeError(err)).To(Equal(expected))
+			},
+			Entry("direct UnmarshalTypeError",
+				&json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(true), Field: "data.paused"}, true),
+			Entry("wrapped UnmarshalTypeError",
+				fmt.Errorf("some wrapper: %w", &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(true), Field: "data.paused"}), true),
+			Entry("generic error",
+				fmt.Errorf("some generic error"), false),
+			Entry("MaxBytesError",
+				&http.MaxBytesError{Limit: 1024}, false),
+		)
+	})
+
+	Describe("FieldErrorsFromUnmarshalTypeError", func() {
+
+		type testCase struct {
+			description string
+			err         error
+			expected    field.ErrorList
+		}
+
+		testCases := []testCase{
+			{
+				description: "should return nil for a non-UnmarshalTypeError",
+				err:         fmt.Errorf("some generic error"),
+				expected:    nil,
+			},
+			{
+				description: "should convert string-for-bool type mismatch",
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(true), Field: "data.paused"},
+				expected: field.ErrorList{
+					field.TypeInvalid(field.NewPath("data").Child("paused"), "string", "got JSON string, but field requires boolean"),
+				},
+			},
+			{
+				description: "should convert number-for-string type mismatch",
+				err:         &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Field: "data.name"},
+				expected: field.ErrorList{
+					field.TypeInvalid(field.NewPath("data").Child("name"), "number", "got JSON number, but field requires string"),
+				},
+			},
+			{
+				description: "should convert string-for-array type mismatch",
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf([]string{}), Field: "data.accessModes"},
+				expected: field.ErrorList{
+					field.TypeInvalid(field.NewPath("data").Child("accessModes"), "string", "got JSON string, but field requires array"),
+				},
+			},
+			{
+				description: "should convert string-for-object type mismatch",
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(map[string]string{}), Field: "data.contents"},
+				expected: field.ErrorList{
+					field.TypeInvalid(field.NewPath("data").Child("contents"), "string", "got JSON string, but field requires object"),
+				},
+			},
+			{
+				description: "should handle empty field path (top-level type mismatch)",
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(struct{}{}), Field: ""},
+				expected: field.ErrorList{
+					{Type: field.ErrorTypeTypeInvalid, BadValue: "string", Detail: "got JSON string, but field requires object"},
+				},
+			},
+			{
+				description: "should handle pointer types by dereferencing",
+				err:         &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf((*bool)(nil)), Field: "data.paused"},
+				expected: field.ErrorList{
+					field.TypeInvalid(field.NewPath("data").Child("paused"), "number", "got JSON number, but field requires boolean"),
+				},
+			},
+			{
+				description: "should handle deeply nested field paths",
+				err:         &json.UnmarshalTypeError{Value: "bool", Type: reflect.TypeOf(""), Field: "data.podTemplate.options.imageConfig"},
+				expected: field.ErrorList{
+					field.TypeInvalid(field.NewPath("data").Child("podTemplate").Child("options").Child("imageConfig"), "bool", "got JSON bool, but field requires string"),
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			It(tc.description, func() {
+				result := FieldErrorsFromUnmarshalTypeError(tc.err)
+				if tc.expected == nil {
+					Expect(result).To(BeNil())
+				} else {
+					Expect(result).To(ConsistOf(tc.expected))
+				}
+			})
+		}
+	})
+
+	Describe("goTypeToJSONTypeName", func() {
+
+		DescribeTable("should map Go types to JSON type names",
+			func(goType reflect.Type, expectedName string) {
+				Expect(goTypeToJSONTypeName(goType)).To(Equal(expectedName))
+			},
+			Entry("bool", reflect.TypeOf(true), "boolean"),
+			Entry("int", reflect.TypeOf(0), "number"),
+			Entry("int32", reflect.TypeOf(int32(0)), "number"),
+			Entry("int64", reflect.TypeOf(int64(0)), "number"),
+			Entry("float32", reflect.TypeOf(float32(0)), "number"),
+			Entry("float64", reflect.TypeOf(float64(0)), "number"),
+			Entry("uint", reflect.TypeOf(uint(0)), "number"),
+			Entry("string", reflect.TypeOf(""), "string"),
+			Entry("slice", reflect.TypeOf([]string{}), "array"),
+			Entry("array", reflect.TypeOf([3]int{}), "array"),
+			Entry("map", reflect.TypeOf(map[string]string{}), "object"),
+			Entry("struct", reflect.TypeOf(struct{}{}), "object"),
+			Entry("pointer to bool", reflect.TypeOf((*bool)(nil)), "boolean"),
+			Entry("pointer to string", reflect.TypeOf((*string)(nil)), "string"),
+			Entry("pointer to struct", reflect.TypeOf((*struct{})(nil)), "object"),
+		)
+
+		It("should return 'unknown' for nil type", func() {
+			Expect(goTypeToJSONTypeName(nil)).To(Equal("unknown"))
+		})
+	})
+
+	Describe("fieldPathFromJSONPath", func() {
+
+		It("should convert a dot-separated path", func() {
+			path := fieldPathFromJSONPath("data.paused")
+			Expect(path.String()).To(Equal("data.paused"))
+		})
+
+		It("should handle a single-segment path", func() {
+			path := fieldPathFromJSONPath("name")
+			Expect(path.String()).To(Equal("name"))
+		})
+
+		It("should handle a deeply nested path", func() {
+			path := fieldPathFromJSONPath("data.podTemplate.options.imageConfig")
+			Expect(path.String()).To(Equal("data.podTemplate.options.imageConfig"))
+		})
+	})
+})

--- a/workspaces/backend/api/helpers_test.go
+++ b/workspaces/backend/api/helpers_test.go
@@ -20,7 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,9 +39,9 @@ var _ = Describe("Helper Functions", func() {
 				Expect(app.IsUnmarshalTypeError(err)).To(Equal(expected))
 			},
 			Entry("direct UnmarshalTypeError",
-				&json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(true), Field: "data.paused"}, true),
+				&json.UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[bool](), Field: "data.paused"}, true),
 			Entry("wrapped UnmarshalTypeError",
-				fmt.Errorf("some wrapper: %w", &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(true), Field: "data.paused"}), true),
+				fmt.Errorf("some wrapper: %w", &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[bool](), Field: "data.paused"}), true),
 			Entry("generic error",
 				fmt.Errorf("some generic error"), false),
 			Entry("MaxBytesError",
@@ -63,49 +65,49 @@ var _ = Describe("Helper Functions", func() {
 			},
 			{
 				description: "should convert string-for-bool type mismatch",
-				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(true), Field: "data.paused"},
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[bool](), Field: "data.paused"},
 				expected: field.ErrorList{
 					field.TypeInvalid(field.NewPath("data").Child("paused"), "string", "got JSON string, but field requires boolean"),
 				},
 			},
 			{
 				description: "should convert number-for-string type mismatch",
-				err:         &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Field: "data.name"},
+				err:         &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Field: "data.name"},
 				expected: field.ErrorList{
 					field.TypeInvalid(field.NewPath("data").Child("name"), "number", "got JSON number, but field requires string"),
 				},
 			},
 			{
 				description: "should convert string-for-array type mismatch",
-				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf([]string{}), Field: "data.accessModes"},
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[[]string](), Field: "data.accessModes"},
 				expected: field.ErrorList{
 					field.TypeInvalid(field.NewPath("data").Child("accessModes"), "string", "got JSON string, but field requires array"),
 				},
 			},
 			{
 				description: "should convert string-for-object type mismatch",
-				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(map[string]string{}), Field: "data.contents"},
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[map[string]string](), Field: "data.contents"},
 				expected: field.ErrorList{
 					field.TypeInvalid(field.NewPath("data").Child("contents"), "string", "got JSON string, but field requires object"),
 				},
 			},
 			{
 				description: "should handle empty field path (top-level type mismatch)",
-				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeOf(struct{}{}), Field: ""},
+				err:         &json.UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[struct{}](), Field: ""},
 				expected: field.ErrorList{
 					{Type: field.ErrorTypeTypeInvalid, BadValue: "string", Detail: "got JSON string, but field requires object"},
 				},
 			},
 			{
 				description: "should handle pointer types by dereferencing",
-				err:         &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf((*bool)(nil)), Field: "data.paused"},
+				err:         &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[*bool](), Field: "data.paused"},
 				expected: field.ErrorList{
 					field.TypeInvalid(field.NewPath("data").Child("paused"), "number", "got JSON number, but field requires boolean"),
 				},
 			},
 			{
 				description: "should handle deeply nested field paths",
-				err:         &json.UnmarshalTypeError{Value: "bool", Type: reflect.TypeOf(""), Field: "data.podTemplate.options.imageConfig"},
+				err:         &json.UnmarshalTypeError{Value: "bool", Type: reflect.TypeFor[string](), Field: "data.podTemplate.options.imageConfig"},
 				expected: field.ErrorList{
 					field.TypeInvalid(field.NewPath("data").Child("podTemplate").Child("options").Child("imageConfig"), "bool", "got JSON bool, but field requires string"),
 				},
@@ -124,32 +126,116 @@ var _ = Describe("Helper Functions", func() {
 		}
 	})
 
+	Describe("DecodeJSON", func() {
+		type testTarget struct {
+			Name   string `json:"name"`
+			Paused bool   `json:"paused"`
+		}
+
+		type testCase struct {
+			description      string
+			body             string
+			maxBytes         int64
+			errorTypeCheckFn func(*App, error) bool
+			errorSubstring   string
+		}
+
+		testCases := []testCase{
+			{
+				description: "should return nil for valid JSON",
+				body:        `{"name": "test", "paused": true}`,
+			},
+			{
+				description:      "should return an UnmarshalTypeError for type mismatches",
+				body:             `{"name": "test", "paused": "not-a-bool"}`,
+				errorTypeCheckFn: (*App).IsUnmarshalTypeError,
+			},
+			{
+				description:      "should return a MaxBytesError when the body exceeds the size limit",
+				body:             `{"name": "test", "paused": true}`,
+				maxBytes:         5,
+				errorTypeCheckFn: (*App).IsMaxBytesError,
+			},
+			{
+				description:      "should return a wrapped EOF error for an empty body",
+				body:             "",
+				errorTypeCheckFn: (*App).IsEOFError,
+				errorSubstring:   "request body was empty",
+			},
+			{
+				description:    "should return a wrapped error for malformed JSON",
+				body:           `{not valid json}`,
+				errorSubstring: "error decoding JSON",
+			},
+			{
+				// NOTE: Go's json.Decoder returns a plain *errors.errorString for unknown fields
+				// (not a typed error like *json.UnmarshalTypeError), so callers cannot use errors.As
+				// to detect this case — only string matching works.
+				// See: https://github.com/golang/go/blob/master/src/encoding/json/decode.go
+				description:    "should return a plain error for unknown JSON fields (not a typed error)",
+				body:           `{"name": "test", "paused": true, "extraField": "surprise"}`,
+				errorSubstring: "json: unknown field",
+			},
+		}
+
+		for _, tc := range testCases {
+			It(tc.description, func() {
+				app := &App{}
+				r := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(tc.body))
+				if tc.maxBytes > 0 {
+					r.Body = http.MaxBytesReader(nil, r.Body, tc.maxBytes)
+				}
+
+				var target testTarget
+				err := app.DecodeJSON(r, &target)
+
+				if tc.errorTypeCheckFn == nil && tc.errorSubstring == "" {
+					Expect(err).NotTo(HaveOccurred())
+					return
+				}
+
+				Expect(err).To(HaveOccurred())
+				if tc.errorTypeCheckFn != nil {
+					Expect(tc.errorTypeCheckFn(app, err)).To(BeTrue())
+				}
+				if tc.errorSubstring != "" {
+					Expect(err.Error()).To(ContainSubstring(tc.errorSubstring))
+				}
+			})
+		}
+	})
+
 	Describe("goTypeToJSONTypeName", func() {
 
+		type selfRef *selfRef
+
 		DescribeTable("should map Go types to JSON type names",
-			func(goType reflect.Type, expectedName string) {
+			func(goType reflect.Type, expectPanic bool, expectedName string) {
+				if expectPanic {
+					Expect(func() { goTypeToJSONTypeName(goType) }).To(Panic())
+					return
+				}
 				Expect(goTypeToJSONTypeName(goType)).To(Equal(expectedName))
 			},
-			Entry("bool", reflect.TypeOf(true), "boolean"),
-			Entry("int", reflect.TypeOf(0), "number"),
-			Entry("int32", reflect.TypeOf(int32(0)), "number"),
-			Entry("int64", reflect.TypeOf(int64(0)), "number"),
-			Entry("float32", reflect.TypeOf(float32(0)), "number"),
-			Entry("float64", reflect.TypeOf(float64(0)), "number"),
-			Entry("uint", reflect.TypeOf(uint(0)), "number"),
-			Entry("string", reflect.TypeOf(""), "string"),
-			Entry("slice", reflect.TypeOf([]string{}), "array"),
-			Entry("array", reflect.TypeOf([3]int{}), "array"),
-			Entry("map", reflect.TypeOf(map[string]string{}), "object"),
-			Entry("struct", reflect.TypeOf(struct{}{}), "object"),
-			Entry("pointer to bool", reflect.TypeOf((*bool)(nil)), "boolean"),
-			Entry("pointer to string", reflect.TypeOf((*string)(nil)), "string"),
-			Entry("pointer to struct", reflect.TypeOf((*struct{})(nil)), "object"),
+			Entry("bool", reflect.TypeFor[bool](), false, jsonTypeBoolean),
+			Entry("int", reflect.TypeFor[int](), false, jsonTypeNumber),
+			Entry("int32", reflect.TypeFor[int32](), false, jsonTypeNumber),
+			Entry("int64", reflect.TypeFor[int64](), false, jsonTypeNumber),
+			Entry("float32", reflect.TypeFor[float32](), false, jsonTypeNumber),
+			Entry("float64", reflect.TypeFor[float64](), false, jsonTypeNumber),
+			Entry("uint", reflect.TypeFor[uint](), false, jsonTypeNumber),
+			Entry("string", reflect.TypeFor[string](), false, jsonTypeString),
+			Entry("slice", reflect.TypeFor[[]string](), false, jsonTypeArray),
+			Entry("array", reflect.TypeFor[[3]int](), false, jsonTypeArray),
+			Entry("map", reflect.TypeFor[map[string]string](), false, jsonTypeObject),
+			Entry("struct", reflect.TypeFor[struct{}](), false, jsonTypeObject),
+			Entry("pointer to bool", reflect.TypeFor[*bool](), false, jsonTypeBoolean),
+			Entry("pointer to string", reflect.TypeFor[*string](), false, jsonTypeString),
+			Entry("pointer to struct", reflect.TypeFor[*struct{}](), false, jsonTypeObject),
+			Entry("nil type", nil, false, jsonTypeUnknown),
+			Entry("unmapped kind falls back to Type.String()", reflect.TypeFor[chan int](), false, "chan int"),
+			Entry("self-referential pointer type panics", reflect.TypeFor[selfRef](), true, ""),
 		)
-
-		It("should return 'unknown' for nil type", func() {
-			Expect(goTypeToJSONTypeName(nil)).To(Equal("unknown"))
-		})
 	})
 
 })

--- a/workspaces/backend/api/pvcs_handler.go
+++ b/workspaces/backend/api/pvcs_handler.go
@@ -124,11 +124,11 @@ func (a *App) CreatePVCHandler(w http.ResponseWriter, r *http.Request, ps httpro
 			return
 		}
 
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}

--- a/workspaces/backend/api/response_errors_test.go
+++ b/workspaces/backend/api/response_errors_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -270,6 +271,68 @@ var _ = Describe("Error Response Functions", func() {
 
 				expectedErrorResponse := buildExpectedValidationResponse(tc.msg, tc.valErrs, tc.k8sCauses, httpStatusCodeUnprocessableEntityStr)
 				Expect(envelope.Error.ErrorResponse).To(Equal(expectedErrorResponse))
+			})
+		}
+	})
+
+	Describe("failedValidationResponse with UnmarshalTypeError field errors", func() {
+		var httpStatusCodeUnprocessableEntityStr = strconv.Itoa(http.StatusUnprocessableEntity)
+
+		type testCase struct {
+			description             string
+			unmarshalErr            *json.UnmarshalTypeError
+			expectedValidationError ValidationError
+		}
+
+		testCases := []testCase{
+			{
+				description: "should return 422 with correct structure for a type mismatch error",
+				unmarshalErr: &json.UnmarshalTypeError{
+					Value: "string",
+					Type:  reflect.TypeOf(true),
+					Field: "data.paused",
+				},
+				expectedValidationError: ValidationError{
+					Origin:  OriginInternal,
+					Type:    field.ErrorTypeTypeInvalid,
+					Field:   "data.paused",
+					Message: `Invalid value: "string": got JSON string, but field requires boolean`,
+				},
+			},
+			{
+				description: "should return 422 with correct structure for a number-to-string mismatch",
+				unmarshalErr: &json.UnmarshalTypeError{
+					Value: "number",
+					Type:  reflect.TypeOf(""),
+					Field: "data.name",
+				},
+				expectedValidationError: ValidationError{
+					Origin:  OriginInternal,
+					Type:    field.ErrorTypeTypeInvalid,
+					Field:   "data.name",
+					Message: `Invalid value: "number": got JSON number, but field requires string`,
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			It(tc.description, func() {
+				fieldErrs := FieldErrorsFromUnmarshalTypeError(tc.unmarshalErr)
+				app.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+
+				Expect(w.Code).To(Equal(http.StatusUnprocessableEntity))
+
+				var envelope ErrorEnvelope
+				err := json.Unmarshal(w.Body.Bytes(), &envelope)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envelope.Error).NotTo(BeNil())
+				Expect(envelope.Error.ErrorResponse).To(Equal(ErrorResponse{
+					Code:    httpStatusCodeUnprocessableEntityStr,
+					Message: errMsgRequestBodyInvalid,
+					Cause: &ErrorCause{
+						ValidationErrors: []ValidationError{tc.expectedValidationError},
+					},
+				}))
 			})
 		}
 	})

--- a/workspaces/backend/api/response_errors_test.go
+++ b/workspaces/backend/api/response_errors_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Error Response Functions", func() {
 				description: "should return 422 with correct structure for a type mismatch error",
 				unmarshalErr: &json.UnmarshalTypeError{
 					Value: "string",
-					Type:  reflect.TypeOf(true),
+					Type:  reflect.TypeFor[bool](),
 					Field: "data.paused",
 				},
 				expectedValidationError: ValidationError{
@@ -303,7 +303,7 @@ var _ = Describe("Error Response Functions", func() {
 				description: "should return 422 with correct structure for a number-to-string mismatch",
 				unmarshalErr: &json.UnmarshalTypeError{
 					Value: "number",
-					Type:  reflect.TypeOf(""),
+					Type:  reflect.TypeFor[string](),
 					Field: "data.name",
 				},
 				expectedValidationError: ValidationError{

--- a/workspaces/backend/api/secrets_handler.go
+++ b/workspaces/backend/api/secrets_handler.go
@@ -176,12 +176,11 @@ func (a *App) CreateSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}
@@ -295,12 +294,11 @@ func (a *App) UpdateSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}

--- a/workspaces/backend/api/secrets_handler_test.go
+++ b/workspaces/backend/api/secrets_handler_test.go
@@ -32,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
@@ -651,6 +652,50 @@ var _ = Describe("Secrets Handler", func() {
 
 			By("verifying the HTTP response status code")
 			Expect(rs.StatusCode).To(Equal(http.StatusConflict), descUnexpectedHTTPStatus, rr.Body.String())
+		})
+
+		It("should return 422 when name field has wrong type", func() {
+			By("creating a request body with a number where string is expected")
+			bodyStr := `{"data":{"name":123,"type":"Opaque","immutable":false,"contents":{}}}`
+
+			By("creating the HTTP request")
+			req, err := http.NewRequest(http.MethodPost, "/api/v1/secrets/"+namespaceName1, bytes.NewBufferString(bodyStr))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing CreateSecretHandler")
+			ps := httprouter.Params{
+				{Key: constants.NamespacePathParam, Value: namespaceName1},
+			}
+			rr := httptest.NewRecorder()
+			a.CreateSecretHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code is 422")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error response structure")
+			var response ErrorEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.Error).NotTo(BeNil())
+			Expect(response.Error.Cause).NotTo(BeNil())
+			Expect(response.Error.Cause.ValidationErrors).To(ConsistOf(
+				ValidationError{
+					Origin:  OriginInternal,
+					Type:    field.ErrorTypeTypeInvalid,
+					Field:   "data.name",
+					Message: `Invalid value: "number": got JSON number, but field requires string`,
+				},
+			))
 		})
 
 		It("should return 422 for missing name", func() {

--- a/workspaces/backend/api/workspace_actions_handler.go
+++ b/workspaces/backend/api/workspace_actions_handler.go
@@ -79,12 +79,11 @@ func (a *App) PauseActionWorkspaceHandler(w http.ResponseWriter, r *http.Request
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}

--- a/workspaces/backend/api/workspace_actions_handler_test.go
+++ b/workspaces/backend/api/workspace_actions_handler_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
@@ -428,6 +429,101 @@ var _ = Describe("Workspace Actions Handler", func() {
 
 			By("verifying the HTTP response status code is 415")
 			Expect(rs.StatusCode).To(Equal(http.StatusUnsupportedMediaType), descUnexpectedHTTPStatus, rr.Body.String())
+		})
+
+		It("should return 422 when request body has wrong type for field", func() {
+			By("creating a request body with a string where bool is expected")
+			bodyStr := `{"data":{"paused":"yes"}}`
+
+			By("creating the HTTP request")
+			path := strings.Replace(constants.PauseWorkspacePath, ":"+constants.NamespacePathParam, namespaceName1, 1)
+			path = strings.Replace(path, ":"+constants.ResourceNamePathParam, workspaceName1, 1)
+			req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(bodyStr))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+			req.Header.Set("Content-Type", "application/json")
+
+			By("executing PauseActionWorkspaceHandler")
+			ps := httprouter.Params{
+				httprouter.Param{Key: constants.NamespacePathParam, Value: namespaceName1},
+				httprouter.Param{Key: constants.ResourceNamePathParam, Value: workspaceName1},
+			}
+			rr := httptest.NewRecorder()
+			a.PauseActionWorkspaceHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code is 422")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error response structure")
+			var response ErrorEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.Error).NotTo(BeNil())
+			Expect(response.Error.Message).To(Equal(errMsgRequestBodyInvalid))
+			Expect(response.Error.Cause).NotTo(BeNil())
+			Expect(response.Error.Cause.ValidationErrors).To(ConsistOf(
+				ValidationError{
+					Origin:  OriginInternal,
+					Type:    field.ErrorTypeTypeInvalid,
+					Field:   "data.paused",
+					Message: `Invalid value: "string": got JSON string, but field requires boolean`,
+				},
+			))
+		})
+
+		It("should return 422 when data field has wrong type", func() {
+			By("creating a request body with a string where object is expected")
+			bodyStr := `{"data":"not-an-object"}`
+
+			By("creating the HTTP request")
+			path := strings.Replace(constants.PauseWorkspacePath, ":"+constants.NamespacePathParam, namespaceName1, 1)
+			path = strings.Replace(path, ":"+constants.ResourceNamePathParam, workspaceName1, 1)
+			req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(bodyStr))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+			req.Header.Set("Content-Type", "application/json")
+
+			By("executing PauseActionWorkspaceHandler")
+			ps := httprouter.Params{
+				httprouter.Param{Key: constants.NamespacePathParam, Value: namespaceName1},
+				httprouter.Param{Key: constants.ResourceNamePathParam, Value: workspaceName1},
+			}
+			rr := httptest.NewRecorder()
+			a.PauseActionWorkspaceHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code is 422")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error response structure")
+			var response ErrorEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.Error).NotTo(BeNil())
+			Expect(response.Error.Cause).NotTo(BeNil())
+			Expect(response.Error.Cause.ValidationErrors).To(ConsistOf(
+				ValidationError{
+					Origin:  OriginInternal,
+					Type:    field.ErrorTypeTypeInvalid,
+					Field:   "data",
+					Message: `Invalid value: "string": got JSON string, but field requires object`,
+				},
+			))
 		})
 
 		// This test highlights that when the pause API receives a payload of {"data":{}},

--- a/workspaces/backend/api/workspacekind_podtemplate_options_handler.go
+++ b/workspaces/backend/api/workspacekind_podtemplate_options_handler.go
@@ -78,11 +78,11 @@ func (a *App) PodTemplateOptionsListValuesHandler(w http.ResponseWriter, r *http
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -355,11 +355,11 @@ func (a *App) UpdateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -211,12 +211,11 @@ func (a *App) CreateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}
@@ -333,11 +332,11 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 			a.requestEntityTooLargeResponse(w, r, err)
 			return
 		}
-		//
-		// TODO: handle UnmarshalTypeError and return 422,
-		//       decode the paths which were failed to decode (included in the error)
-		//       and also do this in the other handlers which decode json
-		//
+		if a.IsUnmarshalTypeError(err) {
+			fieldErrs := FieldErrorsFromUnmarshalTypeError(err)
+			a.failedValidationResponse(w, r, errMsgRequestBodyInvalid, fieldErrs, nil)
+			return
+		}
 		a.badRequestResponse(w, r, fmt.Errorf("error decoding request body: %w", err))
 		return
 	}


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_

Every handler that calls `DecodeJSON` previously returned a generic HTTP `400` for JSON type mismatches (e.g., sending "yes" for a bool field), leaking Go-internal error text. Now, `json.UnmarshalTypeError` is detected and converted to structured validation errors with the field path, expected type, and actual type — consistent with the existing `failedValidationResponse` infrastructure.