### PR TITLE
feat: enable WorkspaceKind update in FrontEnd

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -1123,6 +1123,10 @@ class EditWorkspaceKind {
     this.findSubmitButton().should('have.text', text);
   }
 
+  assertErrorAlertVisible() {
+    cy.findByTestId('workspace-kind-form-error').should('be.visible');
+  }
+
   private wait() {
     this.findPageTitle();
     cy.testA11y();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -99,6 +99,11 @@ declare global {
           response: ApiWorkspaceKindCreateEnvelope | ApiErrorEnvelope,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'PUT /api/:apiVersion/workspacekinds/:kind',
+          options: { path: { apiVersion: string; kind: string } },
+          response: ApiWorkspaceKindEnvelope | ApiErrorEnvelope,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'GET /api/:apiVersion/persistentvolumeclaims/:namespace',
           options: { path: { apiVersion: string; namespace: string } },
           response: ApiPVCListEnvelope | ApiErrorEnvelope,

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
@@ -1284,4 +1284,70 @@ describe('Edit workspace kind', () => {
       });
     });
   });
+
+  describe('Save and update', () => {
+    it('should enable Save button after editing description', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.assertSubmitButtonDisabled(true);
+
+      editWorkspaceKind.expandPropertiesSection();
+      editWorkspaceKind.typeDescription('Updated description');
+
+      editWorkspaceKind.assertSubmitButtonDisabled(false);
+    });
+
+    it('should call update API when clicking Save after editing description', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspacekinds/:kind',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: mockWorkspaceKind.name } },
+        mockModArchResponse(buildMockWorkspaceKindUpdate(mockWorkspaceKind)),
+      ).as('updateWorkspaceKind');
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.expandPropertiesSection();
+      editWorkspaceKind.typeDescription('Updated description');
+
+      editWorkspaceKind.clickSubmit();
+
+      cy.wait('@updateWorkspaceKind').then((interception) => {
+        expect(interception.request.method).to.equal('PUT');
+        expect(interception.request.body.data.spawner.description).to.equal('Updated description');
+      });
+
+      workspaceKinds.verifyPageURL();
+    });
+
+    it('should display error when update API fails', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspacekinds/:kind',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: mockWorkspaceKind.name } },
+        {
+          error: {
+            code: '500',
+            message: 'Internal server error',
+          },
+        },
+      ).as('updateWorkspaceKindError');
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.expandPropertiesSection();
+      editWorkspaceKind.typeDescription('Updated description');
+
+      editWorkspaceKind.clickSubmit();
+
+      cy.wait('@updateWorkspaceKindError');
+
+      editWorkspaceKind.assertErrorAlertVisible();
+      editWorkspaceKind.verifyPageURL(mockWorkspaceKind.name);
+    });
+  });
 });

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -207,10 +207,6 @@ body,
   border-color: var(--pf-t--global--color--disabled--default);
 }
 
-.mui-theme .pf-v6-c-radio__input:not(.pf-v6-c-card .pf-v6-c-radio__input) {
-  display: unset;
-}
-
 /* Top border separator for non-first storage class group headers in the PVC typeahead select */
 .pvc-select-group-header--with-divider {
   border-top: 1px solid var(--pf-t--global--border--color--default);

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -207,6 +207,10 @@ body,
   border-color: var(--pf-t--global--color--disabled--default);
 }
 
