### PR TITLE
fix: hide workspace kind pod labels in summary

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx
@@ -341,10 +341,8 @@ export const WorkspaceFormSummaryPanel: React.FC<WorkspaceFormSummaryPanelProps>
         title: 'Workspace Kind',
         displayName: selectedKind?.displayName || selectedKind?.name,
         description: selectedKind?.description,
-        labels: selectedKind?.podTemplate.podMetadata.labels,
         originalDisplayName: originalKind?.displayName || originalKind?.name,
         originalDescription: originalKind?.description,
-        originalLabels: originalKind?.podTemplate.podMetadata.labels,
         disabledTooltip: isEditMode
           ? 'Workspace kind cannot be changed after creation.'
           : undefined,

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/__tests__/WorkspaceFormSummaryPanel.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/__tests__/WorkspaceFormSummaryPanel.spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WorkspaceFormSummaryPanel } from '~/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel';
+import { buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+import { WorkspaceFormProperties } from '~/app/types';
+
+describe('WorkspaceFormSummaryPanel', () => {
+  const defaultProperties: WorkspaceFormProperties = {
+    workspaceName: '',
+    homeVolume: undefined,
+    volumes: [],
+    secrets: [],
+  };
+
+  const defaultProps = {
+    mode: 'create' as const,
+    selectedImage: undefined,
+    selectedPodConfig: undefined,
+    properties: defaultProperties,
+    currentStep: 3,
+    onNavigateToStep: jest.fn(),
+    onSelectImage: jest.fn(),
+    onSelectPodConfig: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not show WorkspaceKind pod labels in the summary panel', () => {
+    const selectedKind = buildMockWorkspaceKind({
+      podTemplate: {
+        ...buildMockWorkspaceKind().podTemplate,
+        podMetadata: {
+          labels: {
+            implementationLabel: 'hidden-from-users',
+          },
+          annotations: {},
+        },
+      },
+    });
+
+    const selectedImage = selectedKind.podTemplate.options.imageConfig.values![0];
+    const selectedPodConfig = selectedKind.podTemplate.options.podConfig.values![0];
+
+    render(
+      <WorkspaceFormSummaryPanel
+        {...defaultProps}
+        selectedKind={selectedKind}
+        selectedImage={selectedImage}
+        selectedPodConfig={selectedPodConfig}
+      />,
+    );
+
+    expect(screen.getByText('Workspace Kind')).toBeInTheDocument();
+    expect(screen.getByText(selectedKind.displayName)).toBeInTheDocument();
+    expect(screen.getByText(selectedKind.description)).toBeInTheDocument();
+    expect(screen.queryByText('implementationLabel: hidden-from-users')).not.toBeInTheDocument();
+    expect(screen.getByText('pythonVersion: 3.11')).toBeInTheDocument();
+    expect(screen.getByText('cpu: 100m')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1143.

## Summary
- stop showing WorkspaceKind pod metadata labels in the create-flow summary panel
- keep image and pod config option labels visible in their summary cards
- add a focused unit test for the summary panel behavior

## Tests
- npm run test:jest -- WorkspaceFormSummaryPanel.spec.tsx --runInBand
- npx prettier --check src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx src/app/pages/Workspaces/Form/__tests__/WorkspaceFormSummaryPanel.spec.tsx
- npm run test:lint -- --quiet --ext .tsx src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx src/app/pages/Workspaces/Form/__tests__/WorkspaceFormSummaryPanel.spec.tsx
- git diff --check

## AI Tooling Disclosure
AI tooling was used in developing this contribution. I reviewed, tested, and take full responsibility for the changes.
