### PR TITLE
fix: warn for redirected or hidden workspace options

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -18,6 +18,7 @@ import {
   secretsManagement,
 } from '~/__tests__/cypress/cypress/pages/workspaces/secretsManagement';
 import type { OptionsImageConfigValue, OptionsPodConfigValue } from '~/generated/data-contracts';
+import { OptionsRedirectMessageLevel } from '~/generated/data-contracts';
 
 const STEP_NAMES = {
   KIND: 'Workspace Kind',
@@ -1581,6 +1582,246 @@ describe('Create workspace', () => {
       createWorkspace.clickNext();
 
       createWorkspace.assertPodConfigSelected(bigGpuPod.id);
+    });
+  });
+
+  describe('Redirect confirmation modal', () => {
+    const redirectedImageId = 'jupyterlab_scipy_180';
+    const targetImageId = 'jupyterlab_scipy_190';
+    const redirectedPodConfigId = 'tiny_cpu_old';
+    const targetPodConfigId = 'tiny_cpu';
+
+    const buildKindWithRedirectedImage = () =>
+      buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: {
+              default: targetImageId,
+              values: [
+                {
+                  id: redirectedImageId,
+                  displayName: 'jupyter-scipy:v1.8.0',
+                  description: 'Older JupyterLab',
+                  labels: [],
+                  hidden: false,
+                  redirect: {
+                    to: targetImageId,
+                    message: {
+                      level: OptionsRedirectMessageLevel.RedirectMessageLevelWarning,
+                      text: 'Please use the newer version.',
+                    },
+                  },
+                },
+                buildMockImageConfigValue(
+                  targetImageId,
+                  'jupyter-scipy:v1.9.0',
+                  'Newer JupyterLab',
+                ),
+              ],
+            },
+            podConfig: {
+              default: targetPodConfigId,
+              values: [
+                buildMockPodConfigValue(targetPodConfigId, mockPodConfig.displayName, 'Tiny CPU'),
+              ],
+            },
+          },
+        },
+      });
+
+    const buildKindWithHiddenImage = () =>
+      buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: {
+              default: targetImageId,
+              values: [
+                {
+                  id: redirectedImageId,
+                  displayName: 'jupyter-scipy:v1.8.0',
+                  description: 'Deprecated JupyterLab',
+                  labels: [],
+                  hidden: true,
+                },
+                buildMockImageConfigValue(
+                  targetImageId,
+                  'jupyter-scipy:v1.9.0',
+                  'Newer JupyterLab',
+                ),
+              ],
+            },
+            podConfig: {
+              default: targetPodConfigId,
+              values: [
+                buildMockPodConfigValue(targetPodConfigId, mockPodConfig.displayName, 'Tiny CPU'),
+              ],
+            },
+          },
+        },
+      });
+
+    const buildKindWithRedirectedPodConfig = () =>
+      buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: {
+              default: mockImage.id,
+              values: [
+                buildMockImageConfigValue(mockImage.id, mockImage.displayName, 'JupyterLab'),
+              ],
+            },
+            podConfig: {
+              default: targetPodConfigId,
+              values: [
+                {
+                  id: redirectedPodConfigId,
+                  displayName: 'Tiny CPU (old)',
+                  description: 'Deprecated pod config',
+                  labels: [],
+                  hidden: false,
+                  redirect: {
+                    to: targetPodConfigId,
+                    message: {
+                      level: OptionsRedirectMessageLevel.RedirectMessageLevelInfo,
+                      text: 'Use the updated pod config.',
+                    },
+                  },
+                },
+                buildMockPodConfigValue(targetPodConfigId, 'Tiny CPU', 'Current pod config'),
+              ],
+            },
+          },
+        },
+      });
+
+    it('shows redirect modal on Next for a redirected image and advances on confirm', () => {
+      const kind = buildKindWithRedirectedImage();
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsRedirect');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsRedirect');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.checkExtraFilter('showRedirected');
+      createWorkspace.selectImage(redirectedImageId);
+      createWorkspace.clickNext();
+
+      cy.findByTestId('redirect-confirmation-modal').should('be.visible');
+      cy.findByTestId('redirect-confirmation-modal').within(() => {
+        cy.contains('Redirected Option Selected').should('be.visible');
+        cy.contains('jupyter-scipy:v1.8.0').should('be.visible');
+        cy.contains('jupyter-scipy:v1.9.0').should('be.visible');
+        cy.findByTestId('confirm-button').click();
+      });
+
+      cy.findByTestId('redirect-confirmation-modal').should('not.exist');
+      createWorkspace.findPodConfigCard(targetPodConfigId).should('be.visible');
+    });
+
+    it('shows redirect modal on Next for a redirected image and stays on image step on cancel', () => {
+      const kind = buildKindWithRedirectedImage();
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsRedirectCancel');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsRedirectCancel');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.checkExtraFilter('showRedirected');
+      createWorkspace.selectImage(redirectedImageId);
+      createWorkspace.clickNext();
+
+      cy.findByTestId('redirect-confirmation-modal').should('be.visible');
+      cy.findByTestId('redirect-confirmation-modal').within(() => {
+        cy.findByTestId('cancel-button').click();
+      });
+
+      cy.findByTestId('redirect-confirmation-modal').should('not.exist');
+      createWorkspace.assertImageSelected(redirectedImageId);
+    });
+
+    it('shows hidden option modal on Next for a hidden image and advances on confirm', () => {
+      const kind = buildKindWithHiddenImage();
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsHidden');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsHidden');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.checkExtraFilter('showHidden');
+      createWorkspace.selectImage(redirectedImageId);
+      createWorkspace.clickNext();
+
+      cy.findByTestId('redirect-confirmation-modal').should('be.visible');
+      cy.findByTestId('redirect-confirmation-modal').within(() => {
+        cy.contains('Hidden Option Selected').should('be.visible');
+        cy.findByTestId('confirm-button').click();
+      });
+
+      cy.findByTestId('redirect-confirmation-modal').should('not.exist');
+      createWorkspace.findPodConfigCard(targetPodConfigId).should('be.visible');
+    });
+
+    it('shows redirect modal on Next for a redirected pod config and advances on confirm', () => {
+      const kind = buildKindWithRedirectedPodConfig();
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsRedirectPod');
+      interceptListValues(kind);
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsRedirectPod');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.selectImage(mockImage.id);
+      createWorkspace.clickNext();
+
+      createWorkspace.checkExtraFilter('showRedirected');
+      createWorkspace.selectPodConfig(redirectedPodConfigId);
+      createWorkspace.clickNext();
+
+      cy.findByTestId('redirect-confirmation-modal').should('be.visible');
+      cy.findByTestId('redirect-confirmation-modal').within(() => {
+        cy.contains('Redirected Option Selected').should('be.visible');
+        cy.contains('Tiny CPU (old)').should('be.visible');
+        cy.contains('Tiny CPU').should('be.visible');
+        cy.findByTestId('confirm-button').click();
+      });
+
+      cy.findByTestId('redirect-confirmation-modal').should('not.exist');
+      createWorkspace.findNextButton().should('not.exist');
+      createWorkspace.findSubmitButton().should('exist');
     });
   });
 });

