### PR TITLE
feat: allow ingress from istio-system to workspace pods

### DIFF
--- a/workspaces/controller/manifests/kustomize/components/istio/kustomization.yaml
+++ b/workspaces/controller/manifests/kustomize/components/istio/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Component
 
 resources:
 - network-policy.yaml
+- network-policy-workspaces.yaml
 
 patches:
 - path: deployment_patch.yaml

--- a/workspaces/controller/manifests/kustomize/components/istio/network-policy-workspaces.yaml
+++ b/workspaces/controller/manifests/kustomize/components/istio/network-policy-workspaces.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: workspaces-ingress-allow
+spec:
+  podSelector:
+    matchExpressions:
+      - key: notebooks.kubeflow.org/workspace-name
+        operator: Exists
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - istio-system
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
This PR addresses a routing/access issue when deploying Kubeflow Workspaces/Notebooks v2 with the Istio component overlay.

The namespace base configuration defines a [default-deny-ingress](https://github.com/kubeflow/notebooks/blob/notebooks-v2/workspaces/controller/manifests/kustomize/base/namespace/network-policy-default-deny.yaml) NetworkPolicy, which blocks all incoming traffic to all pods. Currently, there is no companion `NetworkPolicy` configured under the `istio` component to allow ingress traffic from the Istio Ingress Gateway to the dynamic workspace notebook pods. 