### PR TITLE
fix: disable webpack open in Tilt mode

### DIFF
--- a/workspaces/frontend/config/webpack.dev.js
+++ b/workspaces/frontend/config/webpack.dev.js
@@ -91,7 +91,7 @@ module.exports = smp.wrap(
         // rebuilds on changes; just refresh the browser manually.
         hot: !isTilt,
         liveReload: !isTilt,
-        open: [BASE_PATH],
+        open: isTilt ? false : [BASE_PATH],
         proxy: [
           {
             context: ['/api', '/workspaces/api'],


### PR DESCRIPTION
This was causing issues in the WSL setup as webpack detected that it is
running in WSL and tried to automatically open a browser via powershell,
which failed and kept crashing the container:

    ✓ Dashboard available at: http://localhost:8080
    node:events:502
          throw er; // Unhandled 'error' event
      ^

    Error: spawn /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ENOENT
        at ChildProcess._handle.onexit (node:internal/child_process:285:19)
        at onErrorNT (node:internal/child_process:483:16)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
    Emitted 'error' event on ChildProcess instance at:
        at ChildProcess._handle.onexit (node:internal/child_process:291:12)
        at onErrorNT (node:internal/child_process:483:16)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
      errno: -2,
      code: 'ENOENT',
      syscall: 'spawn /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
      path: '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
      spawnargs: [
        '-NoProfile',
        '-NonInteractive',
        '-ExecutionPolicy',
        'Bypass',
        '-EncodedCommand',
        'UwB0AGEAcgB0ACAAIgBoAHQAdABwADoALwAvAGwAbwBjAGEAbABoAG8AcwB0ADoAOAAwADgAMAAvAHcAbwByAGsAcwBwAGEAYwBlAHMALwAiAA=='
      ]
    }

The decoded version of the failing command is the following, not quite sure what that is supposed to do

    $ echo "UwB0AGEAcgB0ACAAIgBoAHQAdABwADoALwAvAGwAbwBjAGEAbABoAG8AcwB0ADoAOAAwADgAMAAvAHcAbwByAGsAcwBwAGEAYwBlAHMALwAiAA==" | base64 -d
    Start "http://localhost:8080/workspaces/"

This fixes https://github.com/kubeflow/notebooks/issues/1066

Tested in WSL on Windows 11 with an Arch Linux WSL guest image ✅ 

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