--- a/workspaces/frontend/src/app/components/RedirectIconWithPopover.tsx
+++ b/workspaces/frontend/src/app/components/RedirectIconWithPopover.tsx
@@ -6,7 +6,8 @@ import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { WorkspacesRedirectStep, WorkspacesRedirectMessageLevel } from '~/generated/data-contracts';
+import { getMessageLevelColor, getMessageLevelText } from '~/shared/utilities/RedirectUtils';
+import { WorkspacesRedirectStep } from '~/generated/data-contracts';
 
 interface RedirectIconWithPopoverProps {
   redirectChain?: WorkspacesRedirectStep[];
@@ -16,34 +17,6 @@ interface RedirectIconWithPopoverProps {
   onActiveChange: (id: string | null) => void;
   onPinnedChange: (id: string | null) => void;
 }
-
-const getMessageLevelColor = (
-  level?: WorkspacesRedirectMessageLevel,
-): 'blue' | 'orange' | 'red' => {
-  switch (level) {
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo:
-      return 'blue';
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
-      return 'orange';
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
-      return 'red';
-    default:
-      return 'blue';
-  }
-};
-
-const getMessageLevelText = (level?: WorkspacesRedirectMessageLevel): string => {
-  switch (level) {
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo:
-      return 'Info';
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
-      return 'Warning';
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
-      return 'Danger';
-    default:
-      return 'Info';
-  }
-};
 
 const buildRedirectPopoverContent = (redirectChain: WorkspacesRedirectStep[]): React.ReactNode => {
   if (redirectChain.length === 0) {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -34,11 +34,14 @@ import { WorkspaceFormData } from '~/app/types';
 import usePodTemplateOptionsListValues from '~/app/hooks/usePodTemplateOptionsListValues';
 import useWorkspaceFormData from '~/app/hooks/useWorkspaceFormData';
 import { useTypedNavigate } from '~/app/routerHelper';
+import { RedirectConfirmationModal } from '~/app/pages/Workspaces/Form/shared/RedirectConfirmationModal';
+import { transformRedirectToChain } from '~/shared/utilities/RedirectUtils';
 import {
   ApiErrorEnvelope,
   OptionsImageConfigValue,
   OptionsPodConfigValue,
   WorkspacekindsWorkspaceKindListItem,
+  WorkspacesRedirectStep,
 } from '~/generated/data-contracts';
 import { extractErrorMessage } from '~/shared/api/apiUtils';
 import { ErrorAlert } from '~/shared/components/ErrorAlert';
@@ -83,6 +86,10 @@ const WorkspaceForm: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentStep, setCurrentStep] = useState(WorkspaceFormSteps.KindSelection);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
+
+  const [isRedirectModalOpen, setIsRedirectModalOpen] = useState(false);
+  const [redirectChain, setRedirectChain] = useState<WorkspacesRedirectStep[]>([]);
+  const [isOptionHidden, setIsOptionHidden] = useState(false);
 
   const [data, setData, resetData, replaceData] =
     useGenericObjectState<WorkspaceFormData>(initialFormData);
@@ -185,14 +192,6 @@ const WorkspaceForm: React.FC = () => {
     setCurrentStep(newStep);
   }, [currentStep]);
 
-  const navigateToStep = useCallback((step: number) => {
-    setCurrentStep(step);
-  }, []);
-
-  const canGoToPreviousStep = useMemo(() => currentStep > 0, [currentStep]);
-
-  const isCurrentStepValid = useMemo(() => isStepValid(currentStep), [isStepValid, currentStep]);
-
   const selectedImage = useMemo(
     () => allValuesData?.imageConfig.values?.find((image) => image.id === data.imageConfig),
     [allValuesData, data.imageConfig],
@@ -205,6 +204,37 @@ const WorkspaceForm: React.FC = () => {
       ),
     [filteredValuesData, allValuesData, data.podConfig],
   );
+
+  const handleNext = useCallback(() => {
+    let currentOption: OptionsImageConfigValue | OptionsPodConfigValue | undefined;
+    let allOptions: (OptionsImageConfigValue | OptionsPodConfigValue)[] = [];
+
+    if (currentStep === WorkspaceFormSteps.ImageSelection && selectedImage) {
+      currentOption = selectedImage;
+      allOptions = allValuesData?.imageConfig.values ?? [];
+    } else if (currentStep === WorkspaceFormSteps.PodConfigSelection && selectedPodConfig) {
+      currentOption = selectedPodConfig;
+      allOptions = (filteredValuesData ?? allValuesData)?.podConfig.values ?? [];
+    }
+
+    if (currentOption && (currentOption.hidden || currentOption.redirect)) {
+      const chain = transformRedirectToChain(currentOption, allOptions);
+      setRedirectChain(chain ?? []);
+      setIsOptionHidden(Boolean(currentOption.hidden));
+      setIsRedirectModalOpen(true);
+      return;
+    }
+
+    nextStep();
+  }, [currentStep, selectedImage, selectedPodConfig, allValuesData, filteredValuesData, nextStep]);
+
+  const navigateToStep = useCallback((step: number) => {
+    setCurrentStep(step);
+  }, []);
+
+  const canGoToPreviousStep = useMemo(() => currentStep > 0, [currentStep]);
+
+  const isCurrentStepValid = useMemo(() => isStepValid(currentStep), [isStepValid, currentStep]);
 
   const canGoToNextStep = useMemo(
     () => currentStep < Object.keys(WorkspaceFormSteps).length / 2 - 1,
@@ -520,7 +550,7 @@ const WorkspaceForm: React.FC = () => {
                       <Button
                         variant="primary"
                         ouiaId="Primary"
-                        onClick={nextStep}
+                        onClick={handleNext}
                         isDisabled={!isCurrentStepValid}
                         data-testid="next-button"
                       >
@@ -549,6 +579,16 @@ const WorkspaceForm: React.FC = () => {
           </Flex>
         </DrawerContentBody>
       </DrawerContent>
+      <RedirectConfirmationModal
+        isOpen={isRedirectModalOpen}
+        onConfirm={() => {
+          setIsRedirectModalOpen(false);
+          nextStep();
+        }}
+        onCancel={() => setIsRedirectModalOpen(false)}
+        redirectChain={redirectChain}
+        isHidden={isOptionHidden}
+      />
     </Drawer>
   );
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/RedirectConfirmationModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/RedirectConfirmationModal.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Modal,
+  ModalVariant,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import { WorkspacesRedirectStep } from '~/generated/data-contracts';
+import { getMessageLevelColor, getMessageLevelText } from '~/shared/utilities/RedirectUtils';
+
+interface RedirectConfirmationModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  redirectChain: WorkspacesRedirectStep[];
+  isHidden?: boolean;
+}
+
+export const RedirectConfirmationModal: React.FC<RedirectConfirmationModalProps> = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+  redirectChain,
+  isHidden,
+}) => (
+  <Modal
+    variant={ModalVariant.medium}
+    isOpen={isOpen}
+    onClose={onCancel}
+    data-testid="redirect-confirmation-modal"
+  >
+    <ModalHeader
+      title={isHidden ? 'Hidden Option Selected' : 'Redirected Option Selected'}
+      titleIconVariant="warning"
+    />
+    <ModalBody>
+      <Stack hasGutter>
+        <StackItem>
+          {isHidden
+            ? 'The option you selected has been hidden or deprecated. Selecting this option may result in using a configuration that is no longer recommended.'
+            : 'Your administrator has redirected the option you selected. The following redirect chain will be applied:'}
+        </StackItem>
+        {!isHidden && (
+          <StackItem>
+            <Stack hasGutter>
+              {redirectChain.map((step, index) => (
+                <React.Fragment key={index}>
+                  {index > 0 && (
+                    <StackItem>
+                      <Divider />
+                    </StackItem>
+                  )}
+                  <StackItem>
+                    <Stack hasGutter>
+                      <StackItem>
+                        <Flex
+                          alignItems={{ default: 'alignItemsCenter' }}
+                          spaceItems={{ default: 'spaceItemsSm' }}
+                        >
+                          {step.message && (
+                            <FlexItem>
+                              <Label color={getMessageLevelColor(step.message.level)}>
+                                {getMessageLevelText(step.message.level)}
+                              </Label>
+                            </FlexItem>
+                          )}
+                          <FlexItem>
+                            <strong>
+                              {step.source.displayName} → {step.target.displayName}
+                            </strong>
+                          </FlexItem>
+                        </Flex>
+                      </StackItem>
+                      {step.message?.text && <StackItem>{step.message.text}</StackItem>}
+                    </Stack>
+                  </StackItem>
+                </React.Fragment>
+              ))}
+            </Stack>
+          </StackItem>
+        )}
+        <StackItem>
+          {isHidden
+            ? 'Are you sure you want to proceed with this hidden option?'
+            : 'Do you want to apply the redirect and proceed?'}
+        </StackItem>
+      </Stack>
+    </ModalBody>
+    <ModalFooter>
+      <Button key="confirm" variant="primary" onClick={onConfirm} data-testid="confirm-button">
+        Confirm
+      </Button>
+      <Button key="cancel" variant="link" onClick={onCancel} data-testid="cancel-button">
+        Cancel
+      </Button>
+    </ModalFooter>
+  </Modal>
+);

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
@@ -9,15 +9,7 @@ import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { HiddenIconWithPopover } from '~/app/components/HiddenIconWithPopover';
 import { RedirectIconWithPopover } from '~/app/components/RedirectIconWithPopover';
