### PR TITLE
chore: fix typo 'indented' -> 'intended' in `user_cluster_roles.yaml`

### DIFF
--- a/workspaces/controller/manifests/kustomize/base/manager/user_cluster_roles.yaml
+++ b/workspaces/controller/manifests/kustomize/base/manager/user_cluster_roles.yaml
@@ -1,7 +1,7 @@
 ##
 ## WARNING: Kubernetes will REMOVE any existing content of `rules` when using `aggregationRule`. 
 ##          So, we define both the `aggregate-to-kubeflow-workspaces-edit` and `kubeflow-workspaces-edit` 
-##          even though only `kubeflow-workspaces-edit` is indented to be used in a binding.
+##          even though only `kubeflow-workspaces-edit` is intended to be used in a binding.
 ##          https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
 ##
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
See https://github.com/kubeflow/manifests/pull/3492#discussion_r3358794780
