### PR TITLE
feat: use listValues to render Image and Pod Config steps in Workspac…

### DIFF
--- a/workspaces/frontend/config/cspell-ignore-words.txt
+++ b/workspaces/frontend/config/cspell-ignore-words.txt
@@ -18,3 +18,6 @@ unhover
 unhovering
 toleration
 tolerations
+podtemplate
+listvalues
+cuda

--- a/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -2,6 +2,7 @@ import type { UserSettings } from 'mod-arch-core';
 import type {
   ApiErrorEnvelope,
   ApiNamespaceListEnvelope,
+  ApiPodTemplateOptionsEnvelope,
   ApiPVCCreateEnvelope,
   ApiPVCListEnvelope,
   ApiSecretCreateEnvelope,
@@ -102,6 +103,11 @@ declare global {
           type: 'PUT /api/:apiVersion/workspacekinds/:kind',
           options: { path: { apiVersion: string; kind: string } },
           response: ApiWorkspaceKindEnvelope | ApiErrorEnvelope,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/:apiVersion/workspacekinds/:kind/podtemplate/options/listvalues',
+          options: { path: { apiVersion: string; kind: string } },
+          response: ApiPodTemplateOptionsEnvelope | ApiErrorEnvelope,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/persistentvolumeclaims/:namespace',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -11,6 +11,7 @@ import {
   buildMockWorkspaceCreate,
   buildMockWorkspaceKind,
 } from '~/shared/mock/mockBuilder';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
 import {
   secretsDetachModal,
@@ -118,6 +119,8 @@ describe('Create workspace', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKind]),
     ).as('getWorkspaceKinds');
+
+    interceptListValues(mockWorkspaceKind);
 
     workspaces.visit();
     cy.wait('@getNamespaces');
@@ -364,6 +367,7 @@ describe('Create workspace', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKindWithMultipleImages]),
       ).as('getWorkspaceKindsMultiple');
+      interceptListValues(mockWorkspaceKindWithMultipleImages);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKindsMultiple');
@@ -414,6 +418,7 @@ describe('Create workspace', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKindWithMultiplePodConfigs]),
       ).as('getWorkspaceKindsMultiplePodConfigs');
+      interceptListValues(mockWorkspaceKindWithMultiplePodConfigs);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKindsMultiplePodConfigs');
@@ -451,6 +456,8 @@ describe('Create workspace', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind, mockWorkspaceKind2]),
       ).as('getMultipleWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
+      interceptListValues(mockWorkspaceKind2);
 
       createWorkspace.visit();
       cy.wait('@getMultipleWorkspaceKinds');
@@ -528,6 +535,7 @@ describe('Create workspace', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKindSingleImage]),
       ).as('getWorkspaceKindsSingleImage');
+      interceptListValues(mockWorkspaceKindSingleImage);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKindsSingleImage');
@@ -564,6 +572,7 @@ describe('Create workspace', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKindSinglePodConfig]),
       ).as('getWorkspaceKindsSinglePodConfig');
+      interceptListValues(mockWorkspaceKindSinglePodConfig);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKindsSinglePodConfig');
@@ -691,6 +700,7 @@ describe('Create workspace', () => {
           { path: { apiVersion: NOTEBOOKS_API_VERSION } },
           mockModArchResponse([mockWorkspaceKindWithMultipleOptions]),
         ).as('getWorkspaceKindsWithOptions');
+        interceptListValues(mockWorkspaceKindWithMultipleOptions);
       });
 
       it('should filter images by name', () => {
@@ -742,6 +752,7 @@ describe('Create workspace', () => {
           { path: { apiVersion: NOTEBOOKS_API_VERSION } },
           mockModArchResponse([mockWorkspaceKindWithMultipleOptions]),
         ).as('getWorkspaceKindsWithOptions');
+        interceptListValues(mockWorkspaceKindWithMultipleOptions);
       });
 
       it('should filter pod configs by name', () => {
@@ -1429,6 +1440,147 @@ describe('Create workspace', () => {
         // Verify table is gone (no secrets left)
         cy.findByTestId('secrets-table').should('not.exist');
       });
+    });
+  });
+
+  describe('ListValues options', () => {
+    const cpuImage: OptionsImageConfigValue = {
+      id: 'jupyter_cpu',
+      displayName: 'jupyter-scipy:v2.1.0',
+      description: 'JupyterLab, CPU only',
+      labels: [{ key: 'pythonVersion', value: '3.13' }],
+      hidden: false,
+    };
+
+    const cudaImage: OptionsImageConfigValue = {
+      id: 'jupyter_cuda',
+      displayName: 'jupyter-scipy:v2.1.0-cuda',
+      description: 'JupyterLab with CUDA support',
+      labels: [
+        { key: 'pythonVersion', value: '3.13' },
+        { key: 'cuda', value: '12.4' },
+        { key: 'gpuRequired', value: 'true' },
+      ],
+      hidden: false,
+    };
+
+    const smallCpuPod: OptionsPodConfigValue = {
+      id: 'small_cpu',
+      displayName: 'Small CPU',
+      description: 'Pod with 0.5 CPU, 512 Mb RAM',
+      labels: [
+        { key: 'cpu', value: '500m' },
+        { key: 'memory', value: '512Mi' },
+      ],
+      hidden: false,
+    };
+
+    const bigGpuPod: OptionsPodConfigValue = {
+      id: 'big_gpu',
+      displayName: 'Big GPU',
+      description: 'Pod with 4 CPU, 16 GB RAM, and 1 GPU',
+      labels: [
+        { key: 'cpu', value: '4000m' },
+        { key: 'memory', value: '16Gi' },
+        { key: 'gpu', value: '1' },
+      ],
+      hidden: false,
+    };
+
+    it('should show all images and pod configs from listValues response', () => {
+      const kind = buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: { default: cpuImage.id, values: [cpuImage, cudaImage] },
+            podConfig: { default: smallCpuPod.id, values: [smallCpuPod, bigGpuPod] },
+          },
+        },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsListValues');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsListValues');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.findImageCard(cpuImage.id).should('be.visible');
+      createWorkspace.findImageCard(cudaImage.id).should('be.visible');
+
+      createWorkspace.selectImage(cudaImage.id);
+      createWorkspace.clickNext();
+
+      createWorkspace.findPodConfigCard(smallCpuPod.id).should('be.visible');
+      createWorkspace.findPodConfigCard(bigGpuPod.id).should('be.visible');
+    });
+
+    it('should show only CPU pod configs when listValues returns no GPU options', () => {
+      const kind = buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: { default: cpuImage.id, values: [cpuImage] },
+            podConfig: { default: smallCpuPod.id, values: [smallCpuPod] },
+          },
+        },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsListValues');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsListValues');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.selectImage(cpuImage.id);
+      createWorkspace.clickNext();
+
+      createWorkspace.findPodConfigCard(smallCpuPod.id).should('be.visible');
+      createWorkspace.findPodConfigCard(bigGpuPod.id).should('not.exist');
+    });
+
+    it('should auto-select default image and pod config from listValues', () => {
+      const kind = buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: { default: cudaImage.id, values: [cpuImage, cudaImage] },
+            podConfig: { default: bigGpuPod.id, values: [smallCpuPod, bigGpuPod] },
+          },
+        },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsListValues');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsListValues');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.assertImageSelected(cudaImage.id);
+
+      createWorkspace.clickNext();
+
+      createWorkspace.assertPodConfigSelected(bigGpuPod.id);
     });
   });
 });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/defaultSelection.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/defaultSelection.cy.ts
