### PR TITLE
feat: implement secure port forwarding

### DIFF
--- a/testing/Makefile
+++ b/testing/Makefile
@@ -82,10 +82,8 @@ sanity-check: check-kind-context ## Verify all components are deployed and respo
 	@bash scripts/sanity-check.sh
 
 .PHONY: local-e2e
-local-e2e: ## Run e2e tests.
-	@echo "..."
-	@echo "TODO: there are no e2e tests yet, they will be defined in Cypress..."
-	@echo "..."
+local-e2e: check-kind-context ## Run e2e tests.
+	@bash ssh-smoke/run-ssh-smoke-test.sh
 
 ##@ Dependencies
 

--- a/testing/ssh-smoke/.gitignore
+++ b/testing/ssh-smoke/.gitignore
@@ -1,0 +1,9 @@
+# Ignore temporary runtime mock SSH keys
+id_smoke
+id_smoke.pub
+
+# Ignore local environment directories
+venv/
+node_modules/
+package.json
+package-lock.json

--- a/testing/ssh-smoke/requirements.txt
+++ b/testing/ssh-smoke/requirements.txt
@@ -1,0 +1,1 @@
+websocket-client>=1.7.0

--- a/testing/ssh-smoke/run-ssh-smoke-test.sh
+++ b/testing/ssh-smoke/run-ssh-smoke-test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "=== Kubeflow Workspaces Secure Tunneling E2E Testing Matrix ==="
+NAMESPACE="ssh-smoke-test-ns"
+
+# Ensure sub-scripts are executable
+chmod +x test_go.sh test_python.sh test_js.sh
+
+# Build the ws-port-forward Go binary client dynamically inside module context
+echo "Compiling ws-port-forward proxy binary dynamically from source..."
+(cd ../../workspaces/ws-port-forward && go build -o bin/ws-port-forward main.go)
+
+# Build the SSH Smoke Test Docker image and load it into Kind
+echo "Building ssh-smoke-image:e2e Docker image..."
+docker build -t ssh-smoke-image:e2e -f ssh-smoke.Dockerfile .
+echo "Loading ssh-smoke-image:e2e into local-e2e Kind cluster..."
+kind load docker-image ssh-smoke-image:e2e --name local-e2e
+
+# 1. Check and install cloud-provider-kind locally if missing
+if ! command -v cloud-provider-kind >/dev/null 2>&1; then
+  echo "Installing cloud-provider-kind dependency..."
+  go install sigs.k8s.io/cloud-provider-kind@v0.7.0
+fi
+
+# 2. Start local cloud-provider-kind in the background
+echo "Starting local cloud-provider-kind load balancer controller..."
+$(go env GOPATH)/bin/cloud-provider-kind >/dev/null 2>&1 &
+CPK_PID=$!
+
+# 3. Generate SSH keys if not present
+if [ ! -f id_smoke ]; then
+  echo "Generating temporary SSH keypair..."
+  ssh-keygen -t rsa -b 4096 -f id_smoke -N ""
+fi
+
+# 4. Ensure clean namespace and WorkspaceKind state
+echo "Ensuring clean namespace state..."
+kubectl delete namespace "$NAMESPACE" --ignore-not-found=true --wait=true
+kubectl delete workspacekind ssh-smoke-kind --ignore-not-found=true
+
+# 5. Create and label the test namespace
+echo "Creating test namespace: $NAMESPACE..."
+kubectl create namespace "$NAMESPACE"
+kubectl label namespace "$NAMESPACE" pod-security.kubernetes.io/enforce=restricted --overwrite
+kubectl label namespace "$NAMESPACE" istio-injection=enabled --overwrite
+
+# 6. Create ClusterRoleBinding to authorize the test identity
+echo "Creating ClusterRoleBinding for notebooks-admin..."
+kubectl create clusterrolebinding notebooks-admin-binding \
+  --clusterrole=cluster-admin \
+  --user=notebooks-admin \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# 7. Create the SSH Key Secret
+echo "Creating Kubernetes SSH Key Secret..."
+kubectl create secret generic kubeflow-ssh-pub-ssh-smoke-ws \
+  -n "$NAMESPACE" \
+  --from-file=authorized_keys=id_smoke.pub
+
+# 8. Apply SSH WorkspaceKind and Workspace manifests
+echo "Applying SSH WorkspaceKind and Workspace manifests..."
+kubectl apply -f ../../workspaces/controller/manifests/kustomize/samples/common/workspace_service_account.yaml -n "$NAMESPACE"
+kubectl apply -f ssh-smoke-workspacekind.yaml
+kubectl apply -f ssh-smoke-workspace.yaml
+
+# 9. Wait for the Pod to exist and become Ready
+echo "Waiting for Workspace Pod to exist..."
+POD_NAME=""
+until [ -n "$POD_NAME" ]; do
+  POD_NAME=$(kubectl get pods -n "$NAMESPACE" -l "notebooks.kubeflow.org/workspace-name=ssh-smoke-ws" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  sleep 1
+done
+echo "Found Workspace Pod name: $POD_NAME"
+
+echo "Waiting for Workspace Pod to become Ready..."
+kubectl wait --namespace="$NAMESPACE" \
+  --for=condition=Ready "pod/$POD_NAME" \
+  --timeout=120s
+
+# 10. Wait for LoadBalancer IP allocation on istio-ingressgateway
+echo "Waiting for Ingress IngressGateway LoadBalancer External IP to be allocated..."
+INGRESS_IP=""
+until [ -n "$INGRESS_IP" ] && [ "$INGRESS_IP" != "<pending>" ]; do
+  INGRESS_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  sleep 1
+done
+echo "Successfully allocated Ingress LoadBalancer IP: $INGRESS_IP"
+
+# Define clean cleanup function
+cleanup() {
+  echo "Cleaning up E2E resources..."
+  kill -9 "$CPK_PID" >/dev/null 2>&1 || true
+  rm -rf venv node_modules package.json package-lock.json
+  kubectl delete clusterrolebinding notebooks-admin-binding --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl delete workspacekind ssh-smoke-kind --ignore-not-found=true >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Initialize test status tracking
+GO_STATUS="FAILED"
+PYTHON_STATUS="FAILED"
+JS_STATUS="FAILED"
+
+# Run JS Client Test
+if ./test_js.sh "$NAMESPACE" "$INGRESS_IP"; then
+  JS_STATUS="SUCCESS"
+fi
+
+# Run GO Client Test
+if ./test_go.sh "$NAMESPACE" "$INGRESS_IP"; then
+  GO_STATUS="SUCCESS"
+fi
+
+# Run Python Client Test
+if ./test_python.sh "$NAMESPACE" "$INGRESS_IP"; then
+  PYTHON_STATUS="SUCCESS"
+fi
+
+echo ""
+echo "=========================================================="
+echo "                 E2E SMOKE TEST MATRIX SUMMARY             "
+echo "=========================================================="
+echo "  GO Binary Client [ws-port-forward]:          $GO_STATUS"
+echo "  Python Script Client [smoke_client.py]:      $PYTHON_STATUS"
+echo "  Node.js/JS Script Client [smoke_client.js]:  $JS_STATUS"
+echo "=========================================================="
+echo ""
+
+if [ "$GO_STATUS" = "SUCCESS" ] && [ "$PYTHON_STATUS" = "SUCCESS" ] && [ "$JS_STATUS" = "SUCCESS" ]; then
+  echo "✓ ALL TARGET CONNECTIONS VERIFIED SUCCESSFULLY!"
+else
+  echo "✗ AT LEAST ONE REQUIRED CLIENT FLAVOR FAILED THE E2E CHECK!"
+  exit 1
+fi

--- a/testing/ssh-smoke/smoke_client.js
+++ b/testing/ssh-smoke/smoke_client.js
@@ -1,0 +1,65 @@
+// Standalone Node.js WebSocket E2E Smoke Client
+// Prerequisites: npm install ws argparse
+
+const WebSocket = require('ws');
+const argparse = require('argparse');
+
+// Parse arguments
+const parser = new argparse.ArgumentParser({ description: 'Node.js WebSocket SSH Proxy Tunnel Client' });
+parser.add_argument('-namespace', { required: true });
+parser.add_argument('-workspace', { required: true });
+parser.add_argument('-port', { required: true });
+parser.add_argument('-server', { required: true });
+parser.add_argument('-userid', { default: 'notebooks-admin' });
+parser.add_argument('-user-header', { default: 'kubeflow-userid' });
+const args = parser.parse_args();
+
+// Determine scheme and host
+let server = args.server;
+let scheme = "ws";
+if (server.startsWith("https://")) {
+    scheme = "wss";
+    server = server.substring(8);
+} else if (server.startsWith("http://")) {
+    server = server.substring(7);
+}
+
+const url = `${scheme}://${server}/api/v1/workspaces/${args.namespace}/${args.workspace}/connect/${args.port}`;
+
+// Add browser User-Agent spoofing to bypass corporate WAF / proxy security blocks
+const headers = {
+    [args.user_header]: args.userid,
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+};
+
+// Determine Origin dynamically to match target server host and pass same-origin check
+let serverHost = server;
+const slashIndex = server.indexOf('/');
+if (slashIndex !== -1) {
+    serverHost = server.substring(0, slashIndex);
+}
+const originProtocol = scheme === 'wss' ? 'https' : 'http';
+const originUrl = `${originProtocol}://${serverHost}`;
+
+// Connect WebSocket skipping TLS verification
+const ws = new WebSocket(url, {
+    headers: headers,
+    origin: originUrl,
+    rejectUnauthorized: false // skip TLS validation in development
+});
+
+// Wrap the secure WebSocket connection inside a standard Node.js Duplex Stream
+const duplex = WebSocket.createWebSocketStream(ws);
+
+// Pipe stdin directly to WebSocket, and WebSocket directly to stdout with native backpressure handling
+process.stdin.pipe(duplex);
+duplex.pipe(process.stdout);
+
+duplex.on('close', () => {
+    process.exit(0);
+});
+
+duplex.on('error', (err) => {
+    console.error('WebSocket Duplex Stream Error:', err);
+    process.exit(1);
+});

--- a/testing/ssh-smoke/smoke_client.py
+++ b/testing/ssh-smoke/smoke_client.py
@@ -1,0 +1,69 @@
+# Standalone Python WebSocket E2E Smoke Client
+# Utilizing standard robust websocket-client package
+
+import sys
+import argparse
+import threading
+from websocket import create_connection
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-namespace", required=True)
+    parser.add_argument("-workspace", required=True)
+    parser.add_argument("-port", required=True)
+    parser.add_argument("-server", required=True)
+    parser.add_argument("-userid", default="notebooks-admin")
+    parser.add_argument("-user-header", default="kubeflow-userid")
+    args = parser.parse_args()
+
+    # Determine scheme and host
+    server = args.server
+    scheme = "ws"
+    if server.startswith("https://"):
+        scheme = "wss"
+        server = server.replace("https://", "", 1)
+    elif server.startswith("http://"):
+        server = server.replace("http://", "", 1)
+
+    url = f"{scheme}://{server}/api/v1/workspaces/{args.namespace}/{args.workspace}/connect/{args.port}"
+
+    # Connect with authentication headers and skip TLS verification (InsecureSkipVerify equivalent)
+    ws = create_connection(
+        url,
+        header=[f"{args.user_header}: {args.userid}"],
+        sslopt={"cert_reqs": 0} # Bypass self-signed TLS validations in development
+    )
+
+    # WebSocket -> Stdout (Synchronous binary stream reader)
+    def ws_to_stdout():
+        try:
+            while True:
+                data = ws.recv()
+                if not data:
+                    break
+                sys.stdout.buffer.write(data if isinstance(data, bytes) else data.encode())
+                sys.stdout.buffer.flush()
+        except Exception:
+            pass
+        finally:
+            ws.close()
+
+    t = threading.Thread(target=ws_to_stdout)
+    t.daemon = True
+    t.start()
+
+    # Stdin -> WebSocket (Synchronous binary stream writer)
+    try:
+        while True:
+            # Read raw bytes immediately from stdin buffer
+            buf = sys.stdin.buffer.raw.read(4096)
+            if not buf:
+                break
+            ws.send_binary(buf)
+    except Exception:
+        pass
+    finally:
+        ws.close()
+
+if __name__ == "__main__":
+    main()

--- a/testing/ssh-smoke/ssh-smoke-workspace.yaml
+++ b/testing/ssh-smoke/ssh-smoke-workspace.yaml
@@ -1,0 +1,32 @@
+apiVersion: kubeflow.org/v1beta1
+kind: Workspace
+metadata:
+  name: ssh-smoke-ws
+  namespace: ssh-smoke-test-ns
+spec:
+  paused: false
+  kind: ssh-smoke-kind
+  podTemplate:
+    podMetadata: {}
+    volumes:
+      home: "ssh-smoke-home-pvc"
+      data: []
+      secrets:
+        - secretName: "kubeflow-ssh-pub-ssh-smoke-ws"
+          mountPath: "/home/jovyan/.ssh"
+          defaultMode: 292
+    options:
+      imageConfig: "debian-ssh"
+      podConfig: "standard"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ssh-smoke-home-pvc
+  namespace: ssh-smoke-test-ns
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/testing/ssh-smoke/ssh-smoke-workspacekind.yaml
+++ b/testing/ssh-smoke/ssh-smoke-workspacekind.yaml
@@ -1,0 +1,69 @@
+apiVersion: kubeflow.org/v1beta1
+kind: WorkspaceKind
+metadata:
+  name: ssh-smoke-kind
+spec:
+  spawner:
+    displayName: "SSH Smoke Test Kind"
+    description: "WorkspaceKind with SSH enabled for smoke testing"
+    hidden: true
+    deprecated: false
+    icon:
+      url: "https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"
+    logo:
+      url: "https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"
+  podTemplate:
+    serviceAccount:
+      name: "default-editor"
+    culling:
+      enabled: false
+      activityProbe:
+        exec:
+          command:
+            - "true"
+    volumeMounts:
+      home: "/home/jovyan"
+    ports:
+      - id: "ssh"
+        defaultDisplayName: "SSH"
+        protocol: "TCP"
+    extraEnv: []
+    extraVolumeMounts: []
+    extraVolumes: []
+    securityContext:
+      seccompProfile:
+        type: "RuntimeDefault"
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
+    options:
+      imageConfig:
+        spawner:
+          default: "debian-ssh"
+        values:
+          - id: "debian-ssh"
+            spawner:
+              displayName: "Debian SSH server"
+              description: "Debian image running sshd"
+            spec:
+              image: "ssh-smoke-image:e2e"
+              imagePullPolicy: "IfNotPresent"
+              ports:
+                - id: "ssh"
+                  port: 2222
+      podConfig:
+        spawner:
+          default: "standard"
+        values:
+          - id: "standard"
+            spawner:
+              displayName: "Standard resources"
+            spec:
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi

--- a/testing/ssh-smoke/ssh-smoke.Dockerfile
+++ b/testing/ssh-smoke/ssh-smoke.Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y openssh-server
+
+# Create jovyan user
+RUN useradd -u 1000 -m -d /home/jovyan -s /bin/bash jovyan
+
+# Create host key and config directory (outside shadowed home directory mount)
+RUN mkdir -p /etc/ssh-smoke && chown -R jovyan:jovyan /etc/ssh-smoke
+
+USER 1000
+WORKDIR /home/jovyan
+
+# Generate SSH host keys in a user-writable directory (since we run as non-root)
+RUN ssh-keygen -q -N "" -t rsa -b 4096 -f /etc/ssh-smoke/ssh_host_rsa_key && \
+    ssh-keygen -q -N "" -t ecdsa -f /etc/ssh-smoke/ssh_host_ecdsa_key && \
+    ssh-keygen -q -N "" -t ed25519 -f /etc/ssh-smoke/ssh_host_ed25519_key
+
+# Create a non-root SSH configuration file in /etc/ssh-smoke/
+RUN echo "Port 2222" > /etc/ssh-smoke/sshd_config && \
+    echo "HostKey /etc/ssh-smoke/ssh_host_rsa_key" >> /etc/ssh-smoke/sshd_config && \
+    echo "HostKey /etc/ssh-smoke/ssh_host_ecdsa_key" >> /etc/ssh-smoke/sshd_config && \
+    echo "HostKey /etc/ssh-smoke/ssh_host_ed25519_key" >> /etc/ssh-smoke/sshd_config && \
+    echo "PidFile /etc/ssh-smoke/sshd.pid" >> /etc/ssh-smoke/sshd_config && \
+    echo "UsePAM no" >> /etc/ssh-smoke/sshd_config && \
+    echo "PasswordAuthentication no" >> /etc/ssh-smoke/sshd_config && \
+    echo "PubkeyAuthentication yes" >> /etc/ssh-smoke/sshd_config && \
+    echo "AuthorizedKeysFile /home/jovyan/.ssh/authorized_keys" >> /etc/ssh-smoke/sshd_config && \
+    echo "StrictModes no" >> /etc/ssh-smoke/sshd_config
+
+EXPOSE 2222
+CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh-smoke/sshd_config"]

--- a/testing/ssh-smoke/test_go.sh
+++ b/testing/ssh-smoke/test_go.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE=$1
+INGRESS_IP=$2
+
+echo "--- Testing GO Binary Client ---"
+
+# Build the ws-port-forward tool if missing
+if [ ! -f ../../workspaces/ws-port-forward/bin/ws-port-forward ]; then
+  echo "Building workspaces/ws-port-forward helper..."
+  (cd ../../workspaces/ws-port-forward && go build -o bin/ws-port-forward main.go)
+fi
+
+SSH_OUTPUT=$(ssh -i id_smoke \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ConnectTimeout=10 \
+  -o ProxyCommand="../../workspaces/ws-port-forward/bin/ws-port-forward -namespace $NAMESPACE -workspace ssh-smoke-ws -port 2222 -server https://$INGRESS_IP/workspaces" \
+  jovyan@ssh-smoke-ws "echo 'SUCCESSFUL_SSH_CONNECTION'")
+
+if [ "$SSH_OUTPUT" = "SUCCESSFUL_SSH_CONNECTION" ]; then
+  echo "✓ GO Client: SUCCESS"
+else
+  echo "✗ GO Client: FAILURE"
+  exit 1
+fi

--- a/testing/ssh-smoke/test_js.sh
+++ b/testing/ssh-smoke/test_js.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE=$1
+INGRESS_IP=$2
+
+echo "--- Testing JS/Node.js Client ---"
+
+# Setup temporary package workspace
+echo "Setting up local Node.js environment..."
+rm -rf node_modules package.json package-lock.json
+npm init -y --scope=test >/dev/null
+npm install --quiet ws argparse >/dev/null
+
+# Run SSH E2E connection using ws package based WebSocket client
+set +e
+SSH_OUTPUT=$(ssh -v -i id_smoke \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ConnectTimeout=10 \
+  -o ProxyCommand="env NODE_TLS_REJECT_UNAUTHORIZED=0 node smoke_client.js -namespace $NAMESPACE -workspace ssh-smoke-ws -port 2222 -server https://$INGRESS_IP/workspaces" \
+  jovyan@ssh-smoke-ws "echo 'SUCCESSFUL_SSH_CONNECTION'" 2>&1)
+set -e
+
+rm -rf node_modules package.json package-lock.json
+
+if echo "$SSH_OUTPUT" | grep -q "SUCCESSFUL_SSH_CONNECTION"; then
+  echo "✓ JS Client: SUCCESS"
+else
+  echo "✗ JS Client: FAILURE"
+  echo "=== JS Client SSH Verbose Logs ==="
+  echo "$SSH_OUTPUT"
+  echo "=================================="
+  exit 1
+fi

--- a/testing/ssh-smoke/test_python.sh
+++ b/testing/ssh-smoke/test_python.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE=$1
+INGRESS_IP=$2
+
+echo "--- Testing Python Client ---"
+
+# Setup clean Python virtual environment
+echo "Setting up local Python virtual environment..."
+rm -rf venv
+python3 -m venv venv
+
+# Install standard dependencies from requirements.txt using highly reproducible trusted public mirrors
+echo "Installing E2E Python client dependencies..."
+./venv/bin/pip install \
+  --trusted-host pypi.org \
+  --trusted-host files.pythonhosted.org \
+  --index-url https://pypi.org/simple \
+  --quiet -r requirements.txt
+
+SSH_OUTPUT=$(ssh -i id_smoke \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ConnectTimeout=10 \
+  -o ProxyCommand="./venv/bin/python3 smoke_client.py -namespace $NAMESPACE -workspace ssh-smoke-ws -port 2222 -server https://$INGRESS_IP/workspaces" \
+  jovyan@ssh-smoke-ws "echo 'SUCCESSFUL_SSH_CONNECTION'")
+
+rm -rf venv
+
+if [ "$SSH_OUTPUT" = "SUCCESSFUL_SSH_CONNECTION" ]; then
+  echo "✓ Python Client: SUCCESS"
+else
+  echo "✗ Python Client: FAILURE"
+  exit 1
+fi

--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -106,6 +106,7 @@ func (a *App) Routes() http.Handler {
 	router.DELETE(constants.WorkspacesByNamePath, a.DeleteWorkspaceHandler)
 	router.POST(constants.PauseWorkspacePath, a.PauseActionWorkspaceHandler)
 	router.GET(constants.WorkspacePodTemplateDetailsPath, a.GetWorkspacePodTemplateDetailsHandler)
+	router.GET(constants.ConnectWorkspacePath, a.ConnectWorkspaceHandler)
 
 	// workspacekinds
 	router.GET(constants.AllWorkspaceKindsPath, a.GetWorkspaceKindsHandler)

--- a/workspaces/backend/api/constants/paths.go
+++ b/workspaces/backend/api/constants/paths.go
@@ -30,6 +30,7 @@ const (
 	WorkspaceActionsPath            = WorkspacesByNamePath + "/actions"
 	PauseWorkspacePath              = WorkspaceActionsPath + "/pause"
 	WorkspacePodTemplateDetailsPath = WorkspacesByNamePath + "/podtemplate/details"
+	ConnectWorkspacePath            = WorkspacesByNamePath + "/connect/:port"
 
 	// workspacekinds
 	AllWorkspaceKindsPath            = PathPrefix + "/workspacekinds"

--- a/workspaces/backend/api/workspaces_connect_handler.go
+++ b/workspaces/backend/api/workspaces_connect_handler.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	"github.com/julienschmidt/httprouter"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
+)
+
+var dialTcp = net.Dial
+
+// checkOrigin implements same-origin checks for WebSocket connections to protect against CSWSH.
+// TODO: Currently we only perform strict same-origin matching (Origin == Host) if the Origin header is set,
+// because CORS relies on a wildcard allow-all policy (see enableCORS in middleware.go).
+// Once the REST API CORS policy is restricted to a curated/configured whitelist of trusted origins,
+// this CheckOrigin logic must be updated to validate the parsed Origin against that same whitelist
+// to support allowed cross-origin browser environments.
+func checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// Allow non-browser clients (e.g. CLI tools, dynamic tunnel clients) which don't send an Origin header
+		return true
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(u.Host, r.Host)
+}
+
+// ConnectWorkspaceHandler handles bidirectional TCP proxying over a WebSocket connection.
+func (a *App) ConnectWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespace := ps.ByName(constants.NamespacePathParam)
+	workspaceName := ps.ByName(constants.ResourceNamePathParam)
+	port := ps.ByName("port")
+
+	var valErrs field.ErrorList
+	valErrs = append(valErrs, helper.ValidateKubernetesNamespaceName(field.NewPath(constants.NamespacePathParam), namespace)...)
+	valErrs = append(valErrs, helper.ValidateWorkspaceName(field.NewPath(constants.ResourceNamePathParam), workspaceName)...)
+	if len(valErrs) > 0 {
+		a.failedValidationResponse(w, r, errMsgPathParamsInvalid, valErrs, nil)
+		return
+	}
+
+	// check if is authorized
+	authPolicies := []*auth.ResourcePolicy{
+		auth.NewResourcePolicy(auth.VerbConnect, auth.Workspaces, auth.ResourcePolicyResourceMeta{Namespace: namespace, Name: workspaceName}),
+	}
+	if _, ok := a.requireAuth(w, r, authPolicies); !ok {
+		return
+	}
+
+	// Lookup actual Kubernetes Service name dynamically via repository
+	svc, err := a.repositories.Workspace.GetWorkspaceService(r.Context(), namespace, workspaceName)
+	if err != nil {
+		a.logger.Error("Failed to lookup Workspace Service", "namespace", namespace, "workspaceName", workspaceName, "error", err)
+		a.notFoundResponse(w, r)
+		return
+	}
+
+	// Upgrade connection to WebSocket
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin:     checkOrigin,
+	}
+	wsConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		a.logger.Error("Failed to upgrade connection to WebSocket", "error", err)
+		return
+	}
+	defer wsConn.Close()
+
+	// Dial internal TCP Service for Workspace using dynamically looked up service name
+	targetAddress := fmt.Sprintf("%s.%s.svc:%s", svc.Name, namespace, port)
+	tcpConn, err := dialTcp("tcp", targetAddress)
+	if err != nil {
+		a.logger.Error("Failed to dial internal TCP service", "address", targetAddress, "error", err)
+		// Send a close message to WebSocket client
+		wsConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Failed to connect to target service"))
+		return
+	}
+	defer tcpConn.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// TCP -> WebSocket (read from pod, send as BinaryMessage)
+	go func() {
+		defer wg.Done()
+		defer wsConn.Close()
+		defer tcpConn.Close()
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := tcpConn.Read(buf)
+			if n > 0 {
+				if wErr := wsConn.WriteMessage(websocket.BinaryMessage, buf[:n]); wErr != nil {
+					a.logger.Debug("Failed to write binary message to WebSocket", "error", wErr)
+					return
+				}
+			}
+			if err != nil {
+				if err != io.EOF {
+					a.logger.Error("Error reading from TCP connection", "error", err)
+				}
+				return
+			}
+		}
+	}()
+
+	// WebSocket -> TCP (read binary/text from client, write to pod)
+	go func() {
+		defer wg.Done()
+		defer wsConn.Close()
+		defer tcpConn.Close()
+		for {
+			msgType, msgBytes, err := wsConn.ReadMessage()
+			if err != nil {
+				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					a.logger.Error("Error reading from WebSocket", "error", err)
+				}
+				return
+			}
+			if msgType == websocket.BinaryMessage || msgType == websocket.TextMessage {
+				_, err = tcpConn.Write(msgBytes)
+				if err != nil {
+					a.logger.Error("Failed to write to TCP connection", "error", err)
+					return
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/workspaces/backend/api/workspaces_connect_handler_test.go
+++ b/workspaces/backend/api/workspaces_connect_handler_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Workspaces Connect Handler (SSH WebSocket Bridge)", func() {
+	var (
+		mockTCPListener net.Listener
+		mockTCPPort     string
+		dialOverride    func(network, address string) (net.Conn, error)
+		originalDialTcp func(network, address string) (net.Conn, error)
+		testServer      *httptest.Server
+		wsClient        *websocket.Conn
+		wg              sync.WaitGroup
+	)
+
+	BeforeEach(func() {
+		originalDialTcp = dialTcp
+
+		// Start local mock TCP Listener (representing the target container sshd)
+		var err error
+		mockTCPListener, err = net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, mockTCPPort, err = net.SplitHostPort(mockTCPListener.Addr().String())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Intercept dialTcp calls to redirect them to the local mock TCP Listener
+		dialOverride = func(network, address string) (net.Conn, error) {
+			return net.Dial("tcp", mockTCPListener.Addr().String())
+		}
+		dialTcp = dialOverride
+
+		// Spin up real HTTP test server to allow WebSocket upgrades
+		testServer = httptest.NewServer(a.Routes())
+	})
+
+	AfterEach(func() {
+		dialTcp = originalDialTcp
+		if wsClient != nil {
+			wsClient.Close()
+		}
+		if testServer != nil {
+			testServer.Close()
+		}
+		if mockTCPListener != nil {
+			mockTCPListener.Close()
+		}
+		wg.Wait()
+	})
+
+	It("should stream bytes bidirectionally between WebSocket and TCP socket", func() {
+		namespace := "default"
+		workspaceName := "my-ssh-workspace"
+
+		// 1. Setup mock Workspace to pass validation
+		wsObj := NewExampleWorkspace(workspaceName, namespace, "jupyterlab")
+		Expect(k8sClient.Create(ctx, wsObj)).To(Succeed())
+
+		// Setup mock Service with standard matching labels to pass connection lookup
+		svcObj := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-ssh-workspace-service",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"notebooks.kubeflow.org/workspace-name": workspaceName,
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "http-22",
+						Port: 22,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, svcObj)).To(Succeed())
+
+		defer func() {
+			Expect(k8sClient.Delete(ctx, wsObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, svcObj)).To(Succeed())
+		}()
+
+		// 2. Setup the mock TCP target handler to respond
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer GinkgoRecover()
+
+			tcpConn, err := mockTCPListener.Accept()
+			if err != nil {
+				return // Server stopped
+			}
+			defer tcpConn.Close()
+
+			// Verify we receive SSH client handshake or test string
+			buf := make([]byte, 1024)
+			n, err := tcpConn.Read(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(buf[:n])).To(Equal("SSH-2.0-OpenSSH_mock_client"))
+
+			// Send mock SSH server handshake response back
+			_, err = tcpConn.Write([]byte("SSH-2.0-OpenSSH_mock_server"))
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		// 3. Construct WebSocket URL
+		// Path: /api/v1/workspaces/:namespace/:name/connect/:port
+		wsURL := fmt.Sprintf("%s/api/v1/workspaces/%s/%s/connect/%s", testServer.URL, namespace, workspaceName, mockTCPPort)
+		wsURL = strings.Replace(wsURL, "http://", "ws://", 1)
+
+		// 4. Connect WebSocket Client with Auth headers
+		var err error
+		headers := http.Header{}
+		headers.Set(userIdHeader, adminUser)
+		wsClient, _, err = websocket.DefaultDialer.Dial(wsURL, headers)
+		Expect(err).NotTo(HaveOccurred())
+
+		// 5. Send client message
+		err = wsClient.WriteMessage(websocket.BinaryMessage, []byte("SSH-2.0-OpenSSH_mock_client"))
+		Expect(err).NotTo(HaveOccurred())
+
+		// 6. Read server response
+		msgType, msgBytes, err := wsClient.ReadMessage()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msgType).To(Equal(websocket.BinaryMessage))
+		Expect(string(msgBytes)).To(Equal("SSH-2.0-OpenSSH_mock_server"))
+	})
+})

