### PR TITLE
fix: pass namespace to list workspacekinds on workspace edit

### DIFF
--- a/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
@@ -43,6 +43,31 @@ describe('useWorkspaceFormData', () => {
     expect(workspaceFormData).toEqual(EMPTY_FORM_DATA);
   });
 
+  it('returns error when workspace kinds fail to load', async () => {
+    mockUseNotebookAPI.mockReturnValue({
+      api: {} as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const kindsError = new Error('Failed to fetch workspace kinds');
+    mockUseWorkspaceKinds.mockReturnValue([[], false, kindsError, jest.fn()]);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useWorkspaceFormData({
+        namespace: 'ns',
+        workspaceName: 'my-workspace',
+        workspaceKindName: 'jupyterlab',
+      }),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toEqual(EMPTY_FORM_DATA);
+    expect(loaded).toBe(false);
+    expect(error).toBeDefined();
+  });
+
   it('maps workspace and kind into form data when API available', async () => {
     const mockWorkspace = buildMockWorkspace({});
     const mockWorkspaceUpdate = buildMockWorkspaceUpdateFromWorkspace({ workspace: mockWorkspace });

--- a/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '~/__tests__/unit/testUtils/hooks';
 import useWorkspaceFormData, { EMPTY_FORM_DATA } from '~/app/hooks/useWorkspaceFormData';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { NotebookApis } from '~/shared/api/notebookApi';
 import {
   buildMockWorkspace,
@@ -12,11 +13,15 @@ jest.mock('~/app/hooks/useNotebookAPI', () => ({
   useNotebookAPI: jest.fn(),
 }));
 
+jest.mock('~/app/hooks/useWorkspaceKinds', () => jest.fn());
+
 const mockUseNotebookAPI = useNotebookAPI as jest.MockedFunction<typeof useNotebookAPI>;
+const mockUseWorkspaceKinds = useWorkspaceKinds as jest.MockedFunction<typeof useWorkspaceKinds>;
 
 describe('useWorkspaceFormData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseWorkspaceKinds.mockReturnValue([[], false, undefined, jest.fn()]);
   });
 
   it('returns empty form data when missing namespace or name', async () => {
@@ -46,11 +51,9 @@ describe('useWorkspaceFormData', () => {
       ok: true,
       data: mockWorkspaceUpdate,
     });
-    const listWorkspaceKinds = jest.fn().mockResolvedValue({ ok: true, data: [mockWorkspaceKind] });
 
     const api = {
       workspaces: { getWorkspace },
-      workspaceKinds: { listWorkspaceKinds },
     } as unknown as NotebookApis;
 
     mockUseNotebookAPI.mockReturnValue({
@@ -58,6 +61,8 @@ describe('useWorkspaceFormData', () => {
       apiAvailable: true,
       refreshAllAPI: jest.fn(),
     });
+
+    mockUseWorkspaceKinds.mockReturnValue([[mockWorkspaceKind], true, undefined, jest.fn()]);
 
     const { result, waitForNextUpdate } = renderHook(() =>
       useWorkspaceFormData({
@@ -92,5 +97,7 @@ describe('useWorkspaceFormData', () => {
       },
       revision: mockWorkspaceUpdate.revision,
     });
+
+    expect(mockUseWorkspaceKinds).toHaveBeenCalledWith('ns');
   });
 });

--- a/workspaces/frontend/src/app/hooks/useWorkspaceFormData.ts
+++ b/workspaces/frontend/src/app/hooks/useWorkspaceFormData.ts
@@ -24,7 +24,7 @@ const useWorkspaceFormData = (args: {
 }): FetchState<WorkspaceFormData> => {
   const { namespace, workspaceName, workspaceKindName } = args;
   const { api, apiAvailable } = useNotebookAPI();
-  const [workspaceKinds, workspaceKindsLoaded] = useWorkspaceKinds(namespace);
+  const [workspaceKinds, workspaceKindsLoaded, workspaceKindsError] = useWorkspaceKinds(namespace);
 
   const call = useCallback<FetchStateCallbackPromise<WorkspaceFormData>>(async () => {
     if (!apiAvailable) {
@@ -33,6 +33,10 @@ const useWorkspaceFormData = (args: {
 
     if (!namespace || !workspaceName || !workspaceKindName) {
       return EMPTY_FORM_DATA;
+    }
+
+    if (workspaceKindsError) {
+      return Promise.reject(workspaceKindsError);
     }
 
     if (!workspaceKindsLoaded) {
@@ -80,6 +84,7 @@ const useWorkspaceFormData = (args: {
     workspaceKindName,
     workspaceKinds,
     workspaceKindsLoaded,
+    workspaceKindsError,
   ]);
 
   return useFetchState(call, EMPTY_FORM_DATA);

--- a/workspaces/frontend/src/app/hooks/useWorkspaceFormData.ts
+++ b/workspaces/frontend/src/app/hooks/useWorkspaceFormData.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
-import { FetchState, FetchStateCallbackPromise, useFetchState } from 'mod-arch-core';
+import { FetchState, FetchStateCallbackPromise, useFetchState, NotReadyError } from 'mod-arch-core';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { WorkspaceFormData } from '~/app/types';
 
 export const EMPTY_FORM_DATA: WorkspaceFormData = {
@@ -23,6 +24,7 @@ const useWorkspaceFormData = (args: {
 }): FetchState<WorkspaceFormData> => {
   const { namespace, workspaceName, workspaceKindName } = args;
   const { api, apiAvailable } = useNotebookAPI();
+  const [workspaceKinds, workspaceKindsLoaded] = useWorkspaceKinds(namespace);
 
   const call = useCallback<FetchStateCallbackPromise<WorkspaceFormData>>(async () => {
     if (!apiAvailable) {
@@ -33,12 +35,13 @@ const useWorkspaceFormData = (args: {
       return EMPTY_FORM_DATA;
     }
 
-    const [workspaceEnvelope, workspaceKindsEnvelope] = await Promise.all([
-      api.workspaces.getWorkspace(namespace, workspaceName),
-      api.workspaceKinds.listWorkspaceKinds({}),
-    ]);
+    if (!workspaceKindsLoaded) {
+      return Promise.reject(new NotReadyError('Workspace kinds not yet available'));
+    }
+
+    const workspaceEnvelope = await api.workspaces.getWorkspace(namespace, workspaceName);
     const workspaceUpdate = workspaceEnvelope.data;
-    const workspaceKind = workspaceKindsEnvelope.data.find((k) => k.name === workspaceKindName);
+    const workspaceKind = workspaceKinds.find((k) => k.name === workspaceKindName);
     const { imageConfig, podConfig } = workspaceUpdate.podTemplate.options;
 
     return {
@@ -69,7 +72,15 @@ const useWorkspaceFormData = (args: {
           : undefined,
       },
     };
-  }, [api, apiAvailable, namespace, workspaceName, workspaceKindName]);
+  }, [
+    api,
+    apiAvailable,
+    namespace,
+    workspaceName,
+    workspaceKindName,
+    workspaceKinds,
+    workspaceKindsLoaded,
+  ]);
 
   return useFetchState(call, EMPTY_FORM_DATA);
 };


### PR DESCRIPTION
Closes: #1102 

When editing a Workspace via the UI, non-admin users received a 403 error. The root cause was that useWorkspaceFormData called listWorkspaceKinds({}) directly — without the namespaceFilter query parameter. Without namespaceFilter, the backend checks for cluster-level "list WorkspaceKinds" permission instead of the namespace-scoped "create Workspaces" permission that regular users have.

The create flow worked because WorkspaceFormKindSelection fetches kinds through useWorkspaceKinds(namespace), which always includes namespaceFilter. The edit flow bypassed that code path entirely.

Rather than just adding namespaceFilter to the raw API call, this fix replaces the direct listWorkspaceKinds({}) call with the shared useWorkspaceKinds(namespace) hook. Both the edit flow (useWorkspaceFormData) and the create flow (WorkspaceFormKindSelection) now go through the same code path, so they cannot diverge on authorization behavior.