### PR TITLE
ci: automatically approve tests for org members

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -16,12 +16,34 @@ concurrency:
 
 jobs:
   ok-to-test:
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
+      - name: Check if author is a Kubeflow GitHub member
+        id: membership-check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const username = context.payload.pull_request.user.login;
+            const org = context.repo.owner;
+            try {
+              const res = await github.rest.orgs.checkMembershipForUser({
+                org,
+                username
+              });
+              core.setOutput("is_member", true);
+            } catch (error) {
+              if (error.status === 404) {
+                core.setOutput("is_member", false);
+              } else {
+                throw error;
+              }
+            }
+
       - name: Approve Pending Workflow Runs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: steps.membership-check.outputs.is_member == 'true' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
         with:
           retries: 3
           script: |
@@ -32,10 +54,10 @@ jobs:
               status: "action_required",
               head_sha: context.payload.pull_request.head.sha,
             }
-            
+
             core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
             const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
-            
+
             core.info(`Found ${runs.length} workflow runs that need approval`)
             for (const run of runs) {
               core.info(`Approving workflow run ${run.id}`)


### PR DESCRIPTION
The idea behind this is that they could set the 'ok-to-test' label
anyways via prow and it eases the burden of the maintainers having to do
this manually for org members.

The code is taken from the way that `kubeflow/sdk` does it for their
equivalent job.

Link: https://github.com/kubeflow/sdk/blob/main/.github/workflows/gh-workflow-approve.yaml

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