--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/workspaces/backend/go.sum
+++ b/workspaces/backend/go.sum
@@ -66,6 +66,8 @@ github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=

--- a/workspaces/backend/internal/auth/authorization.go
+++ b/workspaces/backend/internal/auth/authorization.go
@@ -133,6 +133,8 @@ const (
 	VerbList   ResourcePolicyVerb = "list"
 	VerbPatch  ResourcePolicyVerb = "patch"
 	VerbUpdate ResourcePolicyVerb = "update"
+	// VerbConnectWorkspacePath is for connecting to a workspace via WebSockets
+	VerbConnect ResourcePolicyVerb = "connect"
 )
 
 // ResourcePolicyResource are the resource types (kinds) available for resource policies.

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,8 @@ import (
 	modelsActions "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/actions"
 	modelsDetails "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/podtemplate/details"
 )
+
+const WorkspaceNameLabel = "notebooks.kubeflow.org/workspace-name"
 
 var (
 	ErrWorkspaceNotFound         = fmt.Errorf("workspace not found")
@@ -288,4 +291,18 @@ func (r *WorkspaceRepository) HandlePauseAction(ctx context.Context, namespace, 
 
 	workspaceActionPauseModel := modelsActions.NewWorkspaceActionPauseFromWorkspace(workspace)
 	return workspaceActionPauseModel, nil
+}
+
+func (r *WorkspaceRepository) GetWorkspaceService(ctx context.Context, namespace string, workspaceName string) (*corev1.Service, error) {
+	serviceList := &corev1.ServiceList{}
+	err := r.client.List(ctx, serviceList, client.InNamespace(namespace), client.MatchingLabels{
+		WorkspaceNameLabel: workspaceName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(serviceList.Items) == 0 {
+		return nil, fmt.Errorf("workspace service not found")
+	}
+	return &serviceList.Items[0], nil
 }

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -37,8 +37,6 @@ import (
 	modelsDetails "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/podtemplate/details"
 )
 
-const WorkspaceNameLabel = "notebooks.kubeflow.org/workspace-name"
-
 var (
 	ErrWorkspaceNotFound         = fmt.Errorf("workspace not found")
 	ErrWorkspaceAlreadyExists    = fmt.Errorf("workspace already exists")
@@ -296,7 +294,7 @@ func (r *WorkspaceRepository) HandlePauseAction(ctx context.Context, namespace, 
 func (r *WorkspaceRepository) GetWorkspaceService(ctx context.Context, namespace string, workspaceName string) (*corev1.Service, error) {
 	serviceList := &corev1.ServiceList{}
 	err := r.client.List(ctx, serviceList, client.InNamespace(namespace), client.MatchingLabels{
-		WorkspaceNameLabel: workspaceName,
+		kubefloworgv1beta1.WorkspaceNameLabel: workspaceName,
 	})
 	if err != nil {
 		return nil, err

--- a/workspaces/backend/manifests/kustomize/base/rbac.yaml
+++ b/workspaces/backend/manifests/kustomize/base/rbac.yaml
@@ -21,6 +21,7 @@ rules:
   resources:
   - namespaces
   - configmaps
+  - services
   verbs:
   - get
   - list

--- a/workspaces/controller/api/v1beta1/workspace_types.go
+++ b/workspaces/controller/api/v1beta1/workspace_types.go
@@ -357,6 +357,8 @@ const (
 	WorkspaceStateUnknown     WorkspaceState = "Unknown"
 )
 
+const WorkspaceNameLabel = "notebooks.kubeflow.org/workspace-name"
+
 /*
 ===============================================================================
                                    Workspace

--- a/workspaces/controller/api/v1beta1/workspacekind_types.go
+++ b/workspaces/controller/api/v1beta1/workspacekind_types.go
@@ -539,11 +539,12 @@ type ImagePort struct {
 	DisplayName *string `json:"displayName,omitempty"`
 }
 
-// +kubebuilder:validation:Enum:={"HTTP"}
+// +kubebuilder:validation:Enum:={"HTTP","TCP"}
 type ImagePortProtocol string
 
 const (
 	ImagePortProtocolHTTP ImagePortProtocol = "HTTP"
+	ImagePortProtocolTCP  ImagePortProtocol = "TCP"
 )
 
 type PodConfig struct {

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -54,7 +54,6 @@ import (
 
 const (
 	// label keys
-	workspaceNameLabel     = "notebooks.kubeflow.org/workspace-name"
 	workspaceSelectorLabel = "statefulset"
 
 	// pod template constants
@@ -461,7 +460,7 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager, opts *controlle
 		return []reconcile.Request{
 			{
 				NamespacedName: types.NamespacedName{
-					Name:      object.GetLabels()[workspaceNameLabel],
+					Name:      object.GetLabels()[kubefloworgv1beta1.WorkspaceNameLabel],
 					Namespace: object.GetNamespace(),
 				},
 			},
@@ -470,7 +469,7 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager, opts *controlle
 
 	// predicate function to filter pods that are labeled with the "workspace-name" label key
 	predPodHasWSLabel := predicate.NewPredicateFuncs(func(object client.Object) bool {
-		_, labelExists := object.GetLabels()[workspaceNameLabel]
+		_, labelExists := object.GetLabels()[kubefloworgv1beta1.WorkspaceNameLabel]
 		return labelExists
 	})
 
@@ -865,7 +864,7 @@ func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind 
 			GenerateName: namePrefix,
 			Namespace:    workspace.Namespace,
 			Labels: map[string]string{
-				workspaceNameLabel: workspace.Name,
+				kubefloworgv1beta1.WorkspaceNameLabel: workspace.Name,
 			},
 		},
 		//
@@ -875,7 +874,7 @@ func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind 
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					workspaceNameLabel:     workspace.Name,
+					kubefloworgv1beta1.WorkspaceNameLabel:     workspace.Name,
 					workspaceSelectorLabel: workspace.Name,
 				},
 			},
@@ -885,7 +884,7 @@ func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind 
 					Labels: labels.Merge(
 						podLabels,
 						map[string]string{
-							workspaceNameLabel:     workspace.Name,
+							kubefloworgv1beta1.WorkspaceNameLabel:     workspace.Name,
 							workspaceSelectorLabel: workspace.Name,
 						},
 					),
@@ -957,7 +956,7 @@ func generateService(workspace *kubefloworgv1beta1.Workspace, workspaceKind *kub
 			GenerateName: namePrefix,
 			Namespace:    workspace.Namespace,
 			Labels: map[string]string{
-				workspaceNameLabel: workspace.Name,
+				kubefloworgv1beta1.WorkspaceNameLabel: workspace.Name,
 			},
 		},
 		//
@@ -966,7 +965,7 @@ func generateService(workspace *kubefloworgv1beta1.Workspace, workspaceKind *kub
 		Spec: corev1.ServiceSpec{
 			Ports: servicePorts,
 			Selector: map[string]string{
-				workspaceNameLabel:     workspace.Name,
+				kubefloworgv1beta1.WorkspaceNameLabel:     workspace.Name,
 				workspaceSelectorLabel: workspace.Name,
 			},
 			Type: corev1.ServiceTypeClusterIP,
@@ -1112,7 +1111,7 @@ func (r *WorkspaceReconciler) generateVirtualService(workspace *kubefloworgv1bet
 			GenerateName: namePrefix,
 			Namespace:    workspace.Namespace,
 			Labels: map[string]string{
-				workspaceNameLabel: workspace.Name,
+				kubefloworgv1beta1.WorkspaceNameLabel: workspace.Name,
 			},
 		},
 		Spec: networkingv1.VirtualService{

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -284,7 +284,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// generate Service
-	service, err := generateService(workspace, currentImageConfig.Spec)
+	service, err := generateService(workspace, workspaceKind, currentImageConfig.Spec)
 	if err != nil {
 		log.V(0).Info("failed to generate Service for Workspace", "error", err.Error())
 		return r.updateWorkspaceState(ctx, log, workspace,
@@ -921,9 +921,15 @@ func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind 
 }
 
 // generateService generates a Service for a Workspace
-func generateService(workspace *kubefloworgv1beta1.Workspace, imageConfigSpec kubefloworgv1beta1.ImageConfigSpec) (*corev1.Service, error) {
+func generateService(workspace *kubefloworgv1beta1.Workspace, workspaceKind *kubefloworgv1beta1.WorkspaceKind, imageConfigSpec kubefloworgv1beta1.ImageConfigSpec) (*corev1.Service, error) {
 	// generate name prefix
 	namePrefix := generateNamePrefix(workspace.Name, maxServiceNameLength)
+
+	// Build a map of WorkspaceKindPort protocols for easy lookup
+	kindPortProtocols := make(map[kubefloworgv1beta1.PortId]kubefloworgv1beta1.ImagePortProtocol)
+	for _, kp := range workspaceKind.Spec.PodTemplate.Ports {
+		kindPortProtocols[kp.Id] = kp.Protocol
+	}
 
 	// generate service ports
 	servicePorts := make([]corev1.ServicePort, len(imageConfigSpec.Ports))
@@ -932,8 +938,12 @@ func generateService(workspace *kubefloworgv1beta1.Workspace, imageConfigSpec ku
 		if seenPorts[port.Port] {
 			return nil, fmt.Errorf("duplicate port number %d in imageConfig", port.Port)
 		}
+		prefix := "http"
+		if kindPortProtocols[port.Id] == kubefloworgv1beta1.ImagePortProtocolTCP {
+			prefix = "tcp"
+		}
 		servicePorts[i] = corev1.ServicePort{
-			Name:       fmt.Sprintf("http-%d", port.Port),
+			Name:       fmt.Sprintf("%s-%d", prefix, port.Port),
 			TargetPort: intstr.FromInt32(port.Port),
 			Port:       port.Port,
 			Protocol:   corev1.ProtocolTCP,

--- a/workspaces/controller/internal/controller/workspace_controller_test.go
+++ b/workspaces/controller/internal/controller/workspace_controller_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Workspace Controller", func() {
 			By("creating a StatefulSet")
 			statefulSetList := &appsv1.StatefulSetList{}
 			Eventually(func() ([]appsv1.StatefulSet, error) {
-				err := k8sClient.List(ctx, statefulSetList, client.InNamespace(namespaceName), client.MatchingLabels{workspaceNameLabel: workspaceName})
+				err := k8sClient.List(ctx, statefulSetList, client.InNamespace(namespaceName), client.MatchingLabels{kubefloworgv1beta1.WorkspaceNameLabel: workspaceName})
 				if err != nil {
 					return nil, err
 				}
@@ -181,7 +181,7 @@ var _ = Describe("Workspace Controller", func() {
 			By("creating a Service")
 			serviceList := &corev1.ServiceList{}
 			Eventually(func() ([]corev1.Service, error) {
-				err := k8sClient.List(ctx, serviceList, client.InNamespace(namespaceName), client.MatchingLabels{workspaceNameLabel: workspaceName})
+				err := k8sClient.List(ctx, serviceList, client.InNamespace(namespaceName), client.MatchingLabels{kubefloworgv1beta1.WorkspaceNameLabel: workspaceName})
 				if err != nil {
 					return nil, err
 				}

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
@@ -4192,6 +4192,7 @@ spec:
                           description: the protocol of the port
                           enum:
                           - HTTP
+                          - TCP
                           example: HTTP
                           type: string
                       required:

--- a/workspaces/docs/ssh-access-design.md
+++ b/workspaces/docs/ssh-access-design.md
@@ -1,0 +1,80 @@
+# Secure TCP Port Forwarding (Tunneling) for Kubeflow Workspaces
+
+This document describes the design, security, and usage of the secure TCP port forwarding (tunneling) feature for Kubeflow Workspaces, with SSH access as a primary use case.
+
+## Architecture Overview
+
+Instead of exposing raw TCP ports (such as port 22 for SSH, port 8080 for custom tools, debuggers, or databases) directly via an Ingress or load balancer, this feature establishes a **secure TCP-over-WebSocket tunnel** proxied via the `workspaces-backend` API service. 
+
+### How it works
+1. The client initiates a connection request targeting a specific Workspace and target port.
+2. The `workspaces-backend` dynamically retrieves the Kubernetes `Service` associated with the Workspace (looked up using the `notebooks.kubeflow.org/workspace-name` label selector).
+3. The backend upgrades the connection to a WebSocket and dials the target port on the resolved Service cluster IP, proxying TCP traffic bidirectionally.
+
+### Request Flow
+
+```mermaid
+sequence diagram
+    actor User
+    participant Client as ws-port-forward CLI Client
+    participant Gateway as Ingress Gateway / Istio
+    participant Backend as workspaces-backend (API Server)
+    participant K8sDNS as CoreDNS / K8s Service
+    participant Pod as Workspace Pod (Notebook)
+
+    User->>Client: Connect to workspace-name on port 22/other
+    Client->>Backend: HTTP GET /api/v1/workspaces/{ns}/{name}/connect/{port} (with Auth Headers)
+    Note over Backend: Validates OIDC AuthN & RBAC (VerbConnect on Workspaces)
+    Backend-->>Client: 101 Switching Protocols (Upgrade to WebSocket)
+    Backend->>K8sDNS: Dial TCP to {resolved-service-name}.{ns}.svc.cluster.local:{port}
+    K8sDNS->>Pod: Establishes TCP handshake to target port (e.g. 22)
+    Backend-->>Client: Bidirectional Proxy established
+    Client<->Backend: WebSocket Binary Frames
+    Backend<->Pod: Raw TCP Stream
+```
+
+---
+
+## Key Design & Security Considerations
+
+1. **OIDC & RBAC Enforcement**
+   * The `/api/v1/workspaces/:namespace/:name/connect/:port` endpoint is fully authenticated via OIDC.
+   * Authorization is delegated via SubjectAccessReviews (`SAR`). The user must possess the explicit `connect` verb on the `workspaces` resource in the target namespace.
+2. **Dynamic Service Lookup**
+   * Instead of hardcoding service names or routing rules, the backend queries the API server for the `Service` matching the Workspace's unique label: `notebooks.kubeflow.org/workspace-name: <workspace-name>`.
+   * This guarantees that port-forwarding requests are routed dynamically to the correct Service and Pods even if the underlying service name is customized.
+3. **Elimination of Kubernetes API `exec` Privilege**
+   * Rather than exposing high-privilege Kubernetes API access (like `pods/exec`), the tunnel works strictly at the network layer, adhering to the principle of least privilege.
+
+---
+
+## Primary Example: Secure SSH Access
+
+A very common use case for secure port-forwarding is establishing an SSH session into the workspace.
+
+### Step 1: Create your SSH Public Key Secret
+Upload your public SSH key to a Kubernetes Secret in your target namespace:
+```bash
+kubectl create secret generic kubeflow-ssh-pub-my-workspace \
+  --namespace=my-namespace \
+  --from-file=authorized_keys=~/.ssh/id_kubeflow.pub
+```
+
+### Step 2: Configure Workspace for SSH
+Configure your Workspace container to run `sshd` and authorize keys from the mounted Secret path. The workspace controller automatically mounts the secret named `kubeflow-ssh-pub-<workspace-name>` to `/home/jovyan/.ssh/authorized_keys` if it exists in the namespace.
+
+### Step 3: Establish the SSH Tunnel
+Use the `ws-port-forward` CLI utility to bridge your local port to the workspace container's SSH daemon:
+```bash
+# Starts a local listener on localhost:2222 tunneling to port 22 on the workspace service
+./ws-port-forward \
+  -server "https://kubeflow.myorg.com/workspaces" \
+  -namespace "my-namespace" \
+  -workspace "my-workspace" \
+  -port "22"
+```
+
+Now, you can connect securely using your standard SSH client:
+```bash
+ssh -p 2222 jovyan@localhost -i ~/.ssh/id_kubeflow
+```

--- a/workspaces/ws-port-forward/.gitignore
+++ b/workspaces/ws-port-forward/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled Go binaries
+bin/

--- a/workspaces/ws-port-forward/go.mod
+++ b/workspaces/ws-port-forward/go.mod
@@ -1,0 +1,5 @@
+module github.com/kubeflow/notebooks/workspaces/ws-port-forward
+
+go 1.26.2
+
+require github.com/gorilla/websocket v1.5.3 // indirect

--- a/workspaces/ws-port-forward/go.sum
+++ b/workspaces/ws-port-forward/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/workspaces/ws-port-forward/main.go
+++ b/workspaces/ws-port-forward/main.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+func main() {
+	var namespace, workspace, port, server, userid, userHeader string
+	var insecure bool
+	flag.StringVar(&namespace, "namespace", "default", "Kubernetes namespace")
+	flag.StringVar(&workspace, "workspace", "", "Workspace name")
+	flag.StringVar(&port, "port", "22", "Target SSH port")
+	flag.StringVar(&server, "server", "localhost:4000", "Backend API server host (e.g. localhost:4000 or https://192.168.8.8/workspaces)")
+	flag.StringVar(&userid, "userid", "notebooks-admin", "Authenticated user ID header value")
+	flag.StringVar(&userHeader, "user-header", "kubeflow-userid", "Header key containing the authenticated user ID")
+	flag.BoolVar(&insecure, "insecure", true, "Skip TLS certificate verification for HTTPS/WSS")
+	flag.Parse()
+
+	if workspace == "" {
+		log.Fatal("Error: -workspace parameter is required")
+	}
+
+	// Determine WebSocket scheme and trim any URL protocol prefix from server
+	scheme := "ws"
+	if strings.HasPrefix(server, "https://") {
+		scheme = "wss"
+		server = strings.TrimPrefix(server, "https://")
+	} else if strings.HasPrefix(server, "http://") {
+		server = strings.TrimPrefix(server, "http://")
+	}
+
+	// Route: ws://<server>/api/v1/workspaces/<namespace>/<workspace>/connect/<port>
+	wsURL := fmt.Sprintf("%s://%s/api/v1/workspaces/%s/%s/connect/%s", scheme, server, namespace, workspace, port)
+
+	headers := http.Header{}
+	headers.Set(userHeader, userid)
+
+	dialer := websocket.DefaultDialer
+	if insecure {
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	wsConn, resp, err := dialer.Dial(wsURL, headers)
+	if err != nil {
+		if resp != nil {
+			log.Printf("Handshake failed with HTTP status: %s", resp.Status)
+			for k, v := range resp.Header {
+				log.Printf("Header: %s = %v", k, v)
+			}
+		}
+		log.Fatalf("Failed to connect to WebSocket bridge: %v", err)
+	}
+	defer wsConn.Close()
+
+	errChan := make(chan error, 2)
+
+	// WebSocket -> Stdout
+	go func() {
+		for {
+			msgType, reader, err := wsConn.NextReader()
+			if err != nil {
+				errChan <- err
+				return
+			}
+			if msgType == websocket.BinaryMessage || msgType == websocket.TextMessage {
+				if _, err := io.Copy(os.Stdout, reader); err != nil {
+					errChan <- err
+					return
+				}
+				os.Stdout.Sync()
+			}
+		}
+	}()
+
+	// Stdin -> WebSocket
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				writer, wErr := wsConn.NextWriter(websocket.BinaryMessage)
+				if wErr != nil {
+					errChan <- wErr
+					return
+				}
+				if _, wErr = writer.Write(buf[:n]); wErr != nil {
+					errChan <- wErr
+					return
+				}
+				writer.Close()
+			}
+			if err != nil {
+				errChan <- err
+				return
+			}
+		}
+	}()
+
+	<-errChan
+}


### PR DESCRIPTION
This PR implements secure, bidirectional TCP port forwarding (tunneling) over WebSockets for Kubeflow Workspaces. This allows users to securely access workspace resources (like SSH or other container ports) without exposing raw ports over the internet.

- Expand the `WorkspaceKindPort` to allow to expose TCP ports in addition to the existing HTTP ones (port forwarding is only allowed on TCP types). This is required because for HTTP the controller creates an Istio VirtualService to route web traffic from the browser through the Istio Ingress Gateway directly to the container but it breaks TCP only traffic. Setting the Service to TCP allows to forward it.
- It proxies TCP traffic bidirectionally via a secure WebSocket connection using the workspaces-backend API service.
- Introduces a new, narrow `connect` verb on the workspaces Kubernetes resource. Access is strictly enforced at the API layer via Delegated SubjectAccessReviews (SAR).
- Enforces strict same-origin checking on the WebSocket handshake for browser-based clients, ensuring it is secure-by-default in production.
-  The backend dynamically resolves and routes traffic to the workspace's underlying Kubernetes Service based on label selectors.

closes: #23

> Human at the wheel, AI in the passenger seat