### PR TITLE
chore: bump dorny/paths-filter from 3.0.2 to 4.0.1

### DIFF
--- a/.github/workflows/ws-publish.yml
+++ b/.github/workflows/ws-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           base: ${{ github.ref }}


### PR DESCRIPTION
Bumps dorny/paths-filter from 3.0.2 to 4.0.1. Also corrects the inline version comment to reflect the full version (v4.0.1).
