### PR TITLE
refactor: Add omitempty to slice fields in backend types

### DIFF
--- a/workspaces/backend/internal/models/pvcs/funcs.go
+++ b/workspaces/backend/internal/models/pvcs/funcs.go
@@ -59,17 +59,8 @@ func NewPVCListItemFromPVC(pvc *corev1.PersistentVolumeClaim, pv *corev1.Persist
 		}
 	}
 
-	// build the list of PodInfo for pods that mount this PVC, if any.
-	podList := make([]PodInfo, 0)
-	if pvcToPodInfoList[pvc.Name] != nil {
-		podList = pvcToPodInfoList[pvc.Name]
-	}
-
-	// build the list of WorkspaceInfo for workspaces that reference this PVC, if any.
-	workspaceList := make([]WorkspaceInfo, 0)
-	if pvcToWorkspaceInfoList[pvc.Name] != nil {
-		workspaceList = pvcToWorkspaceInfoList[pvc.Name]
-	}
+	podList := pvcToPodInfoList[pvc.Name]
+	workspaceList := pvcToWorkspaceInfoList[pvc.Name]
 
 	return PVCListItem{
 		Name:       pvc.Name,

--- a/workspaces/backend/internal/models/pvcs/types.go
+++ b/workspaces/backend/internal/models/pvcs/types.go
@@ -28,8 +28,8 @@ type PVCListItem struct {
 	Name       string          `json:"name"`
 	CanMount   bool            `json:"canMount"`
 	CanUpdate  bool            `json:"canUpdate"`
-	Pods       []PodInfo       `json:"pods"`
-	Workspaces []WorkspaceInfo `json:"workspaces"`
+	Pods       []PodInfo       `json:"pods,omitempty"`
+	Workspaces []WorkspaceInfo `json:"workspaces,omitempty"`
 	Audit      common.Audit    `json:"audit"`
 	PVCSpec    PVCSpec         `json:"pvcSpec"`
 
@@ -67,7 +67,7 @@ type PodTemplatePod struct {
 // PVCSpec represents the PVC spec fields
 type PVCSpec struct {
 	Requests    StorageRequests                     `json:"requests"`
-	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes"`
+	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	VolumeMode  corev1.PersistentVolumeMode         `json:"volumeMode"`
 
 	// This field may be an empty string in two cases:
@@ -86,7 +86,7 @@ type PVInfo struct {
 	Name                          string                               `json:"name"`
 	PersistentVolumeReclaimPolicy corev1.PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy"`
 	VolumeMode                    corev1.PersistentVolumeMode          `json:"volumeMode"`
-	AccessModes                   []corev1.PersistentVolumeAccessMode  `json:"accessModes"`
+	AccessModes                   []corev1.PersistentVolumeAccessMode  `json:"accessModes,omitempty"`
 
 	// This field should only be nil if the bound PV does not have a storage class (i.e. manual or out-of-band binding).
 	StorageClass *StorageClassInfo `json:"storageClass,omitempty"`

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -40,7 +40,7 @@ type WorkspaceListItem struct {
 	StateMessage    string                            `json:"stateMessage"`
 	PodTemplate     PodTemplate                       `json:"podTemplate"`
 	Activity        Activity                          `json:"activity"`
-	Services        []Service                         `json:"services"`
+	Services        []Service                         `json:"services,omitempty"`
 	Audit           commonCore.Audit                  `json:"audit"`
 }
 
@@ -74,7 +74,7 @@ type OptionInfo struct {
 	Id          string        `json:"id"`
 	DisplayName string        `json:"displayName"`
 	Description string        `json:"description"`
-	Labels      []OptionLabel `json:"labels"`
+	Labels      []OptionLabel `json:"labels,omitempty"`
 }
 
 type OptionLabel struct {

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -39,7 +39,7 @@ type WorkspaceListItem struct {
 	StateMessage  string                            `json:"stateMessage"`
 	PodTemplate   PodTemplate                       `json:"podTemplate"`
 	Activity      Activity                          `json:"activity"`
-	Services      []Service                         `json:"services"`
+	Services      []Service                         `json:"services,omitempty"`
 	Audit         commonCore.Audit                  `json:"audit"`
 }
 
@@ -73,7 +73,7 @@ type OptionInfo struct {
 	Id          string        `json:"id"`
 	DisplayName string        `json:"displayName"`
 	Description string        `json:"description"`
-	Labels      []OptionLabel `json:"labels"`
+	Labels      []OptionLabel `json:"labels,omitempty"`
 }
 
 type OptionLabel struct {

--- a/workspaces/backend/internal/models/workspaces/types_write.go
+++ b/workspaces/backend/internal/models/workspaces/types_write.go
@@ -136,7 +136,7 @@ func (p *PodMetadataMutate) Validate(prefix *field.Path) []*field.Error {
 
 type PodVolumesMutate struct {
 	Home    *string          `json:"home,omitempty"`
-	Data    []PodVolumeMount `json:"data"`
+	Data    []PodVolumeMount `json:"data,omitempty"`
 	Secrets []PodSecretMount `json:"secrets,omitempty"`
 }
 

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -2893,9 +2893,7 @@ const docTemplate = `{
                 "canMount",
                 "canUpdate",
                 "name",
-                "pods",
-                "pvcSpec",
-                "workspaces"
+                "pvcSpec"
             ],
             "properties": {
                 "audit": {
@@ -2938,7 +2936,6 @@ const docTemplate = `{
         "pvcs.PVCSpec": {
             "type": "object",
             "required": [
-                "accessModes",
                 "requests",
                 "storageClassName",
                 "volumeMode"
@@ -2965,7 +2962,6 @@ const docTemplate = `{
         "pvcs.PVInfo": {
             "type": "object",
             "required": [
-                "accessModes",
                 "name",
                 "persistentVolumeReclaimPolicy",
                 "volumeMode"
@@ -7211,8 +7207,7 @@ const docTemplate = `{
             "required": [
                 "description",
                 "displayName",
-                "id",
-                "labels"
+                "id"
             ],
             "properties": {
                 "description": {
@@ -7383,9 +7378,6 @@ const docTemplate = `{
         },
         "workspaces.PodVolumesMutate": {
             "type": "object",
-            "required": [
-                "data"
-            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -7531,7 +7523,6 @@ const docTemplate = `{
                 "paused",
                 "pausedTime",
                 "podTemplate",
-                "services",
                 "state",
                 "stateMessage",
                 "workspaceKind"

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -2992,9 +2992,7 @@ const docTemplate = `{
                 "canMount",
                 "canUpdate",
                 "name",
-                "pods",
-                "pvcSpec",
-                "workspaces"
+                "pvcSpec"
             ],
             "properties": {
                 "audit": {
@@ -3037,7 +3035,6 @@ const docTemplate = `{
         "pvcs.PVCSpec": {
             "type": "object",
             "required": [
-                "accessModes",
                 "requests",
                 "storageClassName",
                 "volumeMode"
@@ -3064,7 +3061,6 @@ const docTemplate = `{
         "pvcs.PVInfo": {
             "type": "object",
             "required": [
-                "accessModes",
                 "name",
                 "persistentVolumeReclaimPolicy",
                 "volumeMode"
@@ -7593,8 +7589,7 @@ const docTemplate = `{
             "required": [
                 "description",
                 "displayName",
-                "id",
-                "labels"
+                "id"
             ],
             "properties": {
                 "description": {
@@ -7765,9 +7760,6 @@ const docTemplate = `{
         },
         "workspaces.PodVolumesMutate": {
             "type": "object",
-            "required": [
-                "data"
-            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -7914,7 +7906,6 @@ const docTemplate = `{
                 "paused",
                 "pausedTime",
                 "podTemplate",
-                "services",
                 "state",
                 "stateMessage",
                 "workspaceKind"

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -2990,9 +2990,7 @@
                 "canMount",
                 "canUpdate",
                 "name",
-                "pods",
-                "pvcSpec",
-                "workspaces"
+                "pvcSpec"
             ],
             "properties": {
                 "audit": {
@@ -3035,7 +3033,6 @@
         "pvcs.PVCSpec": {
             "type": "object",
             "required": [
-                "accessModes",
                 "requests",
                 "storageClassName",
                 "volumeMode"
@@ -3062,7 +3059,6 @@
         "pvcs.PVInfo": {
             "type": "object",
             "required": [
-                "accessModes",
                 "name",
                 "persistentVolumeReclaimPolicy",
                 "volumeMode"
@@ -7591,8 +7587,7 @@
             "required": [
                 "description",
                 "displayName",
-                "id",
-                "labels"
+                "id"
             ],
             "properties": {
                 "description": {
@@ -7763,9 +7758,6 @@
         },
         "workspaces.PodVolumesMutate": {
             "type": "object",
-            "required": [
-                "data"
-            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -7912,7 +7904,6 @@
                 "paused",
                 "pausedTime",
                 "podTemplate",
-                "services",
                 "state",
                 "stateMessage",
                 "workspaceKind"

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -2891,9 +2891,7 @@
                 "canMount",
                 "canUpdate",
                 "name",
-                "pods",
-                "pvcSpec",
-                "workspaces"
+                "pvcSpec"
             ],
             "properties": {
                 "audit": {
@@ -2936,7 +2934,6 @@
         "pvcs.PVCSpec": {
             "type": "object",
             "required": [
-                "accessModes",
                 "requests",
                 "storageClassName",
                 "volumeMode"
@@ -2963,7 +2960,6 @@
         "pvcs.PVInfo": {
             "type": "object",
             "required": [
-                "accessModes",
                 "name",
                 "persistentVolumeReclaimPolicy",
                 "volumeMode"
@@ -7209,8 +7205,7 @@
             "required": [
                 "description",
                 "displayName",
-                "id",
-                "labels"
+                "id"
             ],
             "properties": {
                 "description": {
@@ -7381,9 +7376,6 @@
         },
         "workspaces.PodVolumesMutate": {
             "type": "object",
-            "required": [
-                "data"
-            ],
             "properties": {
                 "data": {
                     "type": "array",
@@ -7529,7 +7521,6 @@
                 "paused",
                 "pausedTime",
                 "podTemplate",
-                "services",
                 "state",
                 "stateMessage",
                 "workspaceKind"


### PR DESCRIPTION
Split out from the original PR (which also introduces the custom linter) so it is easier to review / merge separately.

Related-to: https://github.com/kubeflow/notebooks/pull/976

Related-to: https://github.com/kubeflow/notebooks/pull/980

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
