### PR TITLE
chore: do not rely on type/immutable fields from secret list

### DIFF
--- a/workspaces/frontend/src/app/hooks/__tests__/useSecret.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useSecret.spec.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '~/__tests__/unit/testUtils/hooks';
 import { useNamespaceSelectorWrapper } from '~/app/hooks/useNamespaceSelectorWrapper';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
-import useSecretContents from '~/app/hooks/useSecretContents';
+import useSecret from '~/app/hooks/useSecret';
 import { NotebookApis } from '~/shared/api/notebookApi';
 
 jest.mock('~/app/hooks/useNotebookAPI', () => ({
@@ -16,7 +16,7 @@ const mockUseNamespaceSelectorWrapper = useNamespaceSelectorWrapper as jest.Mock
   typeof useNamespaceSelectorWrapper
 >;
 
-describe('useSecretContents', () => {
+describe('useSecret', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseNamespaceSelectorWrapper.mockReturnValue({
@@ -32,12 +32,10 @@ describe('useSecretContents', () => {
       refreshAllAPI: jest.fn(),
     });
 
-    const { result } = renderHook(() =>
-      useSecretContents({ isOpen: true, secretName: 'my-secret' }),
-    );
+    const { result } = renderHook(() => useSecret({ isOpen: true, secretName: 'my-secret' }));
 
-    const [contents, loaded] = result.current;
-    expect(contents).toEqual([]);
+    const [details, loaded] = result.current;
+    expect(details).toEqual({ keyValuePairs: [], immutable: false, type: 'Opaque' });
     expect(loaded).toBe(false);
   });
 
@@ -48,12 +46,10 @@ describe('useSecretContents', () => {
       refreshAllAPI: jest.fn(),
     });
 
-    const { result } = renderHook(() =>
-      useSecretContents({ isOpen: false, secretName: 'my-secret' }),
-    );
+    const { result } = renderHook(() => useSecret({ isOpen: false, secretName: 'my-secret' }));
 
-    const [contents, loaded] = result.current;
-    expect(contents).toEqual([]);
+    const [details, loaded] = result.current;
+    expect(details).toEqual({ keyValuePairs: [], immutable: false, type: 'Opaque' });
     expect(loaded).toBe(false);
   });
 
@@ -64,16 +60,18 @@ describe('useSecretContents', () => {
       refreshAllAPI: jest.fn(),
     });
 
-    const { result } = renderHook(() => useSecretContents({ isOpen: true, secretName: undefined }));
+    const { result } = renderHook(() => useSecret({ isOpen: true, secretName: undefined }));
 
-    const [contents, loaded] = result.current;
-    expect(contents).toEqual([]);
+    const [details, loaded] = result.current;
+    expect(details).toEqual({ keyValuePairs: [], immutable: false, type: 'Opaque' });
     expect(loaded).toBe(false);
   });
 
   it('fetches and decodes secret contents when API is available', async () => {
     const getSecret = jest.fn().mockResolvedValue({
       data: {
+        type: 'Opaque',
+        immutable: false,
         contents: {
           KEY1: { base64: Buffer.from('value1').toString('base64') },
           KEY2: { base64: Buffer.from('value2').toString('base64') },
@@ -87,23 +85,31 @@ describe('useSecretContents', () => {
     });
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSecretContents({ isOpen: true, secretName: 'my-secret' }),
+      useSecret({ isOpen: true, secretName: 'my-secret' }),
     );
     await waitForNextUpdate();
 
-    const [contents, loaded, error] = result.current;
+    const [details, loaded, error] = result.current;
     expect(getSecret).toHaveBeenCalledWith('test-namespace', 'my-secret');
-    expect(contents).toEqual([
+    expect(details.keyValuePairs).toEqual([
       { key: 'KEY1', value: 'value1' },
       { key: 'KEY2', value: 'value2' },
     ]);
+    expect(details.immutable).toBe(false);
+    expect(details.type).toBe('Opaque');
     expect(loaded).toBe(true);
     expect(error).toBeUndefined();
   });
 
-  it('returns empty array when secret has no contents', async () => {
+  it('returns immutable and type from the GET response', async () => {
     const getSecret = jest.fn().mockResolvedValue({
-      data: { contents: {} },
+      data: {
+        type: 'kubernetes.io/tls',
+        immutable: true,
+        contents: {
+          'tls.crt': { base64: Buffer.from('cert').toString('base64') },
+        },
+      },
     });
     mockUseNotebookAPI.mockReturnValue({
       api: { secrets: { getSecret } } as unknown as NotebookApis,
@@ -112,12 +118,35 @@ describe('useSecretContents', () => {
     });
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSecretContents({ isOpen: true, secretName: 'empty-secret' }),
+      useSecret({ isOpen: true, secretName: 'tls-secret' }),
     );
     await waitForNextUpdate();
 
-    const [contents, loaded, error] = result.current;
-    expect(contents).toEqual([]);
+    const [details, loaded] = result.current;
+    expect(details.immutable).toBe(true);
+    expect(details.type).toBe('kubernetes.io/tls');
+    expect(details.keyValuePairs).toEqual([{ key: 'tls.crt', value: 'cert' }]);
+    expect(loaded).toBe(true);
+  });
+
+  it('returns empty keyValuePairs when secret has no contents', async () => {
+    const getSecret = jest.fn().mockResolvedValue({
+      data: { type: 'Opaque', immutable: false, contents: {} },
+    });
+    mockUseNotebookAPI.mockReturnValue({
+      api: { secrets: { getSecret } } as unknown as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSecret({ isOpen: true, secretName: 'empty-secret' }),
+    );
+    await waitForNextUpdate();
+
+    const [details, loaded, error] = result.current;
+    expect(details.keyValuePairs).toEqual([]);
+    expect(details.immutable).toBe(false);
     expect(loaded).toBe(true);
     expect(error).toBeUndefined();
   });
@@ -125,6 +154,8 @@ describe('useSecretContents', () => {
   it('uses empty string when entry has no base64', async () => {
     const getSecret = jest.fn().mockResolvedValue({
       data: {
+        type: 'Opaque',
+        immutable: false,
         contents: {
           NO_BASE64: {},
         },
@@ -137,11 +168,11 @@ describe('useSecretContents', () => {
     });
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSecretContents({ isOpen: true, secretName: 'my-secret' }),
+      useSecret({ isOpen: true, secretName: 'my-secret' }),
     );
     await waitForNextUpdate();
 
-    const [contents] = result.current;
-    expect(contents).toEqual([{ key: 'NO_BASE64', value: '' }]);
+    const [details] = result.current;
+    expect(details.keyValuePairs).toEqual([{ key: 'NO_BASE64', value: '' }]);
   });
 });

--- a/workspaces/frontend/src/app/hooks/useSecret.ts
+++ b/workspaces/frontend/src/app/hooks/useSecret.ts
@@ -8,19 +8,28 @@ export interface SecretKeyValuePair {
   value: string;
 }
 
-interface UseSecretContentsOptions {
+export interface SecretDetails {
+  keyValuePairs: SecretKeyValuePair[];
+  immutable: boolean;
+  type: string;
+}
+
+interface UseSecretOptions {
   isOpen: boolean;
   secretName: string | undefined;
 }
 
-const useSecretContents = ({
-  isOpen,
-  secretName,
-}: UseSecretContentsOptions): FetchState<SecretKeyValuePair[]> => {
+const DEFAULT_SECRET_DETAILS: SecretDetails = {
+  keyValuePairs: [],
+  immutable: false,
+  type: 'Opaque',
+};
+
+const useSecret = ({ isOpen, secretName }: UseSecretOptions): FetchState<SecretDetails> => {
   const { api, apiAvailable } = useNotebookAPI();
   const { selectedNamespace } = useNamespaceSelectorWrapper();
 
-  const call = useCallback<FetchStateCallbackPromise<SecretKeyValuePair[]>>(async () => {
+  const call = useCallback<FetchStateCallbackPromise<SecretDetails>>(async () => {
     if (!apiAvailable) {
       return Promise.reject(new NotReadyError('API not yet available'));
     }
@@ -30,19 +39,20 @@ const useSecretContents = ({
     }
 
     const response = await api.secrets.getSecret(selectedNamespace, secretName);
-    const { contents } = response.data;
+    const { contents, immutable, type } = response.data;
 
-    if (Object.keys(contents).length === 0) {
-      return [];
-    }
+    const keyValuePairs =
+      Object.keys(contents).length === 0
+        ? []
+        : Object.entries(contents).map(([key, value]) => ({
+            key,
+            value: value.base64 ? atob(value.base64) : '',
+          }));
 
-    return Object.entries(contents).map(([key, value]) => ({
-      key,
-      value: value.base64 ? atob(value.base64) : '',
-    }));
+    return { keyValuePairs, immutable, type };
   }, [api.secrets, apiAvailable, isOpen, secretName, selectedNamespace]);
 
-  return useFetchState(call, [], { initialPromisePurity: true });
+  return useFetchState(call, DEFAULT_SECRET_DETAILS, { initialPromisePurity: true });
 };
 
-export default useSecretContents;
+export default useSecret;

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSecrets.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesSecrets.tsx
@@ -14,7 +14,6 @@ import {
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Dropdown, DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown';
 import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
 import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
@@ -313,7 +312,6 @@ export const WorkspaceFormPropertiesSecrets: React.FC<WorkspaceFormPropertiesSec
             </Thead>
             {secrets.map((secret, index) => {
               const secretDetails = availableSecrets.find((s) => s.name === secret.secretName);
-              const isImmutable = secretDetails?.immutable ?? false;
               const canUpdate = secretDetails?.canUpdate ?? true;
               const isExpanded = expandedSecrets.has(secret.secretName);
 
@@ -328,21 +326,7 @@ export const WorkspaceFormPropertiesSecrets: React.FC<WorkspaceFormPropertiesSec
                       }}
                       data-testid={`expand-secret-${secret.secretName}`}
                     />
-                    <Td dataLabel="Secret Name">
-                      <Flex
-                        spaceItems={{ default: 'spaceItemsSm' }}
-                        alignItems={{ default: 'alignItemsCenter' }}
-                      >
-                        <FlexItem>{secret.secretName}</FlexItem>
-                        {isImmutable && (
-                          <FlexItem>
-                            <Label color="orange" isCompact>
-                              Immutable
-                            </Label>
-                          </FlexItem>
-                        )}
-                      </Flex>
-                    </Td>
+                    <Td dataLabel="Secret Name">{secret.secretName}</Td>
                     <Td dataLabel="Mount Path" hasAction>
                       <MountPathField
                         variant="cell"
@@ -377,14 +361,8 @@ export const WorkspaceFormPropertiesSecrets: React.FC<WorkspaceFormPropertiesSec
                         onOpenChange={(isOpen) => setDropdownOpen(isOpen ? index : null)}
                         popperProps={{ position: 'right' }}
                       >
-                        {isImmutable || !canUpdate ? (
-                          <Tooltip
-                            content={
-                              isImmutable
-                                ? 'This secret is immutable and cannot be edited.'
-                                : 'You do not have permission to edit this secret.'
-                            }
-                          >
+                        {!canUpdate ? (
+                          <Tooltip content="You do not have permission to edit this secret.">
                             <DropdownItem
                               isAriaDisabled
                               data-testid={`edit-secret-${secret.secretName}`}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/secrets/SecretsAttachModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/secrets/SecretsAttachModal.tsx
@@ -181,12 +181,6 @@ export const SecretsAttachModal: React.FC<SecretsAttachModalProps> = ({
               <Stack>
                 <StackItem>
                   <LabelGroup>
-                    <Label isCompact>Type: {secret.type}</Label>
-                    {secret.immutable && (
-                      <Label color="orange" isCompact>
-                        Immutable
-                      </Label>
-                    )}
                     {!secret.canMount && <Label isCompact>Unmountable</Label>}
                   </LabelGroup>
                 </StackItem>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/secrets/SecretsAttachModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/secrets/SecretsAttachModal.tsx
@@ -14,7 +14,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/comp
 import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { ValidatedOptions } from '@patternfly/react-core/helpers';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
-import { Label, LabelGroup } from '@patternfly/react-core/dist/esm/components/Label';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
@@ -179,11 +179,11 @@ export const SecretsAttachModal: React.FC<SecretsAttachModalProps> = ({
           <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
             <FlexItem>
               <Stack>
-                <StackItem>
-                  <LabelGroup>
-                    {!secret.canMount && <Label isCompact>Unmountable</Label>}
-                  </LabelGroup>
-                </StackItem>
+                {!secret.canMount && (
+                  <StackItem>
+                    <Label isCompact>Unmountable</Label>
+                  </StackItem>
+                )}
                 {secret.mounts && (
                   <StackItem className="pf-v6-u-ml-sm pf-v6-u-mt-xs">
                     <Flex gap={{ default: 'gapXs' }}>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/secrets/SecretsCreateModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/secrets/SecretsCreateModal.tsx
@@ -20,7 +20,7 @@ import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { useNamespaceSelectorWrapper } from '~/app/hooks/useNamespaceSelectorWrapper';
 import { SecretsSecretListItem } from '~/generated/data-contracts';
 import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
-import useSecretContents, { SecretKeyValuePair } from '~/app/hooks/useSecretContents';
+import useSecret, { SecretKeyValuePair } from '~/app/hooks/useSecret';
 import { EditableRowsTable } from '~/app/pages/WorkspaceKinds/Form/EditableRowsTable';
 
 interface SecretsCreateModalProps {
@@ -61,7 +61,7 @@ export const SecretsCreateModal: React.FC<SecretsCreateModalProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [immutable, setImmutable] = useState(false);
 
-  const [secretContents, isSecretContentsLoaded, secretContentsError] = useSecretContents({
+  const [secretDetails, isSecretLoaded, secretLoadError] = useSecret({
     isOpen,
     secretName: secretToEdit?.name,
   });
@@ -70,23 +70,27 @@ export const SecretsCreateModal: React.FC<SecretsCreateModalProps> = ({
   useEffect(() => {
     if (isOpen && secretToEdit) {
       setSecretName(secretToEdit.name);
-      setImmutable(secretToEdit.immutable);
     }
   }, [isOpen, secretToEdit]);
 
-  // Sync fetched secret contents to form state
+  // Sync fetched secret data to form state
   useEffect(() => {
-    if (isSecretContentsLoaded && secretContents.length > 0) {
-      setKeyValuePairs(secretContents);
+    if (isSecretLoaded) {
+      if (secretDetails.keyValuePairs.length > 0) {
+        setKeyValuePairs(secretDetails.keyValuePairs);
+      }
+      if (isEditMode) {
+        setImmutable(secretDetails.immutable);
+      }
     }
-  }, [isSecretContentsLoaded, secretContents]);
+  }, [isSecretLoaded, secretDetails, isEditMode]);
 
-  // Set error from secret contents fetch
+  // Set error from secret fetch
   useEffect(() => {
-    if (secretContentsError) {
+    if (secretLoadError) {
       setError('Failed to load secret contents');
     }
-  }, [secretContentsError]);
+  }, [secretLoadError]);
 
   const validateSecretName = useCallback(
     (name: string): string | null => {
@@ -244,7 +248,7 @@ export const SecretsCreateModal: React.FC<SecretsCreateModalProps> = ({
             {error}
           </Alert>
         )}
-        {isEditMode && !isSecretContentsLoaded && !secretContentsError && (
+        {isEditMode && !isSecretLoaded && !secretLoadError && (
           <Alert variant={AlertVariant.info} isInline title="Loading">
             Loading secret data...
           </Alert>
@@ -304,7 +308,7 @@ export const SecretsCreateModal: React.FC<SecretsCreateModalProps> = ({
               }
               isChecked={immutable}
               onChange={(_event, checked) => setImmutable(checked)}
-              isDisabled={isEditMode && secretToEdit.immutable}
+              isDisabled={isEditMode && secretDetails.immutable}
             />
           </FormGroup>
           <ThemeAwareFormGroupWrapper label="Secret type" isRequired fieldId="secret-type">
@@ -354,8 +358,8 @@ export const SecretsCreateModal: React.FC<SecretsCreateModalProps> = ({
           isLoading={isSubmitting}
           isDisabled={
             isSubmitting ||
-            (isEditMode && !isSecretContentsLoaded) ||
-            (isEditMode && secretToEdit.immutable) ||
+            (isEditMode && !isSecretLoaded) ||
+            (isEditMode && secretDetails.immutable) ||
             (isEditMode && !secretToEdit.canUpdate)
           }
           data-testid="secret-modal-submit-button"


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_ 

The upcoming Secrets API implementation (https://github.com/kubeflow/notebooks/pull/955) removes `type` and `immutable` from `SecretListItem` because the list endpoint will use a metadata-only cache (PartialObjectMetadata) that does not have access to these fields. This commit prepares the frontend so that PR is not a breaking change.

Key changes:

- SecretsAttachModal: remove Type label and Immutable badge from the secret picker dropdown, as these were sourced from the list response

- WorkspaceFormPropertiesSecrets: remove Immutable badge from the secrets table, simplify edit-action disable logic from `isImmutable || !canUpdate` to `!canUpdate` (immutability enforcement now happens inside the edit modal itself)

- Rename useSecretContents to useSecret: expand the hook to return `immutable` and `type` from the single-secret GET response (SecretUpdate), which still carries these fields. The hook was already making this API call but was discarding everything except key-value pairs.

- SecretsCreateModal: source immutable state from the useSecret hook (GET response) instead of from secretToEdit (list item). The immutable switch disable guard and submit button disable guard are preserved, just re-wired to the GET response data. This is important because canUpdate (a label) and immutable (a K8s Secret field) are independent — the backend does not enforce that immutable secrets have canUpdate=false.