@@ -2,6 +2,7 @@ import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 
 type ImageConfigOption = {
   id: string;
@@ -100,6 +101,7 @@ describe('Workspace Form - Default Selection', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -133,6 +135,7 @@ describe('Workspace Form - Default Selection', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -172,6 +175,7 @@ describe('Workspace Form - Default Selection', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -210,6 +214,7 @@ describe('Workspace Form - Default Selection', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -253,6 +258,7 @@ describe('Workspace Form - Default Selection', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -288,6 +294,7 @@ describe('Workspace Form - Default Selection', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
@@ -13,6 +13,7 @@ import {
   buildMockWorkspaceUpdate,
 } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
 import { toastNotification } from '~/__tests__/cypress/cypress/pages/components/toastNotification';
 
@@ -116,6 +117,7 @@ const setupEditWorkspace = (): EditWorkspaceSetup => {
     { path: { apiVersion: NOTEBOOKS_API_VERSION } },
     mockModArchResponse([mockWorkspaceKind]),
   ).as('getWorkspaceKinds');
+  interceptListValues(mockWorkspaceKind);
 
   return { mockNamespace, mockWorkspace, mockWorkspaceKind };
 };
@@ -372,6 +374,8 @@ describe('Edit workspace', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind, differentWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
+      interceptListValues(differentWorkspaceKind);
 
       visitEditWorkspace();
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterImagesByLabels.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterImagesByLabels.cy.ts
@@ -8,7 +8,10 @@ import {
   buildMockWorkspaceKind,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
-import { buildMockImageWithLabels } from '~/__tests__/cypress/cypress/utils/testBuilders';
+import {
+  buildMockImageWithLabels,
+  interceptListValues,
+} from '~/__tests__/cypress/cypress/utils/testBuilders';
 import type { WorkspacekindsWorkspaceKindListItem } from '~/generated/data-contracts';
 
 const STEP_NAMES = {
@@ -137,6 +140,7 @@ describe('Filter Images by Labels', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKind]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKind);
 
     workspaces.visit();
     cy.wait('@getNamespaces');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterPodConfigsByLabels.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterPodConfigsByLabels.cy.ts
@@ -8,7 +8,10 @@ import {
   buildMockWorkspaceKind,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
-import { buildMockPodConfigWithLabels } from '~/__tests__/cypress/cypress/utils/testBuilders';
+import {
+  buildMockPodConfigWithLabels,
+  interceptListValues,
+} from '~/__tests__/cypress/cypress/utils/testBuilders';
 import type { WorkspacekindsWorkspaceKindListItem } from '~/generated/data-contracts';
 
 const STEP_NAMES = {
@@ -98,6 +101,7 @@ describe('Filter Pod Configs by Labels', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKind]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKind);
 
     workspaces.visit();
     cy.wait('@getNamespaces');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/optionCardDisplay.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/optionCardDisplay.cy.ts
@@ -2,6 +2,7 @@ import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { OptionsRedirectMessageLevel } from '~/generated/data-contracts';
 
 type ImageConfigOption = {
@@ -110,6 +111,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -157,6 +159,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -205,6 +208,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -245,6 +249,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -285,6 +290,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -330,6 +336,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -377,6 +384,7 @@ describe('Workspace Form - Option Card Display', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
@@ -11,6 +11,7 @@ import {
   buildMockWorkspaceUpdateFromWorkspace,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
 
 describe('SecretsAttachModal', () => {
@@ -60,6 +61,7 @@ describe('SecretsAttachModal', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKindFull]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKindFull);
 
     cy.intercept('GET', `/api/${NOTEBOOKS_API_VERSION}/secrets/${mockNamespace.name}`, {
       data: mockSecrets,

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
@@ -15,6 +15,7 @@ import {
   buildMockWorkspaceUpdateFromWorkspace,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
 
 describe('Edit Secret Modal', () => {
@@ -96,6 +97,7 @@ describe('Edit Secret Modal', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKindFull]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKindFull);
 
     cy.interceptApi(
       'GET /api/:apiVersion/secrets/:namespace',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
@@ -15,6 +15,7 @@ import {
   buildMockWorkspaceUpdateFromWorkspace,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
 
 describe('Secrets Expandable Key/Value Pairs', () => {
@@ -66,6 +67,7 @@ describe('Secrets Expandable Key/Value Pairs', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKindFull]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKindFull);
 
     // Intercept list secrets API (called when secrets section loads)
     cy.intercept('GET', `/api/${NOTEBOOKS_API_VERSION}/secrets/${mockNamespace.name}`, {
@@ -205,6 +207,7 @@ describe('Secrets Management - Attach Modal', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKindFull]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKindFull);
 
     cy.interceptApi(
       'GET /api/:apiVersion/secrets/:namespace',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/smartFilterDefaults.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/smartFilterDefaults.cy.ts
@@ -2,6 +2,7 @@ import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { OptionsRedirectMessageLevel } from '~/generated/data-contracts';
 
 describe('Workspace Form - Smart Filter Defaults', () => {
@@ -62,6 +63,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -128,6 +130,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -194,6 +197,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -253,6 +257,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -313,6 +318,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -378,6 +384,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -438,6 +445,7 @@ describe('Workspace Form - Smart Filter Defaults', () => {
         { path: { apiVersion: NOTEBOOKS_API_VERSION } },
         mockModArchResponse([mockWorkspaceKind]),
       ).as('getWorkspaceKinds');
+      interceptListValues(mockWorkspaceKind);
 
       createWorkspace.visit();
       cy.wait('@getWorkspaceKinds');
@@ -453,72 +461,6 @@ describe('Workspace Form - Smart Filter Defaults', () => {
 
       // Hidden option should now be hidden
       createWorkspace.assertCardNotVisible('jupyterlab_scipy_200_hidden');
-    });
-
-    it('should auto-deselect when selected option is filtered out', () => {
-      const mockWorkspaceKind = buildMockWorkspaceKind({
-        name: 'jupyterlab',
-        podTemplate: {
-          ...buildMockWorkspaceKind().podTemplate,
-          options: {
-            imageConfig: {
-              default: 'jupyterlab_scipy_200_hidden',
-              values: [
-                {
-                  id: 'jupyterlab_scipy_190',
-                  displayName: 'jupyter-scipy:v1.9.0',
-                  description: 'JupyterLab v1.9.0',
-                  labels: [],
-                  hidden: false,
-                },
-                {
-                  id: 'jupyterlab_scipy_200_hidden',
-                  displayName: 'jupyter-scipy:v2.0.0 (Hidden)',
-                  description: 'JupyterLab v2.0.0',
-                  labels: [],
-                  hidden: true,
-                },
-              ],
-            },
-            podConfig: {
-              default: 'tiny_cpu',
-              values: [
-                {
-                  id: 'tiny_cpu',
-                  displayName: 'Tiny CPU',
-                  description: 'Small pod',
-                  labels: [],
-                  hidden: false,
-                },
-              ],
-            },
-          },
-        },
-      });
-
-      cy.interceptApi(
-        'GET /api/:apiVersion/workspacekinds',
-        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
-        mockModArchResponse([mockWorkspaceKind]),
-      ).as('getWorkspaceKinds');
-
-      createWorkspace.visit();
-      cy.wait('@getWorkspaceKinds');
-
-      createWorkspace.selectKind('jupyterlab');
-      createWorkspace.clickNext();
-
-      // Hidden option should be auto-selected and visible
-      createWorkspace.assertImageSelected('jupyterlab_scipy_200_hidden');
-
-      // Uncheck "Show hidden" to filter it out
-      createWorkspace.clickExtraFilter('showHidden');
-
-      // The selected option should be deselected
-      cy.get('#jupyterlab_scipy_200_hidden').should('not.exist');
-
-      // Next button should be disabled since nothing is selected
-      createWorkspace.assertNextButtonDisabled();
     });
   });
 });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryRedirectPopover.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryRedirectPopover.cy.ts
@@ -3,6 +3,7 @@ import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/cr
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import type { OptionsImageConfigValue } from '~/generated/data-contracts';
 import { OptionsRedirectMessageLevel } from '~/generated/data-contracts';
 
@@ -71,6 +72,7 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKind]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKind);
 
     cy.visit('/workspaces/create');
     cy.wait('@getNamespaces');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryStep.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryStep.cy.ts
@@ -12,6 +12,7 @@ import {
   buildMockWorkspaceUpdate,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import {
   V1Beta1WorkspaceState,
   type OptionsImageConfigValue,
@@ -105,6 +106,7 @@ describe('Summary step', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKind]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKind);
 
     cy.interceptApi(
       'GET /api/:apiVersion/persistentvolumeclaims/:namespace',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
@@ -17,6 +17,7 @@ import {
   buildMockWorkspaceUpdateFromWorkspace,
 } from '~/shared/mock/mockBuilder';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import {
   V1Beta1WorkspaceState,
   V1PersistentVolumeAccessMode,
@@ -142,6 +143,7 @@ describe('Volumes Management - Attach and Create', () => {
       { path: { apiVersion: NOTEBOOKS_API_VERSION } },
       mockModArchResponse([mockWorkspaceKindFull]),
     ).as('getWorkspaceKinds');
+    interceptListValues(mockWorkspaceKindFull);
 
     cy.interceptApi(
       'GET /api/:apiVersion/persistentvolumeclaims/:namespace',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceFormStyling.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceFormStyling.cy.ts
@@ -3,6 +3,7 @@ import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/cr
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
+import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import type { OptionsImageConfigValue } from '~/generated/data-contracts';
 import { OptionsRedirectMessageLevel } from '~/generated/data-contracts';
 
@@ -85,6 +86,7 @@ describe('Workspace Form Styling', () => {
       headers: { 'content-type': 'image/svg+xml' },
       body: '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
     });
+    interceptListValues(mockWorkspaceKind);
   });
 
   describe('Workspace Kind logo styling', () => {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/utils/testBuilders.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/utils/testBuilders.ts
@@ -7,7 +7,10 @@ import {
   buildPodTemplateOptions,
   buildMockImageConfig,
 } from '~/shared/mock/mockBuilder';
-import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import {
+  V1Beta1WorkspaceState,
+  type WorkspacekindsWorkspaceKindListItem,
+} from '~/generated/data-contracts';
 
 export const buildMockWorkspaceWithGPU = (args: {
   name: string;
@@ -163,3 +166,31 @@ export const buildMockPodConfigWithLabels = (
   redirect: undefined,
   clusterMetrics: undefined,
 });
+
+export const interceptListValues = (
+  kind: WorkspacekindsWorkspaceKindListItem,
+): Cypress.Chainable<null> => {
+  const allImages = kind.podTemplate.options.imageConfig.values ?? [];
+  const allPodConfigs = kind.podTemplate.options.podConfig.values ?? [];
+
+  return cy
+    .intercept('POST', `**/workspacekinds/${kind.name}/podtemplate/options/listvalues`, (req) => {
+      const imageId = req.body?.data?.context?.imageConfig?.id;
+
+      const images = imageId ? allImages.filter((img) => img.id === imageId) : allImages;
+
+      req.reply({
+        data: {
+          imageConfig: {
+            default: kind.podTemplate.options.imageConfig.default,
+            values: images,
+          },
+          podConfig: {
+            default: kind.podTemplate.options.podConfig.default,
+            values: allPodConfigs,
+          },
+        },
+      });
+    })
+    .as(`listValues-${kind.name}`);
+};

--- a/workspaces/frontend/src/app/components/LoadError.tsx
+++ b/workspaces/frontend/src/app/components/LoadError.tsx
@@ -1,19 +1,33 @@
 import React from 'react';
+import axios from 'axios';
 import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { EmptyState, EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { ApiErrorEnvelope } from '~/generated/data-contracts';
+import { formatValidationErrorMessages, isApiErrorEnvelope } from '~/shared/api/apiUtils';
 
 interface LoadErrorProps {
   title: string;
-  error: Error;
+  error: Error | ApiErrorEnvelope;
 }
 
-// TODO: simple LoadError component -- we should improve this later
+function resolveErrorMessage(error: Error | ApiErrorEnvelope): string {
+  if (isApiErrorEnvelope(error)) {
+    return formatValidationErrorMessages(error).join('\n');
+  }
+  if (axios.isAxiosError<ApiErrorEnvelope>(error)) {
+    const envelope = error.response?.data;
+    if (envelope && isApiErrorEnvelope(envelope)) {
+      return formatValidationErrorMessages(envelope).join('\n');
+    }
+  }
+  return error.message;
+}
 
 export const LoadError: React.FC<LoadErrorProps> = ({ title, error }) => (
   <Bullseye>
     <EmptyState titleText={title} headingLevel="h4" icon={ExclamationCircleIcon} status="danger">
-      <EmptyStateBody>{error.message}</EmptyStateBody>
+      <EmptyStateBody>{resolveErrorMessage(error)}</EmptyStateBody>
     </EmptyState>
   </Bullseye>
 );

--- a/workspaces/frontend/src/app/hooks/__tests__/usePodTemplateOptionsListValues.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/usePodTemplateOptionsListValues.spec.tsx
@@ -1,0 +1,182 @@
+import { renderHook } from '~/__tests__/unit/testUtils/hooks';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import usePodTemplateOptionsListValues from '~/app/hooks/usePodTemplateOptionsListValues';
+import { NotebookApis } from '~/shared/api/notebookApi';
+import { buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+
+jest.mock('~/app/hooks/useNotebookAPI', () => ({
+  useNotebookAPI: jest.fn(),
+}));
+
+const mockUseNotebookAPI = useNotebookAPI as jest.MockedFunction<typeof useNotebookAPI>;
+
+describe('usePodTemplateOptionsListValues', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects when API not available', async () => {
+    mockUseNotebookAPI.mockReturnValue({
+      api: {} as NotebookApis,
+      apiAvailable: false,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodTemplateOptionsListValues({
+        kindName: 'jupyterlab',
+        namespace: 'default',
+        imageId: undefined,
+      }),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toBeNull();
+    expect(loaded).toBe(false);
+    expect(error).toBeDefined();
+  });
+
+  it('rejects when kindName is undefined', async () => {
+    mockUseNotebookAPI.mockReturnValue({
+      api: {} as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodTemplateOptionsListValues({
+        kindName: undefined,
+        namespace: 'default',
+        imageId: undefined,
+      }),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toBeNull();
+    expect(loaded).toBe(false);
+    expect(error).toBeDefined();
+  });
+
+  it('returns options when API is available and kindName is provided', async () => {
+    const mockWorkspaceKind = buildMockWorkspaceKind({});
+    const mockResponse = {
+      imageConfig: mockWorkspaceKind.podTemplate.options.imageConfig,
+      podConfig: mockWorkspaceKind.podTemplate.options.podConfig,
+    };
+
+    const podTemplateOptionsListValues = jest
+      .fn()
+      .mockResolvedValue({ ok: true, data: mockResponse });
+    mockUseNotebookAPI.mockReturnValue({
+      api: {
+        workspaceKinds: { podTemplateOptionsListValues },
+      } as unknown as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodTemplateOptionsListValues({
+        kindName: 'jupyterlab',
+        namespace: 'default',
+        imageId: undefined,
+      }),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toEqual(mockResponse);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+    expect(podTemplateOptionsListValues).toHaveBeenCalledWith('jupyterlab', {
+      data: {
+        context: {
+          namespace: { name: 'default' },
+        },
+      },
+    });
+  });
+
+  it('sends imageConfig context when imageId is provided', async () => {
+    const mockWorkspaceKind = buildMockWorkspaceKind({});
+    const mockResponse = {
+      imageConfig: mockWorkspaceKind.podTemplate.options.imageConfig,
+      podConfig: mockWorkspaceKind.podTemplate.options.podConfig,
+    };
+
+    const podTemplateOptionsListValues = jest
+      .fn()
+      .mockResolvedValue({ ok: true, data: mockResponse });
+    mockUseNotebookAPI.mockReturnValue({
+      api: {
+        workspaceKinds: { podTemplateOptionsListValues },
+      } as unknown as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodTemplateOptionsListValues({
+        kindName: 'jupyterlab',
+        namespace: 'default',
+        imageId: 'jupyterlab_scipy_190',
+      }),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toEqual(mockResponse);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+    expect(podTemplateOptionsListValues).toHaveBeenCalledWith('jupyterlab', {
+      data: {
+        context: {
+          namespace: { name: 'default' },
+          imageConfig: { id: 'jupyterlab_scipy_190' },
+        },
+      },
+    });
+  });
+
+  it('sends no namespace context when namespace is undefined', async () => {
+    const mockWorkspaceKind = buildMockWorkspaceKind({});
+    const mockResponse = {
+      imageConfig: mockWorkspaceKind.podTemplate.options.imageConfig,
+      podConfig: mockWorkspaceKind.podTemplate.options.podConfig,
+    };
+
+    const podTemplateOptionsListValues = jest
+      .fn()
+      .mockResolvedValue({ ok: true, data: mockResponse });
+    mockUseNotebookAPI.mockReturnValue({
+      api: {
+        workspaceKinds: { podTemplateOptionsListValues },
+      } as unknown as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodTemplateOptionsListValues({
+        kindName: 'jupyterlab',
+        namespace: undefined,
+        imageId: undefined,
+      }),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toEqual(mockResponse);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+    expect(podTemplateOptionsListValues).toHaveBeenCalledWith('jupyterlab', {
+      data: {
+        context: {
+          namespace: undefined,
+        },
+      },
+    });
+  });
+});

--- a/workspaces/frontend/src/app/hooks/usePodTemplateOptionsListValues.ts
+++ b/workspaces/frontend/src/app/hooks/usePodTemplateOptionsListValues.ts
@@ -1,0 +1,34 @@
+import { FetchState, FetchStateCallbackPromise, useFetchState } from 'mod-arch-core';
+import { useCallback } from 'react';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import { OptionsPodTemplateOptions } from '~/generated/data-contracts';
+
+const usePodTemplateOptionsListValues = (args: {
+  kindName: string | undefined;
+  namespace: string | undefined;
+  imageId: string | undefined;
+}): FetchState<OptionsPodTemplateOptions | null> => {
+  const { kindName, namespace, imageId } = args;
+  const { api, apiAvailable } = useNotebookAPI();
+
+  const call = useCallback<
+    FetchStateCallbackPromise<OptionsPodTemplateOptions | null>
+  >(async () => {
+    if (!apiAvailable || !kindName) {
+      return Promise.reject(new Error('API not yet available'));
+    }
+    const envelope = await api.workspaceKinds.podTemplateOptionsListValues(kindName, {
+      data: {
+        context: {
+          namespace: namespace ? { name: namespace } : undefined,
+          imageConfig: imageId ? { id: imageId } : undefined,
+        },
+      },
+    });
+    return envelope.data;
+  }, [api, apiAvailable, kindName, namespace, imageId]);
+
+  return useFetchState(call, null, { initialPromisePurity: true });
+};
+
+export default usePodTemplateOptionsListValues;

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -31,6 +31,7 @@ import {
 } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection';
 import { WorkspaceFormPropertiesSelection } from '~/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSelection';
 import { WorkspaceFormData } from '~/app/types';
+import usePodTemplateOptionsListValues from '~/app/hooks/usePodTemplateOptionsListValues';
 import useWorkspaceFormData from '~/app/hooks/useWorkspaceFormData';
 import { useTypedNavigate } from '~/app/routerHelper';
 import {
@@ -86,13 +87,26 @@ const WorkspaceForm: React.FC = () => {
   const [data, setData, resetData, replaceData] =
     useGenericObjectState<WorkspaceFormData>(initialFormData);
 
+  const [allValuesData, allValuesLoaded, allValuesError] = usePodTemplateOptionsListValues({
+    kindName: data.kind?.name,
+    namespace,
+    imageId: undefined,
+  });
+
+  // Re-fetches when imageId changes to get compatibility-filtered pod configs
+  const [filteredValuesData, filteredValuesLoaded, filteredValuesError] =
+    usePodTemplateOptionsListValues({
+      kindName: data.kind?.name,
+      namespace,
+      imageId: data.imageConfig,
+    });
+
   // Store original values for edit mode diff view
   const [originalData, setOriginalData] = useState<WorkspaceFormData | undefined>(undefined);
 
   // Refs for filter control
   const imageFilterControlRef = useRef<ImageSelectionFilterHandle>(null);
   const podConfigFilterControlRef = useRef<PodConfigSelectionFilterHandle>(null);
-
   useEffect(() => {
     if (!initialFormDataLoaded || mode === 'create') {
       return;
@@ -101,6 +115,20 @@ const WorkspaceForm: React.FC = () => {
     // Store original values for diff comparison
     setOriginalData(initialFormData);
   }, [initialFormData, initialFormDataLoaded, mode, replaceData]);
+
+  // Apply default imageConfig and podConfig from listValues when a kind is first selected.
+  // Only sets defaults when the values are unset (undefined), so user selections are never overwritten.
+  useEffect(() => {
+    if (!allValuesData || !allValuesLoaded || !data.kind) {
+      return;
+    }
+    if (!data.imageConfig && allValuesData.imageConfig.default) {
+      setData('imageConfig', allValuesData.imageConfig.default);
+    }
+    if (!data.podConfig && allValuesData.podConfig.default) {
+      setData('podConfig', allValuesData.podConfig.default);
+    }
+  }, [allValuesData, allValuesLoaded, data.kind, data.imageConfig, data.podConfig, setData]);
 
   const getStepVariant = useCallback(
     (step: WorkspaceFormSteps) => {
@@ -166,19 +194,16 @@ const WorkspaceForm: React.FC = () => {
   const isCurrentStepValid = useMemo(() => isStepValid(currentStep), [isStepValid, currentStep]);
 
   const selectedImage = useMemo(
-    () =>
-      data.kind?.podTemplate.options.imageConfig.values?.find(
-        (image) => image.id === data.imageConfig,
-      ),
-    [data.kind, data.imageConfig],
+    () => allValuesData?.imageConfig.values?.find((image) => image.id === data.imageConfig),
+    [allValuesData, data.imageConfig],
   );
 
   const selectedPodConfig = useMemo(
     () =>
-      data.kind?.podTemplate.options.podConfig.values?.find(
+      (filteredValuesData ?? allValuesData)?.podConfig.values?.find(
         (podConfig) => podConfig.id === data.podConfig,
       ),
-    [data.kind, data.podConfig],
+    [filteredValuesData, allValuesData, data.podConfig],
   );
 
   const canGoToNextStep = useMemo(
@@ -239,16 +264,6 @@ const WorkspaceForm: React.FC = () => {
       if (mode === 'create') {
         resetData();
         setData('kind', kind);
-
-        const defaultImageId = kind.podTemplate.options.imageConfig.default;
-        const defaultPodConfigId = kind.podTemplate.options.podConfig.default;
-
-        if (defaultImageId) {
-          setData('imageConfig', defaultImageId);
-        }
-        if (defaultPodConfigId) {
-          setData('podConfig', defaultPodConfigId);
-        }
       }
     },
     [mode, resetData, setData],
@@ -319,6 +334,8 @@ const WorkspaceForm: React.FC = () => {
     onNavigateToStep: navigateToStep,
     onSelectImage: handleImageSelect,
     onSelectPodConfig: handlePodConfigSelect,
+    imageValues: allValuesData?.imageConfig.values ?? [],
+    podConfigValues: allValuesData?.podConfig.values ?? [],
     originalKind: originalData?.kind,
     originalImage,
     originalPodConfig,
@@ -436,24 +453,39 @@ const WorkspaceForm: React.FC = () => {
                         onSelect={handleKindSelect}
                       />
                     )}
-                    {currentStep === WorkspaceFormSteps.ImageSelection && (
-                      <WorkspaceFormImageSelection
-                        selectedImage={selectedImage}
-                        onSelect={handleImageSelect}
-                        images={data.kind?.podTemplate.options.imageConfig.values ?? []}
-                        defaultImageId={data.kind?.podTemplate.options.imageConfig.default}
-                        filterControlRef={imageFilterControlRef}
-                      />
-                    )}
-                    {currentStep === WorkspaceFormSteps.PodConfigSelection && (
-                      <WorkspaceFormPodConfigSelection
-                        selectedPodConfig={selectedPodConfig}
-                        onSelect={handlePodConfigSelect}
-                        podConfigs={data.kind?.podTemplate.options.podConfig.values ?? []}
-                        defaultPodConfigId={data.kind?.podTemplate.options.podConfig.default}
-                        filterControlRef={podConfigFilterControlRef}
-                      />
-                    )}
+                    {currentStep === WorkspaceFormSteps.ImageSelection &&
+                      (allValuesError ? (
+                        <LoadError title="Failed to load image options" error={allValuesError} />
+                      ) : !allValuesLoaded ? (
+                        <LoadingSpinner />
+                      ) : (
+                        <WorkspaceFormImageSelection
+                          selectedImage={selectedImage}
+                          onSelect={handleImageSelect}
+                          images={allValuesData?.imageConfig.values ?? []}
+                          defaultImageId={allValuesData?.imageConfig.default}
+                          filterControlRef={imageFilterControlRef}
+                        />
+                      ))}
+                    {currentStep === WorkspaceFormSteps.PodConfigSelection &&
+                      (filteredValuesError || allValuesError ? (
+                        <LoadError
+                          title="Failed to load pod config options"
+                          error={(filteredValuesError ?? allValuesError)!}
+                        />
+                      ) : !(filteredValuesLoaded || allValuesLoaded) ? (
+                        <LoadingSpinner />
+                      ) : (
+                        <WorkspaceFormPodConfigSelection
+                          selectedPodConfig={selectedPodConfig}
+                          onSelect={handlePodConfigSelect}
+                          podConfigs={(filteredValuesData ?? allValuesData)?.podConfig.values ?? []}
+                          defaultPodConfigId={
+                            (filteredValuesData ?? allValuesData)?.podConfig.default
+                          }
+                          filterControlRef={podConfigFilterControlRef}
+                        />
+                      ))}
                     {currentStep === WorkspaceFormSteps.Properties && (
                       <WorkspaceFormPropertiesSelection
                         mode={mode}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx
@@ -31,6 +31,9 @@ interface WorkspaceFormSummaryPanelProps {
   /** Handlers to switch selected options when clicking redirect target */
   onSelectImage: (image: OptionsImageConfigValue) => void;
   onSelectPodConfig: (podConfig: OptionsPodConfigValue) => void;
+  /** Filtered values from the listValues API for redirect resolution */
+  imageValues?: OptionsImageConfigValue[];
+  podConfigValues?: OptionsPodConfigValue[];
   /** For edit mode: original values to show diff */
   originalKind?: WorkspacekindsWorkspaceKindListItem;
   originalImage?: OptionsImageConfigValue;
@@ -57,6 +60,8 @@ export const WorkspaceFormSummaryPanel: React.FC<WorkspaceFormSummaryPanelProps>
   onNavigateToStep,
   onSelectImage,
   onSelectPodConfig,
+  imageValues = [],
+  podConfigValues = [],
   originalKind,
   originalImage,
   originalPodConfig,
@@ -353,21 +358,16 @@ export const WorkspaceFormSummaryPanel: React.FC<WorkspaceFormSummaryPanelProps>
         labels: selectedImage?.labels,
         redirect: selectedImage?.redirect,
         targetDisplayName: selectedImage?.redirect
-          ? selectedKind?.podTemplate.options.imageConfig.values?.find(
-              (img) => img.id === selectedImage.redirect?.to,
-            )?.displayName
+          ? imageValues.find((img) => img.id === selectedImage.redirect?.to)?.displayName
           : undefined,
-        onClickTarget:
-          selectedImage?.redirect && selectedKind
-            ? () => {
-                const targetImage = selectedKind.podTemplate.options.imageConfig.values?.find(
-                  (img) => img.id === selectedImage.redirect?.to,
-                );
-                if (targetImage) {
-                  onSelectImage(targetImage);
-                }
+        onClickTarget: selectedImage?.redirect
+          ? () => {
+              const targetImage = imageValues.find((img) => img.id === selectedImage.redirect?.to);
+              if (targetImage) {
+                onSelectImage(targetImage);
               }
-            : undefined,
+            }
+          : undefined,
         originalDisplayName: originalImage?.displayName,
         originalDescription: originalImage?.description,
         originalLabels: originalImage?.labels,
@@ -381,21 +381,18 @@ export const WorkspaceFormSummaryPanel: React.FC<WorkspaceFormSummaryPanelProps>
         labels: selectedPodConfig?.labels,
         redirect: selectedPodConfig?.redirect,
         targetDisplayName: selectedPodConfig?.redirect
-          ? selectedKind?.podTemplate.options.podConfig.values?.find(
-              (pc) => pc.id === selectedPodConfig.redirect?.to,
-            )?.displayName
+          ? podConfigValues.find((pc) => pc.id === selectedPodConfig.redirect?.to)?.displayName
           : undefined,
-        onClickTarget:
-          selectedPodConfig?.redirect && selectedKind
-            ? () => {
-                const targetPodConfig = selectedKind.podTemplate.options.podConfig.values?.find(
-                  (pc) => pc.id === selectedPodConfig.redirect?.to,
-                );
-                if (targetPodConfig) {
-                  onSelectPodConfig(targetPodConfig);
-                }
+        onClickTarget: selectedPodConfig?.redirect
+          ? () => {
+              const targetPodConfig = podConfigValues.find(
+                (pc) => pc.id === selectedPodConfig.redirect?.to,
+              );
+              if (targetPodConfig) {
+                onSelectPodConfig(targetPodConfig);
               }
-            : undefined,
+            }
+          : undefined,
         originalDisplayName: originalPodConfig?.displayName,
         originalDescription: originalPodConfig?.description,
         originalLabels: originalPodConfig?.labels,

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, useState, useImperativeHandle } from 'react';
+import React, { useRef, useMemo, useState, useImperativeHandle } from 'react';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import { WorkspaceFormImageList } from '~/app/pages/Workspaces/Form/image/WorkspaceFormImageList';
@@ -31,11 +31,9 @@ const WorkspaceFormImageSelection: React.FunctionComponent<WorkspaceFormImageSel
 }) => {
   const [filteredImages, setFilteredImages] = useState<OptionsImageConfigValue[]>(images);
   const internalFilterControlRef = useRef<FilterControlHandle>(null);
-  const lastEnsuredVisibleImageId = useRef<string | null>(null);
 
   const defaultFilterValues = useMemo(() => {
     const defaults = computeDefaultFilterValues(images, defaultImageId);
-    // Also enable filters if selectedImage needs them
     if (selectedImage) {
       if (selectedImage.hidden) {
         defaults.showHidden = true;
@@ -66,29 +64,10 @@ const WorkspaceFormImageSelection: React.FunctionComponent<WorkspaceFormImageSel
     [defaultFilterValues],
   );
 
-  useEffect(() => {
-    if (!selectedImage) {
-      return;
-    }
-
-    // Skip deselection if we just ensured this image is visible
-    if (lastEnsuredVisibleImageId.current === selectedImage.id) {
-      lastEnsuredVisibleImageId.current = null;
-      return;
-    }
-
-    const isSelectedInFilteredList = filteredImages.some((image) => image.id === selectedImage.id);
-
-    if (!isSelectedInFilteredList) {
-      onSelect(undefined);
-    }
-  }, [filteredImages, selectedImage, onSelect]);
-
   useImperativeHandle(
     filterControlRef,
     () => ({
       adaptFiltersForImage: (image: OptionsImageConfigValue) => {
-        lastEnsuredVisibleImageId.current = image.id;
         internalFilterControlRef.current?.clearAllFilters();
         if (image.hidden) {
           internalFilterControlRef.current?.setExtraFilter('showHidden', true);

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, useState, useImperativeHandle } from 'react';
+import React, { useRef, useMemo, useState, useImperativeHandle } from 'react';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import { WorkspaceFormPodConfigList } from '~/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList';
@@ -27,11 +27,9 @@ const WorkspaceFormPodConfigSelection: React.FunctionComponent<
 > = ({ podConfigs, selectedPodConfig, onSelect, defaultPodConfigId, filterControlRef }) => {
   const [filteredPodConfigs, setFilteredPodConfigs] = useState<OptionsPodConfigValue[]>(podConfigs);
   const internalFilterControlRef = useRef<FilterControlHandle>(null);
-  const lastEnsuredVisiblePodConfigId = useRef<string | null>(null);
 
   const defaultFilterValues = useMemo(() => {
     const defaults = computeDefaultFilterValues(podConfigs, defaultPodConfigId);
-    // Also enable filters if selectedPodConfig needs them
     if (selectedPodConfig) {
       if (selectedPodConfig.hidden) {
         defaults.showHidden = true;
@@ -63,31 +61,10 @@ const WorkspaceFormPodConfigSelection: React.FunctionComponent<
     [defaultFilterValues],
   );
 
-  useEffect(() => {
-    if (!selectedPodConfig) {
-      return;
-    }
-
-    // Skip deselection if we just ensured this pod config is visible
-    if (lastEnsuredVisiblePodConfigId.current === selectedPodConfig.id) {
-      lastEnsuredVisiblePodConfigId.current = null;
-      return;
-    }
-
-    const isSelectedInFilteredList = filteredPodConfigs.some(
-      (podConfig) => podConfig.id === selectedPodConfig.id,
-    );
-
-    if (!isSelectedInFilteredList) {
-      onSelect(undefined);
-    }
-  }, [filteredPodConfigs, selectedPodConfig, onSelect]);
-
   useImperativeHandle(
     filterControlRef,
     () => ({
       adaptFiltersForPodConfig: (podConfig: OptionsPodConfigValue) => {
-        lastEnsuredVisiblePodConfigId.current = podConfig.id;
         internalFilterControlRef.current?.clearAllFilters();
         if (podConfig.hidden) {
           internalFilterControlRef.current?.setExtraFilter('showHidden', true);

--- a/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
@@ -103,7 +103,6 @@ export const mockNotebookApisImpl = (): NotebookApis => ({
     },
     podTemplateOptionsListValues: async (_name, body) => {
       const imageId = body.data.context.imageConfig?.id;
-
       let podConfigs = mockListValuesPodConfigs;
       if (imageId) {
         const selectedImage = mockListValuesImages.find((img) => img.id === imageId);

--- a/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
@@ -3,6 +3,8 @@ import { NotebookApis } from '~/shared/api/notebookApi';
 import {
   mockAllWorkspaces,
   mockedHealthCheckResponse,
+  mockListValuesImages,
+  mockListValuesPodConfigs,
   mockNamespaces,
   mockPVCCreate,
   mockPVCsList,
@@ -87,12 +89,6 @@ export const mockNotebookApisImpl = (): NotebookApis => ({
     deleteWorkspaceKind: async () => {
       await delay(1500);
     },
-    podTemplateOptionsListValues: async () => ({
-      data: {
-        imageConfig: { default: '' },
-        podConfig: { default: '' },
-      },
-    }),
     getWorkspaceKindIcon: async () => {
       const response = await fetch(
         'https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png',
@@ -104,6 +100,35 @@ export const mockNotebookApisImpl = (): NotebookApis => ({
         'https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg',
       );
       return (await response.blob()) as unknown as File;
+    },
+    podTemplateOptionsListValues: async (_name, body) => {
+      const imageId = body.data.context.imageConfig?.id;
+
+      let podConfigs = mockListValuesPodConfigs;
+      if (imageId) {
+        const selectedImage = mockListValuesImages.find((img) => img.id === imageId);
+        const isGpuImage = selectedImage?.labels?.some(
+          (l) => l.key === 'gpuRequired' && l.value === 'true',
+        );
+        if (!isGpuImage) {
+          podConfigs = podConfigs.filter((pc) => !pc.labels?.some((l) => l.key === 'gpu'));
+        }
+      }
+
+      return {
+        data: {
+          imageConfig: {
+            default: mockListValuesImages[0]?.id ?? '',
+            values: imageId
+              ? mockListValuesImages.filter((img) => img.id === imageId)
+              : mockListValuesImages,
+          },
+          podConfig: {
+            default: mockListValuesPodConfigs[0]?.id ?? '',
+            values: podConfigs,
+          },
+        },
+      };
     },
     createWorkspaceKind: async (body) => {
       if (isInvalidYaml(body)) {

--- a/workspaces/frontend/src/shared/mock/mockNotebookServiceData.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookServiceData.ts
@@ -1,4 +1,6 @@
 import {
+  OptionsImageConfigValue,
+  OptionsPodConfigValue,
   PvcsPVCCreate,
   SecretsSecretCreate,
   V1Beta1WorkspaceState,
@@ -587,3 +589,37 @@ export const mockPVCCreate: PvcsPVCCreate = buildMockPVCCreate({
   requests: { storage: '10Gi' },
   storageClassName: 'standard',
 });
+
+// ListValues mock data — extends kind values with CUDA image + GPU pod config
+const defaultKind = buildMockWorkspaceKind();
+
+export const mockListValuesImages: OptionsImageConfigValue[] = [
+  ...(defaultKind.podTemplate.options.imageConfig.values ?? []),
+  {
+    id: 'jupyterlab_scipy_210_cuda',
+    displayName: 'jupyter-scipy:v2.1.0-cuda',
+    description: 'JupyterLab with SciPy Packages and CUDA support for GPU workloads',
+    labels: [
+      { key: 'pythonVersion', value: '3.13' },
+      { key: 'jupyterlabVersion', value: '2.1.0' },
+      { key: 'cuda', value: '12.4' },
+      { key: 'gpuRequired', value: 'true' },
+    ],
+    hidden: false,
+  },
+];
+
+export const mockListValuesPodConfigs: OptionsPodConfigValue[] = [
+  ...(defaultKind.podTemplate.options.podConfig.values ?? []),
+  {
+    id: 'big_gpu',
+    displayName: 'Big GPU',
+    description: 'Pod with 4 CPU, 16 GB RAM, and 1 GPU',
+    hidden: false,
+    labels: [
+      { key: 'cpu', value: '4000m' },
+      { key: 'memory', value: '16Gi' },
+      { key: 'gpu', value: '1' },
+    ],
+  },
+];


### PR DESCRIPTION
closes: #861 


Integrates the POST /workspacekinds/{name}/podtemplate/options/listvalues API endpoint into the Workspace Wizard form. Image and Pod Config options are now fetched via listValues instead of reading inline values from the WorkspaceKind object, enabling future compatibility selector filtering (e.g., hiding GPU pod configs when a CPU-only image is selected).

What changed

**New hook: usePodTemplateOptionsListValues**
- Wraps the podTemplateOptionsListValues API call with useFetchState
- Accepts kindName, namespace, and optional imageId context
- Uses initialPromisePurity: true to reset state on kind changes, preventing stale data from leaking across kind switches

**WorkspaceForm — two-call architecture**
- allValuesData: fetches all images + pod configs (no imageId context) — used for the Image step, defaults, selectedImage, and summary panel
- filteredValuesData: fetches with imageId context for compatible pod configs — only fires when data.imageConfig is set, gated by kindName to avoid redundant calls
- Defaults (imageConfig/podConfig) are applied once from allValuesData when it first loads for a kind
- Loading spinners shown on Image and Pod Config steps while data loads

**WorkspaceFormSummaryPanel**
- Added imageValues and podConfigValues props for redirect target resolution (previously read from selectedKind inline values)

**Removed deselection useEffect from Image/PodConfig selection components**
- The effect that called onSelect(undefined) when a selected item was hidden by filters caused an infinite loop with the defaults effect (deselect → re-apply default → deselect)
- Selection now persists even when the card is hidden by UI filters — the ID remains valid, the card just isn't rendered
- Better [UX](https://www.patternfly.org/patterns/filters/#filtering-demos) 

**Mock data**
- mockNotebookServiceData.ts: added mockListValuesImages (with CUDA variant) and mockListValuesPodConfigs (with GPU pod config)
- mockNotebookApis.ts: handler now inspects imageConfig.id from request body and filters GPU pod configs for non-GPU images

**Cypress tests**
- Added POST listvalues endpoint to interceptApi type system
- Created interceptListValues helper with dynamic route handler that filters images by imageConfig.id from request body
- Added interceptListValues calls to all 14 Cypress test files that navigate past the Kind step
- Added 3 new listValues test cases in createWorkspace.cy.ts (all options visible, CPU-only options, default auto-selection)

**Unit tests**
- 5 tests for usePodTemplateOptionsListValues hook (API unavailable, kindName undefined, successful call, imageId context, no namespace)