### PR TITLE
fix: wrap long workspace option card text

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -12,6 +12,12 @@
   opacity: 1 !important;
 }
 
+.workspace-option-card__title,
+.pf-v6-c-card__body.workspace-option-card__description {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
 .pf-v6-c-card__body.workspace-option-card__description {
   font-size: var(--pf-v6-global--FontSize--xs);
   color: var(--pf-v6-c-content--small--Color);

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
@@ -164,7 +164,9 @@ export const WorkspaceFormKindList: React.FunctionComponent<WorkspaceFormKindLis
                         </WorkspaceKindImage>
                       </FlexItem>
                       <FlexItem>
-                        <CardTitle>{kind.displayName}</CardTitle>
+                        <CardTitle className="workspace-option-card__title">
+                          {kind.displayName}
+                        </CardTitle>
                       </FlexItem>
                     </Flex>
                   </CardHeader>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
@@ -155,7 +155,7 @@ export const WorkspaceFormOptionCard: React.FC<
         }
         data-testid={`option-card-header-${cardId}`}
       >
-        <CardTitle>{option.displayName}</CardTitle>
+        <CardTitle className="workspace-option-card__title">{option.displayName}</CardTitle>
       </CardHeader>
       {option.description && (
         <CardBody

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/__tests__/WorkspaceFormOptionCard.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/__tests__/WorkspaceFormOptionCard.spec.tsx
@@ -518,16 +518,6 @@ describe('WorkspaceFormOptionCard', () => {
       expect(description).toBeInTheDocument();
       expect(description).toHaveTextContent(option.description);
     });
-
-    it('should render title with workspace-option-card__title class', () => {
-      const workspaceKind = buildMockWorkspaceKind();
-      const option = workspaceKind.podTemplate.options.imageConfig.values![0];
-      const allOptions = workspaceKind.podTemplate.options.imageConfig.values!;
-
-      render(<WorkspaceFormOptionCard {...defaultProps} option={option} allOptions={allOptions} />);
-
-      expect(screen.getByText(option.displayName)).toHaveClass('workspace-option-card__title');
-    });
   });
 
   describe('PodConfig options', () => {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/__tests__/WorkspaceFormOptionCard.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/__tests__/WorkspaceFormOptionCard.spec.tsx
@@ -518,6 +518,16 @@ describe('WorkspaceFormOptionCard', () => {
       expect(description).toBeInTheDocument();
       expect(description).toHaveTextContent(option.description);
     });
+
+    it('should render title with workspace-option-card__title class', () => {
+      const workspaceKind = buildMockWorkspaceKind();
+      const option = workspaceKind.podTemplate.options.imageConfig.values![0];
+      const allOptions = workspaceKind.podTemplate.options.imageConfig.values!;
+
+      render(<WorkspaceFormOptionCard {...defaultProps} option={option} allOptions={allOptions} />);
+
+      expect(screen.getByText(option.displayName)).toHaveClass('workspace-option-card__title');
+    });
   });
 
   describe('PodConfig options', () => {


### PR DESCRIPTION
Fixes https://github.com/kubeflow/notebooks/issues/1142

## Summary

- add a shared title class to Workspace option card titles
- apply the same title class to Workspace Kind cards
- allow Workspace option card titles and descriptions to wrap within the card
- add a focused test assertion for the option card title class

## Testing

- npm run prettier:check -- src/app/app.css src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx src/app/pages/Workspaces/Form/shared/__tests__/WorkspaceFormOptionCard.spec.tsx src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
- npm run test:lint -- src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx src/app/pages/Workspaces/Form/shared/__tests__/WorkspaceFormOptionCard.spec.tsx src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
- npm run test:jest -- WorkspaceFormOptionCard.spec.tsx --runInBand --silent
- npm run test:type-check -- --pretty false
- npm run build
