### PR TITLE
fix: default empty workspace state to Unknown in API responses

### DIFF
--- a/workspaces/backend/internal/models/workspaces/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/funcs.go
@@ -86,7 +86,7 @@ func NewWorkspaceListItemFromWorkspace(cfg *config.EnvConfig, ws *kubefloworgv1b
 		Paused:         ptr.Deref(ws.Spec.Paused, false),
 		PausedTime:     ws.Status.PauseTime,
 		PendingRestart: ws.Status.PendingRestart,
-		State:          ws.Status.State,
+		State:          defaultWorkspaceState(ws.Status.State),
 		StateMessage:   ws.Status.StateMessage,
 		PodTemplate: PodTemplate{
 			PodMetadata: PodMetadata{
@@ -117,6 +117,15 @@ func NewWorkspaceListItemFromWorkspace(cfg *config.EnvConfig, ws *kubefloworgv1b
 
 func wskExists(wsk *kubefloworgv1beta1.WorkspaceKind) bool {
 	return wsk != nil && wsk.UID != ""
+}
+
+// defaultWorkspaceState returns WorkspaceStateUnknown when the controller has not
+// yet reconciled a workspace's status, so API consumers never see an empty state.
+func defaultWorkspaceState(state kubefloworgv1beta1.WorkspaceState) kubefloworgv1beta1.WorkspaceState {
+	if state == "" {
+		return kubefloworgv1beta1.WorkspaceStateUnknown
+	}
+	return state
 }
 
 func buildHomeVolume(ws *kubefloworgv1beta1.Workspace, wsk *kubefloworgv1beta1.WorkspaceKind) *PodVolumeInfo {

--- a/workspaces/backend/internal/models/workspaces/funcs_test.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaces
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+)
+
+func TestWorkspacesModels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workspaces Models Suite")
+}
+
+var _ = Describe("defaultWorkspaceState", func() {
+	It("returns WorkspaceStateUnknown for the empty string", func() {
+		Expect(defaultWorkspaceState("")).To(Equal(kubefloworgv1beta1.WorkspaceStateUnknown))
+	})
+
+	It("returns the original state when it is already set", func() {
+		for _, state := range []kubefloworgv1beta1.WorkspaceState{
+			kubefloworgv1beta1.WorkspaceStateRunning,
+			kubefloworgv1beta1.WorkspaceStateTerminating,
+			kubefloworgv1beta1.WorkspaceStatePaused,
+			kubefloworgv1beta1.WorkspaceStatePending,
+			kubefloworgv1beta1.WorkspaceStateError,
+			kubefloworgv1beta1.WorkspaceStateUnknown,
+		} {
+			Expect(defaultWorkspaceState(state)).To(Equal(state))
+		}
+	})
+})


### PR DESCRIPTION
Refs #1104. Replaces #1157.

## Summary
- Default `ws.Status.State` to `WorkspaceStateUnknown` in `NewWorkspaceListItemFromWorkspace` so the list-workspaces API never returns `"state": ""`.
- Add a `defaultWorkspaceState` helper plus a unit test.

## Root cause
`workspaces/backend/internal/models/workspaces/funcs.go` was copying `ws.Status.State` verbatim. `WorkspaceState` is a string-aliased Go type (zero value `""`), and the JSON tag is `json:"state"` (no `omitempty`), so a workspace whose controller had not yet reconciled a status was serialised with an empty `state` field. This contradicts the generated OpenAPI/TS contract, which declares the field as the non-empty `V1Beta1WorkspaceState` enum, and is the source of the empty-label "circle icon" symptom in #1104.

Fixing it server-side keeps the contract honest and removes the need for defensive fallbacks in every client surface (table cell, PVC tooltip, etc.).

## Context
Originally raised as a frontend fallback in #1157; @thaorell correctly flagged the fallback as redundant against the type contract. Tracing the symptom in the backend surfaced the real source.

## Validation
- `go test ./workspaces/backend/internal/models/workspaces/...`
- `go vet ./workspaces/backend/internal/models/workspaces/...`
- `gofmt -d` clean

## AI Assistance
Prepared with AI assistance from Claude. The commit includes an `Assisted-by` trailer.