### PR TITLE
fix: add namespace to storageclasses api and check pvc create for auth

### DIFF
--- a/workspaces/backend/.golangci.yml
+++ b/workspaces/backend/.golangci.yml
@@ -12,6 +12,11 @@ issues:
       linters:
         - lll
 
+    # disable dupl for handler files
+    - path: "api/.*_handler\\.go"
+      linters:
+        - dupl
+
     # disable some linters for internal packages
     - path: "internal/*"
       linters:

--- a/workspaces/backend/api/pvcs_handler.go
+++ b/workspaces/backend/api/pvcs_handler.go
@@ -49,7 +49,7 @@ type PVCCreateEnvelope Envelope[*models.PVCCreate]
 //	@Failure		422			{object}	ErrorEnvelope	"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope	"Internal server error"
 //	@Router			/persistentvolumeclaims/{namespace} [get]
-func (a *App) GetPVCsByNamespaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl
+func (a *App) GetPVCsByNamespaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 
 	// validate path parameters

--- a/workspaces/backend/api/secrets_handler.go
+++ b/workspaces/backend/api/secrets_handler.go
@@ -50,7 +50,7 @@ type SecretCreateEnvelope Envelope[*models.SecretCreate]
 //	@Failure		422			{object}	ErrorEnvelope		"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope		"Internal server error"
 //	@Router			/secrets/{namespace} [get]
-func (a *App) GetSecretsByNamespaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl
+func (a *App) GetSecretsByNamespaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 
 	var valErrs field.ErrorList
@@ -96,7 +96,7 @@ func (a *App) GetSecretsByNamespaceHandler(w http.ResponseWriter, r *http.Reques
 //	@Failure		422			{object}	ErrorEnvelope	"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope	"Internal server error"
 //	@Router			/secrets/{namespace}/{name} [get]
-func (a *App) GetSecretHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl // TODO: Abstract common API patterns once implemented
+func (a *App) GetSecretHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 	secretName := ps.ByName(constants.ResourceNamePathParam)
 
@@ -345,7 +345,7 @@ func (a *App) UpdateSecretHandler(w http.ResponseWriter, r *http.Request, ps htt
 //	@Failure		404			{object}	ErrorEnvelope	"Secret not found"
 //	@Failure		500			{object}	ErrorEnvelope	"Internal server error"
 //	@Router			/secrets/{namespace}/{name} [delete]
-func (a *App) DeleteSecretHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl
+func (a *App) DeleteSecretHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 	secretName := ps.ByName(constants.ResourceNamePathParam)
 

--- a/workspaces/backend/api/storageclasses_handler.go
+++ b/workspaces/backend/api/storageclasses_handler.go
@@ -44,7 +44,7 @@ type StorageClassListEnvelope Envelope[[]models.StorageClassListItem]
 //	@Failure		422			{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope				"Internal server error"
 //	@Router			/storageclasses [get]
-func (a *App) GetStorageClassesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) { //nolint:dupl
+func (a *App) GetStorageClassesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	namespace := r.URL.Query().Get(constants.NamespaceQueryParam)
 
 	// validate query parameters

--- a/workspaces/backend/api/storageclasses_handler.go
+++ b/workspaces/backend/api/storageclasses_handler.go
@@ -20,8 +20,11 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/storageclasses"
 )
 
@@ -30,20 +33,42 @@ type StorageClassListEnvelope Envelope[[]models.StorageClassListItem]
 // GetStorageClassesHandler returns a list of all storage classes in the cluster.
 //
 //	@Summary		List storage classes
-//	@Description	Returns a list of all storage classes in the cluster.
+//	@Description	Returns a list of all storage classes in the cluster. When namespace is provided, authorization checks whether the user can create PersistentVolumeClaims in that namespace instead of requiring a cluster-wide permission to list storage classes.
 //	@Tags			storageclasses
 //	@ID				listStorageClasses
 //	@Produce		application/json
-//	@Success		200	{object}	StorageClassListEnvelope	"Successful storage classes response"
-//	@Failure		401	{object}	ErrorEnvelope				"Unauthorized"
-//	@Failure		403	{object}	ErrorEnvelope				"Forbidden"
-//	@Failure		500	{object}	ErrorEnvelope				"Internal server error"
+//	@Param			namespace	query		string						false	"Namespace to request storage classes for."	extensions(x-example=kubeflow-user-example-com)
+//	@Success		200			{object}	StorageClassListEnvelope	"Successful storage classes response"
+//	@Failure		401			{object}	ErrorEnvelope				"Unauthorized"
+//	@Failure		403			{object}	ErrorEnvelope				"Forbidden"
+//	@Failure		422			{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
+//	@Failure		500			{object}	ErrorEnvelope				"Internal server error"
 //	@Router			/storageclasses [get]
-func (a *App) GetStorageClassesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (a *App) GetStorageClassesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) { //nolint:dupl
+	namespace := r.URL.Query().Get(constants.NamespaceQueryParam)
+
+	// validate query parameters
+	var valErrs field.ErrorList
+	if namespace != "" {
+		valErrs = append(valErrs, helper.ValidateKubernetesNamespaceName(field.NewPath(constants.NamespaceQueryParam), namespace)...)
+	}
+	if len(valErrs) > 0 {
+		a.failedValidationResponse(w, r, errMsgQueryParamsInvalid, valErrs, nil)
+		return
+	}
 
 	// =========================== AUTH ===========================
-	authPolicies := []*auth.ResourcePolicy{
-		auth.NewResourcePolicy(auth.VerbList, auth.StorageClasses, auth.ResourcePolicyResourceMeta{}),
+	var authPolicies []*auth.ResourcePolicy
+	if namespace != "" {
+		// user intends to create a pvc in the namespace
+		authPolicies = []*auth.ResourcePolicy{
+			auth.NewResourcePolicy(auth.VerbCreate, auth.PersistentVolumeClaims, auth.ResourcePolicyResourceMeta{Namespace: namespace}),
+		}
+	} else {
+		// administrative listing of storage classes
+		authPolicies = []*auth.ResourcePolicy{
+			auth.NewResourcePolicy(auth.VerbList, auth.StorageClasses, auth.ResourcePolicyResourceMeta{}),
+		}
 	}
 	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
 		return

--- a/workspaces/backend/api/storageclasses_handler_test.go
+++ b/workspaces/backend/api/storageclasses_handler_test.go
@@ -135,5 +135,74 @@ var _ = Describe("StorageClasses Handler", func() {
 				models.NewStorageClassListItemFromStorageClass(storageClass2),
 			))
 		})