-import {
-  OptionsImageConfigValue,
-  OptionsPodConfigValue,
-  WorkspacesRedirectStep,
-  WorkspacesRedirectMessageLevel,
-  OptionsRedirectMessageLevel,
-} from '~/generated/data-contracts';
-
-type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
+import { transformRedirectToChain, OptionValue } from '~/shared/utilities/RedirectUtils';
 
 interface WorkspaceFormOptionCardProps {
   option: OptionValue;
@@ -30,68 +22,6 @@ interface WorkspaceFormOptionCardProps {
   onActivePopoverChange: (id: string | null) => void;
   onPinnedPopoverChange: (id: string | null) => void;
 }
-
-const transformRedirectMessageLevel = (
-  level?: OptionsRedirectMessageLevel,
-): WorkspacesRedirectMessageLevel => {
-  switch (level) {
-    case OptionsRedirectMessageLevel.RedirectMessageLevelInfo:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
-    case OptionsRedirectMessageLevel.RedirectMessageLevelWarning:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning;
-    case OptionsRedirectMessageLevel.RedirectMessageLevelDanger:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger;
-    default:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
-  }
-};
-
-const transformRedirectToChain = (
-  option: OptionValue,
-  allOptions: OptionValue[],
-): WorkspacesRedirectStep[] | undefined => {
-  if (!option.redirect) {
-    return undefined;
-  }
-
-  const targetOption = allOptions.find((opt) => opt.id === option.redirect?.to);
-
-  const targetInfo = targetOption
-    ? {
-        id: targetOption.id,
-        displayName: targetOption.displayName,
-        description: targetOption.description,
-        labels: (targetOption.labels ?? []).map((label) => ({
-          key: label.key,
-          value: label.value,
-        })),
-      }
-    : {
-        id: option.redirect.to,
-        displayName: `${option.redirect.to} (not found)`,
-        description: '',
-        labels: [],
-      };
-
-  const step: WorkspacesRedirectStep = {
-    source: {
-      id: option.id,
-      displayName: option.displayName,
-      description: option.description,
-      labels: (option.labels ?? []).map((label) => ({ key: label.key, value: label.value })),
-    },
-    target: targetInfo,
-  };
-
-  if (option.redirect.message) {
-    step.message = {
-      level: transformRedirectMessageLevel(option.redirect.message.level),
-      text: option.redirect.message.text,
-    };
-  }
-
-  return [step];
-};
 
 export const WorkspaceFormOptionCard: React.FC<
   WorkspaceFormOptionCardProps & { allOptions: OptionValue[] }

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/__tests__/RedirectConfirmationModal.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/__tests__/RedirectConfirmationModal.spec.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RedirectConfirmationModal } from '~/app/pages/Workspaces/Form/shared/RedirectConfirmationModal';
+
+import { WorkspacesRedirectStep } from '~/generated/data-contracts';
+
+describe('RedirectConfirmationModal', () => {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+  const redirectChain = [
+    {
+      source: { displayName: 'Option A' },
+      target: { displayName: 'Option B' },
+      message: { level: 'info', text: 'Redirected for maintenance' },
+    },
+  ] as unknown as WorkspacesRedirectStep[];
+
+  it('renders redirect information when not hidden', () => {
+    render(
+      <RedirectConfirmationModal
+        isOpen
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        redirectChain={redirectChain}
+      />,
+    );
+
+    expect(screen.getByText('Redirected Option Selected')).toBeInTheDocument();
+    expect(screen.getByText('Option A → Option B')).toBeInTheDocument();
+    expect(screen.getByText('Redirected for maintenance')).toBeInTheDocument();
+    expect(screen.getByText('Info')).toBeInTheDocument();
+  });
+
+  it('renders hidden warning when isHidden is true', () => {
+    render(
+      <RedirectConfirmationModal
+        isOpen
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        redirectChain={[]}
+        isHidden
+      />,
+    );
+
+    expect(screen.getByText('Hidden Option Selected')).toBeInTheDocument();
+    expect(screen.getByText(/has been hidden or deprecated/)).toBeInTheDocument();
+    expect(screen.queryByText('Option A → Option B')).not.toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    render(
+      <RedirectConfirmationModal
+        isOpen
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        redirectChain={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('confirm-button'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    render(
+      <RedirectConfirmationModal
+        isOpen
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        redirectChain={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('cancel-button'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/workspaces/frontend/src/shared/utilities/RedirectUtils.ts
+++ b/workspaces/frontend/src/shared/utilities/RedirectUtils.ts
@@ -1,0 +1,99 @@
+import {
+  OptionsImageConfigValue,
+  OptionsPodConfigValue,
+  WorkspacesRedirectStep,
+  WorkspacesRedirectMessageLevel,
+  OptionsRedirectMessageLevel,
+} from '~/generated/data-contracts';
+
+export type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
+
+export const getMessageLevelColor = (
+  level?: WorkspacesRedirectMessageLevel,
+): 'blue' | 'orange' | 'red' => {
+  switch (level) {
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo:
+      return 'blue';
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
+      return 'orange';
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
+      return 'red';
+    default:
+      return 'blue';
+  }
+};
+
+export const getMessageLevelText = (level?: WorkspacesRedirectMessageLevel): string => {
+  switch (level) {
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo:
+      return 'Info';
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
+      return 'Warning';
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
+      return 'Danger';
+    default:
+      return 'Info';
+  }
+};
+
+export const transformRedirectMessageLevel = (
+  level?: OptionsRedirectMessageLevel,
+): WorkspacesRedirectMessageLevel => {
+  switch (level) {
+    case OptionsRedirectMessageLevel.RedirectMessageLevelInfo:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
+    case OptionsRedirectMessageLevel.RedirectMessageLevelWarning:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning;
+    case OptionsRedirectMessageLevel.RedirectMessageLevelDanger:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger;
+    default:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
+  }
+};
+
+export const transformRedirectToChain = (
+  option: OptionValue,
+  allOptions: OptionValue[],
+): WorkspacesRedirectStep[] | undefined => {
+  if (!option.redirect) {
+    return undefined;
+  }
+
+  const targetOption = allOptions.find((opt) => opt.id === option.redirect?.to);
+
+  const targetInfo = targetOption
+    ? {
+        id: targetOption.id,
+        displayName: targetOption.displayName,
+        description: targetOption.description,
+        labels: (targetOption.labels ?? []).map((label) => ({
+          key: label.key,
+          value: label.value,
+        })),
+      }
+    : {
+        id: option.redirect.to,
+        displayName: `${option.redirect.to} (not found)`,
+        description: '',
+        labels: [],
+      };
+
+  const step: WorkspacesRedirectStep = {
+    source: {
+      id: option.id,
+      displayName: option.displayName,
+      description: option.description,
+      labels: (option.labels ?? []).map((label) => ({ key: label.key, value: label.value })),
+    },
+    target: targetInfo,
+  };
+
+  if (option.redirect.message) {
+    step.message = {
+      level: transformRedirectMessageLevel(option.redirect.message.level),
+      text: option.redirect.message.text,
+    };
+  }
+
+  return [step];
+};

--- a/workspaces/frontend/src/shared/utilities/__tests__/RedirectUtils.spec.tsx
+++ b/workspaces/frontend/src/shared/utilities/__tests__/RedirectUtils.spec.tsx
@@ -1,0 +1,97 @@
+import {
+  transformRedirectMessageLevel,
+  transformRedirectToChain,
+  getMessageLevelColor,
+  getMessageLevelText,
+  OptionValue,
+} from '~/shared/utilities/RedirectUtils';
+import {
+  OptionsRedirectMessageLevel,
+  WorkspacesRedirectMessageLevel,
+} from '~/generated/data-contracts';
+
+describe('RedirectUtils', () => {
+  describe('transformRedirectMessageLevel', () => {
+    it('transforms levels correctly', () => {
+      expect(
+        transformRedirectMessageLevel(OptionsRedirectMessageLevel.RedirectMessageLevelInfo),
+      ).toBe(WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo);
+      expect(
+        transformRedirectMessageLevel(OptionsRedirectMessageLevel.RedirectMessageLevelWarning),
+      ).toBe(WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning);
+      expect(
+        transformRedirectMessageLevel(OptionsRedirectMessageLevel.RedirectMessageLevelDanger),
+      ).toBe(WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger);
+      expect(transformRedirectMessageLevel(undefined)).toBe(
+        WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo,
+      );
+    });
+  });
+
+  describe('transformRedirectToChain', () => {
+    const allOptions = [
+      { id: 'opt-b', displayName: 'Option B', description: 'Desc B', labels: [] },
+    ] as unknown as OptionValue[];
+
+    it('returns undefined if no redirect', () => {
+      expect(
+        transformRedirectToChain({ id: 'opt-a' } as unknown as OptionValue, []),
+      ).toBeUndefined();
+    });
+
+    it('builds a single step chain', () => {
+      const optionA = {
+        id: 'opt-a',
+        displayName: 'Option A',
+        description: 'Desc A',
+        labels: [],
+        redirect: { to: 'opt-b', message: { level: 'info', text: 'Msg' } },
+      } as unknown as OptionValue;
+
+      const chain = transformRedirectToChain(optionA, allOptions);
+      expect(chain).toHaveLength(1);
+      expect(chain![0].source.displayName).toBe('Option A');
+      expect(chain![0].target.displayName).toBe('Option B');
+      expect(chain![0].message?.text).toBe('Msg');
+    });
+
+    it('handles missing target gracefully', () => {
+      const optionA = {
+        id: 'opt-a',
+        displayName: 'Option A',
+        redirect: { to: 'missing' },
+      } as unknown as OptionValue;
+
+      const chain = transformRedirectToChain(optionA, []);
+      expect(chain![0].target.displayName).toContain('not found');
+    });
+  });
+
+  describe('getMessageLevelColor', () => {
+    it('returns correct colors', () => {
+      expect(getMessageLevelColor(WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo)).toBe(
+        'blue',
+      );
+      expect(getMessageLevelColor(WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning)).toBe(
+        'orange',
+      );
+      expect(getMessageLevelColor(WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger)).toBe(
+        'red',
+      );
+    });
+  });
+
+  describe('getMessageLevelText', () => {
+    it('returns correct text', () => {
+      expect(getMessageLevelText(WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo)).toBe(
+        'Info',
+      );
+      expect(getMessageLevelText(WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning)).toBe(
+        'Warning',
+      );
+      expect(getMessageLevelText(WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger)).toBe(
+        'Danger',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1144.

## Summary
- add shared redirect/hidden option helpers
- show a confirmation modal before submitting redirected or hidden options
- add focused coverage for redirect utilities and the confirmation modal

## Validation
- git diff --check
- npm --prefix workspaces/frontend run test:jest -- RedirectConfirmationModal.spec.tsx RedirectUtils.spec.ts --runInBand
- npm --prefix workspaces/frontend run test:type-check

## AI Assistance
This contribution was prepared with AI assistance from OpenAI Codex. The commit includes an Assisted-by trailer.