### PR TITLE
ci: only publish semver-tagged images from release branches

### DIFF
--- a/.github/workflows/ws-publish.yml
+++ b/.github/workflows/ws-publish.yml
@@ -60,7 +60,8 @@ jobs:
     with:
       image_name: ${{ matrix.image_name }}
       tag_with_latest: false # we don't use 'latest' tags for workspace images
-      tag_with_semver: ${{ needs.check_version.outputs.version_changed == 'true' }}
+      # We only publish version-tagged images from release branches
+      tag_with_semver: ${{ needs.check_version.outputs.version_changed == 'true' && startsWith(github.ref, 'refs/heads/v') }}
       tag_with_sha: true
       semver_raw: ${{ needs.check_version.outputs.version_raw }}
       build_file: ${{ matrix.build_file }}


### PR DESCRIPTION
Guard `tag_with_semver` with `startsWith(github.ref, 'refs/heads/v')` to
further ensure that these image are only published from release branches.

See https://github.com/kubeflow/notebooks/pull/987 for reference.