+.mui-theme .pf-v6-c-radio__input:not(.pf-v6-c-card .pf-v6-c-radio__input) {
+  display: unset;
+}
+
 /* Top border separator for non-first storage class group headers in the PVC typeahead select */
 .pvc-select-group-header--with-divider {
   border-top: 1px solid var(--pf-t--global--border--color--default);

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -28,7 +28,7 @@ import { WorkspaceKindFormProperties } from './properties/WorkspaceKindFormPrope
 import { WorkspaceKindFormImage } from './image/WorkspaceKindFormImage';
 import { WorkspaceKindFormPodConfig } from './podConfig/WorkspaceKindFormPodConfig';
 import { WorkspaceKindFormPodTemplate } from './podTemplate/WorkspaceKindFormPodTemplate';
-import { EMPTY_WORKSPACE_KIND_FORM_DATA } from './helpers';
+import { convertFormDataToUpdate, EMPTY_WORKSPACE_KIND_FORM_DATA } from './helpers';
 
 export enum WorkspaceKindFormView {
   Form,
@@ -137,8 +137,10 @@ export const WorkspaceKindForm: React.FC = () => {
   // TODO: Detect mode by route
   const [yamlValue, setYamlValue] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [validated, setValidated] = useState<ValidationStatus>('default');
   const mode: FormMode = useCurrentRouteKey() === 'workspaceKindCreate' ? 'create' : 'edit';
+  const [validated, setValidated] = useState<ValidationStatus>(
+    mode === 'edit' ? 'success' : 'default',
+  );
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
 
   const routeParams = useTypedParams<'workspaceKindEdit' | 'workspaceKindCreate'>();
@@ -180,17 +182,34 @@ export const WorkspaceKindForm: React.FC = () => {
         );
         navigate('workspaceKinds');
       }
-      // TODO: Finish when WSKind API is finalized
-      // const updatedWorkspace = await api.updateWorkspaceKind({}, kind, { data: {} });
-      // console.info('Workspace Kind updated:', JSON.stringify(updatedWorkspace));
-      // navigate('workspaceKinds');
+      const updateResult = await safeApiCall(() =>
+        api.workspaceKinds.updateWorkspaceKind(routeParams?.kind || '', {
+          data: convertFormDataToUpdate(data, initialFormData as WorkspacekindsWorkspaceKindUpdate),
+        }),
+      );
+      if (!updateResult.ok) {
+        throw updateResult.errorEnvelope;
+      }
+      notification.success(`Workspace kind '${routeParams?.kind || ''}' updated successfully`);
+      navigate('workspaceKinds');
     } catch (err) {
       setError(extractErrorMessage(err));
-      setValidated('error');
+      if (mode === 'create') {
+        setValidated('error');
+      }
     } finally {
       setIsSubmitting(false);
     }
-  }, [api, mode, navigate, yamlValue, notification]);
+  }, [
+    mode,
+    api.workspaceKinds,
+    routeParams?.kind,
+    data,
+    initialFormData,
+    navigate,
+    notification,
+    yamlValue,
+  ]);
 
   const canSubmit = useMemo(
     () => !isSubmitting && validated === 'success',
@@ -305,8 +324,7 @@ export const WorkspaceKindForm: React.FC = () => {
               ouiaId="Primary"
               onClick={handleSubmit}
               data-testid="submit-button"
-              // TODO: button is always disabled on edit mode. Need to modify when WorkspaceKind edit is finalized
-              isDisabled={!canSubmit || mode === 'edit'}
+              isDisabled={!canSubmit}
             >
               {mode === 'create' ? 'Create' : 'Save'}
             </Button>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import isEqual from 'lodash-es/isEqual';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
@@ -151,12 +152,15 @@ export const WorkspaceKindForm: React.FC = () => {
   const [data, setData, resetData, replaceData] = useGenericObjectState<WorkspaceKindFormData>(
     initialFormData ? convertToFormData(initialFormData) : EMPTY_WORKSPACE_KIND_FORM_DATA,
   );
+  const [originalFormData, setOriginalFormData] = useState<WorkspaceKindFormData | null>(null);
 
   useEffect(() => {
     if (!initialFormDataLoaded || initialFormData === null || mode === 'create') {
       return;
     }
-    replaceData(convertToFormData(initialFormData));
+    const converted = convertToFormData(initialFormData);
+    replaceData(converted);
+    setOriginalFormData(converted);
   }, [initialFormData, initialFormDataLoaded, mode, replaceData]);
 
   const handleSubmit = useCallback(async () => {
@@ -211,9 +215,14 @@ export const WorkspaceKindForm: React.FC = () => {
     yamlValue,
   ]);
 
+  const hasChanges = useMemo(
+    () => originalFormData !== null && !isEqual(data, originalFormData),
+    [data, originalFormData],
+  );
+
   const canSubmit = useMemo(
-    () => !isSubmitting && validated === 'success',
-    [isSubmitting, validated],
+    () => !isSubmitting && validated === 'success' && (mode === 'create' || hasChanges),
+    [isSubmitting, validated, mode, hasChanges],
   );
 
   const cancel = useCallback(() => {

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -184,17 +184,20 @@ export const WorkspaceKindForm: React.FC = () => {
         notification.success(
           `Workspace kind '${createResult.result.data.name}' created successfully`,
         );
-        navigate('workspaceKinds');
+      } else {
+        const updateResult = await safeApiCall(() =>
+          api.workspaceKinds.updateWorkspaceKind(routeParams?.kind || '', {
+            data: convertFormDataToUpdate(
+              data,
+              initialFormData as WorkspacekindsWorkspaceKindUpdate,
+            ),
+          }),
+        );
+        if (!updateResult.ok) {
+          throw updateResult.errorEnvelope;
+        }
+        notification.success(`Workspace kind '${routeParams?.kind || ''}' updated successfully`);
       }
-      const updateResult = await safeApiCall(() =>
-        api.workspaceKinds.updateWorkspaceKind(routeParams?.kind || '', {
-          data: convertFormDataToUpdate(data, initialFormData as WorkspacekindsWorkspaceKindUpdate),
-        }),
-      );
-      if (!updateResult.ok) {
-        throw updateResult.errorEnvelope;
-      }
-      notification.success(`Workspace kind '${routeParams?.kind || ''}' updated successfully`);
       navigate('workspaceKinds');
     } catch (err) {
       setError(extractErrorMessage(err));

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -11,6 +11,7 @@ import {
   V1Beta1OptionRedirect,
   V1Beta1RedirectMessageLevel,
   V1PullPolicy,
+  V1ResourceList,
   V1Toleration,
   V1TolerationOperator,
   WorkspacekindsWorkspaceKindUpdate,
@@ -254,8 +255,8 @@ export const convertFormDataToUpdate = (
           spec: {
             resources: v.resources
               ? {
-                  requests: v.resources.requests as Record<string, never>,
-                  limits: v.resources.limits as Record<string, never>,
+                  requests: v.resources.requests as V1ResourceList,
+                  limits: v.resources.limits as V1ResourceList,
                 }
               : undefined,
             nodeSelector: v.nodeSelector,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -1,13 +1,19 @@
 import {
   ImagePullPolicy,
   TolerationEntry,
+  WorkspaceKindFormData,
   WorkspaceKindImagePort,
   WorkspaceKindPodConfigValue,
 } from '~/app/types';
 import {
   OptionsOptionLabel,
   OptionsPodConfigValue,
+  V1Beta1OptionRedirect,
+  V1Beta1RedirectMessageLevel,
+  V1PullPolicy,
+  V1Toleration,
   V1TolerationOperator,
+  WorkspacekindsWorkspaceKindUpdate,
 } from '~/generated/data-contracts';
 import { PodResourceEntry } from './podConfig/WorkspaceKindFormResource';
 
@@ -157,6 +163,116 @@ export const emptyToleration = (): TolerationEntry => ({
   operator: V1TolerationOperator.TolerationOpEqual,
   key: '',
   value: '',
+});
+
+const convertRedirectToApi = (
+  redirect: WorkspaceKindPodConfigValue['redirect'],
+): V1Beta1OptionRedirect | undefined => {
+  if (!redirect?.to) {
+    return undefined;
+  }
+  return {
+    to: redirect.to,
+    message: redirect.message
+      ? {
+          level: redirect.message.level as unknown as V1Beta1RedirectMessageLevel,
+          text: redirect.message.text,
+        }
+      : undefined,
+  };
+};
+
+export const convertFormDataToUpdate = (
+  formData: WorkspaceKindFormData,
+  original: WorkspacekindsWorkspaceKindUpdate,
+): WorkspacekindsWorkspaceKindUpdate => ({
+  revision: original.revision,
+  spawner: {
+    displayName: formData.properties.displayName,
+    description: formData.properties.description,
+    deprecated: formData.properties.deprecated,
+    deprecationMessage: formData.properties.deprecationMessage || undefined,
+    hidden: formData.properties.hidden,
+    icon: { url: formData.properties.icon.url || undefined },
+    logo: { url: formData.properties.logo.url || undefined },
+  },
+  podTemplate: {
+    ...original.podTemplate,
+    podMetadata: {
+      labels: formData.podTemplate.podMetadata.labels,
+      annotations: formData.podTemplate.podMetadata.annotations,
+    },
+    volumeMounts: {
+      home: formData.podTemplate.volumeMounts.home,
+    },
+    culling: formData.podTemplate.culling
+      ? {
+          enabled: formData.podTemplate.culling.enabled,
+          maxInactiveSeconds: formData.podTemplate.culling.maxInactiveSeconds,
+          activityProbe: {
+            jupyter: {
+              lastActivity: formData.podTemplate.culling.activityProbe.jupyter.lastActivity,
+            },
+          },
+        }
+      : original.podTemplate.culling,
+    options: {
+      imageConfig: {
+        spawner: { default: formData.imageConfig.default },
+        values: (formData.imageConfig.values ?? []).map((v) => ({
+          id: v.id,
+          redirect: convertRedirectToApi(v.redirect),
+          spawner: {
+            displayName: v.displayName,
+            description: v.description || undefined,
+            hidden: v.hidden,
+            labels: v.labels?.map((l) => ({ key: l.key, value: l.value })),
+          },
+          spec: {
+            image: v.image ?? '',
+            imagePullPolicy: (v.imagePullPolicy ??
+              ImagePullPolicy.IfNotPresent) as unknown as V1PullPolicy,
+            ports: (v.ports ?? []).map((p) => ({
+              id: p.id,
+              displayName: p.displayName || undefined,
+              port: p.port,
+            })),
+          },
+        })),
+      },
+      podConfig: {
+        spawner: { default: formData.podConfig.default },
+        values: (formData.podConfig.values ?? []).map((v) => ({
+          id: v.id,
+          redirect: convertRedirectToApi(v.redirect),
+          spawner: {
+            displayName: v.displayName,
+            description: v.description || undefined,
+            hidden: v.hidden,
+            labels: v.labels?.map((l) => ({ key: l.key, value: l.value })),
+          },
+          spec: {
+            resources: v.resources
+              ? {
+                  requests: v.resources.requests as Record<string, never>,
+                  limits: v.resources.limits as Record<string, never>,
+                }
+              : undefined,
+            nodeSelector: v.nodeSelector,
+            tolerations: v.tolerations?.map(
+              (t): V1Toleration => ({
+                operator: t.operator,
+                effect: t.effect,
+                key: t.key,
+                value: t.value,
+                tolerationSeconds: t.tolerationSeconds,
+              }),
+            ),
+          },
+        })),
+      },
+    },
+  },
 });
 
 // convert from k8s resource object {limits: {}, requests{}} to array of {type: '', limit: '', request: ''} for each type of resource (e.g. CPU, memory, nvidia.com/gpu)

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImage.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/image/WorkspaceKindFormImage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import {
@@ -33,12 +33,16 @@ export const WorkspaceKindFormImage: React.FC<WorkspaceKindFormImageProps> = ({
   updateImageConfig,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [defaultId, setDefaultId] = useState(imageConfig.default || '');
+  const [defaultId, setDefaultId] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [image, setImage] = useState<WorkspaceKindImageConfigValue>({ ...emptyImage });
+
+  useEffect(() => {
+    setDefaultId(imageConfig.default);
+  }, [imageConfig.default]);
 
   const clearForm = useCallback(() => {
     setImage({ ...emptyImage });

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podConfig/WorkspaceKindFormPodConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { Title } from '@patternfly/react-core/dist/esm/components/Title';
@@ -37,13 +37,17 @@ export const WorkspaceKindFormPodConfig: React.FC<WorkspaceKindFormPodConfigProp
   updatePodConfig,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [defaultId, setDefaultId] = useState(podConfig.default || '');
+  const [defaultId, setDefaultId] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [currConfig, setCurrConfig] = useState<WorkspaceKindPodConfigValue>({ ...emptyPodConfig });
   const [tolerationModalOpenFor, setTolerationModalOpenFor] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDefaultId(podConfig.default);
+  }, [podConfig.default]);
 
   const clearForm = useCallback(() => {
     setCurrConfig({ ...emptyPodConfig });


### PR DESCRIPTION
closes: #1085

- Convert form object to WorkspaceKindUpdate payload
- Complete `canSubmit` logic in `WorkspaceKindForm`
- Complete the edit submission handler
- Error Handling
- Remove TODOs
- Add tests