+
+		It("should retrieve storage classes successfully with a valid namespace query parameter", func() {
+			By("creating the HTTP request with namespace query parameter")
+			req, err := http.NewRequest(http.MethodGet, constants.AllStorageClassesPath+"?namespace=kubeflow-user-example-com", http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetStorageClassesHandler")
+			ps := httprouter.Params{}
+			rr := httptest.NewRecorder()
+			a.GetStorageClassesHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("reading the HTTP response body")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response JSON to StorageClassListEnvelope")
+			var response StorageClassListEnvelope
+			err = json.Unmarshal(body, &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("getting the StorageClasses from the Kubernetes API")
+			storageClass1 := &storagev1.StorageClass{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: storageClassName1}, storageClass1)).To(Succeed())
+			storageClass2 := &storagev1.StorageClass{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: storageClassName2}, storageClass2)).To(Succeed())
+
+			By("ensuring the response contains the expected StorageClasses")
+			Expect(response.Data).To(ContainElements(
+				models.NewStorageClassListItemFromStorageClass(storageClass1),
+				models.NewStorageClassListItemFromStorageClass(storageClass2),
+			))
+		})
+
+		It("should return 422 for an invalid namespace query parameter", func() {
+			By("creating the HTTP request with an invalid namespace query parameter")
+			req, err := http.NewRequest(http.MethodGet, constants.AllStorageClassesPath+"?namespace=INVALID_NS!!!", http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetStorageClassesHandler")
+			ps := httprouter.Params{}
+			rr := httptest.NewRecorder()
+			a.GetStorageClassesHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("decoding the error response")
+			var response ErrorEnvelope
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error message indicates a query parameter validation failure")
+			Expect(response.Error.Message).To(Equal(errMsgQueryParamsInvalid))
+			Expect(response.Error.Cause.ValidationErrors).NotTo(BeEmpty())
+			Expect(response.Error.Cause.ValidationErrors[0].Field).To(Equal(constants.NamespaceQueryParam))
+		})
 	})
 })

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -105,7 +105,7 @@ func (a *App) GetWorkspaceKindHandler(w http.ResponseWriter, r *http.Request, ps
 //	@Failure		422				{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
 //	@Failure		500				{object}	ErrorEnvelope				"Internal server error. An unexpected error occurred on the server."
 //	@Router			/workspacekinds [get]
-func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) { //nolint:dupl
+func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	namespace := r.URL.Query().Get(constants.NamespaceFilterQueryParam)
 
 	// validate query parameters

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -105,7 +105,7 @@ func (a *App) GetWorkspaceKindHandler(w http.ResponseWriter, r *http.Request, ps
 //	@Failure		422				{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
 //	@Failure		500				{object}	ErrorEnvelope				"Internal server error. An unexpected error occurred on the server."
 //	@Router			/workspacekinds [get]
-func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) { //nolint:dupl
 	namespace := r.URL.Query().Get(constants.NamespaceFilterQueryParam)
 
 	// validate query parameters

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -55,7 +55,7 @@ type WorkspaceListEnvelope Envelope[[]models.WorkspaceListItem]
 //	@Failure		422			{object}	ErrorEnvelope		"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope		"Internal server error. An unexpected error occurred on the server."
 //	@Router			/workspaces/{namespace}/{name} [get]
-func (a *App) GetWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl // TODO: Abstract common API patterns once implemented
+func (a *App) GetWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 	workspaceName := ps.ByName(constants.ResourceNamePathParam)
 
@@ -404,7 +404,7 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 //	@Failure		422			{object}	ErrorEnvelope	"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope	"Internal server error. An unexpected error occurred on the server."
 //	@Router			/workspaces/{namespace}/{name} [delete]
-func (a *App) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) { //nolint:dupl
+func (a *App) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 	workspaceName := ps.ByName(constants.ResourceNamePathParam)
 

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -663,7 +663,7 @@ const docTemplate = `{
         },
         "/storageclasses": {
             "get": {
-                "description": "Returns a list of all storage classes in the cluster.",
+                "description": "Returns a list of all storage classes in the cluster. When namespace is provided, authorization checks whether the user can create PersistentVolumeClaims in that namespace instead of requiring a cluster-wide permission to list storage classes.",
                 "produces": [
                     "application/json"
                 ],
@@ -672,6 +672,15 @@ const docTemplate = `{
                 ],
                 "summary": "List storage classes",
                 "operationId": "listStorageClasses",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace to request storage classes for.",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful storage classes response",
@@ -687,6 +696,12 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -661,7 +661,7 @@
         },
         "/storageclasses": {
             "get": {
-                "description": "Returns a list of all storage classes in the cluster.",
+                "description": "Returns a list of all storage classes in the cluster. When namespace is provided, authorization checks whether the user can create PersistentVolumeClaims in that namespace instead of requiring a cluster-wide permission to list storage classes.",
                 "produces": [
                     "application/json"
                 ],
@@ -670,6 +670,15 @@
                 ],
                 "summary": "List storage classes",
                 "operationId": "listStorageClasses",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace to request storage classes for.",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful storage classes response",
@@ -685,6 +694,12 @@
                     },
                     "403": {
                         "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }


### PR DESCRIPTION
Regular Kubeflow users get 403 on /storageclasses because the backend issues a cluster-wide SAR (namespace="") that requires a ClusterRoleBinding, but users only have a namespace-scoped RoleBinding.

- Add namespace query param to GET /storageclasses: when provided the SAR
  is scoped to that namespace (matching the existing workspacekinds pattern) and checks if the users is allowed to create a PVC in the namespace. This is allowing regular users through; without it the endpoint remains admin-only
- Drop duplication linter for `"api/.*_handler.go` and remove leftover nolint directives

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
