### PR TITLE
feat: add custom Prometheus metrics to the controller

### DIFF
--- a/workspaces/controller/go.mod
+++ b/workspaces/controller/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
+	github.com/prometheus/client_golang v1.19.1
 	golang.org/x/time v0.3.0
 	google.golang.org/protobuf v1.34.2
 	istio.io/api v1.22.8
@@ -46,7 +47,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/workspaces/controller/internal/controller/metrics.go
+++ b/workspaces/controller/internal/controller/metrics.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	workspaceKindWorkspaceCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "notebooks",
+			Name:      "workspacekind_workspace_count",
+			Help:      "Number of Workspace resources managed by each WorkspaceKind.",
+		},
+		[]string{"workspace_kind"},
+	)
+
+	workspaceKindImageConfigWorkspaceCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "notebooks",
+			Name:      "workspacekind_image_config_workspace_count",
+			Help:      "Number of Workspace resources using each imageConfig option, grouped by WorkspaceKind.",
+		},
+		[]string{"workspace_kind", "image_config"},
+	)
+
+	workspaceKindPodConfigWorkspaceCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "notebooks",
+			Name:      "workspacekind_pod_config_workspace_count",
+			Help:      "Number of Workspace resources using each podConfig option, grouped by WorkspaceKind.",
+		},
+		[]string{"workspace_kind", "pod_config"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		workspaceKindWorkspaceCount,
+		workspaceKindImageConfigWorkspaceCount,
+		workspaceKindPodConfigWorkspaceCount,
+	)
+}
+
+// clearWorkspaceKindMetrics removes all metric time series for a deleted WorkspaceKind.
+func clearWorkspaceKindMetrics(kindName string) {
+	workspaceKindWorkspaceCount.DeleteLabelValues(kindName)
+	workspaceKindImageConfigWorkspaceCount.DeletePartialMatch(prometheus.Labels{"workspace_kind": kindName})
+	workspaceKindPodConfigWorkspaceCount.DeletePartialMatch(prometheus.Labels{"workspace_kind": kindName})
+}

--- a/workspaces/controller/internal/controller/workspacekind_controller.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -75,6 +76,7 @@ func (r *WorkspaceKindReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			// Return and don't requeue.
+			clearWorkspaceKindMetrics(req.Name)
 			return ctrl.Result{}, nil
 		}
 		log.Error(err, "unable to fetch WorkspaceKind")
@@ -141,6 +143,18 @@ func (r *WorkspaceKindReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Id:         podConfig.Id,
 			Workspaces: podConfigCount[podConfig.Id],
 		}
+	}
+
+	// update Prometheus metrics
+	workspaceKindWorkspaceCount.WithLabelValues(workspaceKind.Name).Set(float64(numWorkspace))
+	// we call metric.DeletePartialMatch() to ensure that there are no stale stale time series
+	workspaceKindImageConfigWorkspaceCount.DeletePartialMatch(prometheus.Labels{"workspace_kind": workspaceKind.Name})
+	for _, m := range imageConfigMetrics {
+		workspaceKindImageConfigWorkspaceCount.WithLabelValues(workspaceKind.Name, m.Id).Set(float64(m.Workspaces))
+	}
+	workspaceKindPodConfigWorkspaceCount.DeletePartialMatch(prometheus.Labels{"workspace_kind": workspaceKind.Name})
+	for _, m := range podConfigMetrics {
+		workspaceKindPodConfigWorkspaceCount.WithLabelValues(workspaceKind.Name, m.Id).Set(float64(m.Workspaces))
 	}
 
 	// populate the WorkspaceKind status

--- a/workspaces/controller/internal/controller/workspacekind_controller_test.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -398,6 +399,77 @@ var _ = Describe("WorkspaceKind Controller", func() {
 			By("verifying the logo still has its SHA256 hash")
 			Expect(workspaceKind.Status.SpawnerLogo.Sha256).To(Equal(logoHash))
 			Expect(workspaceKind.Status.SpawnerLogo.ConfigMap).To(BeNil())
+		})
+	})
+
+	Context("When reconciling Prometheus metrics", Serial, Ordered, func() {
+
+		var (
+			workspaceName     string
+			workspaceKindName string
+			workspaceKindKey  types.NamespacedName
+		)
+
+		BeforeAll(func() {
+			uniqueName := "wsk-metrics-test"
+			workspaceName = fmt.Sprintf("workspace-%s", uniqueName)
+			workspaceKindName = fmt.Sprintf("workspacekind-%s", uniqueName)
+			workspaceKindKey = types.NamespacedName{Name: workspaceKindName}
+		})
+
+		It("should expose workspace counts in Prometheus metrics", func() {
+
+			By("creating a WorkspaceKind")
+			workspaceKind := NewExampleWorkspaceKind1(workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspaceKind)).To(Succeed())
+
+			By("creating a Workspace")
+			workspace := NewExampleWorkspace1(workspaceName, namespaceName, workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+
+			By("waiting for the WorkspaceKind to be reconciled")
+			Eventually(func() int32 {
+				if err := k8sClient.Get(ctx, workspaceKindKey, workspaceKind); err != nil {
+					return -1
+				}
+				return workspaceKind.Status.Workspaces
+			}, timeout, interval).Should(Equal(int32(1)))
+
+			By("asserting the workspace count metric")
+			Expect(testutil.ToFloat64(workspaceKindWorkspaceCount.WithLabelValues(workspaceKindName))).To(Equal(float64(1)))
+
+			By("asserting the imageConfig usage metric")
+			Expect(testutil.ToFloat64(workspaceKindImageConfigWorkspaceCount.WithLabelValues(workspaceKindName, "jupyterlab_scipy_180"))).To(Equal(float64(1)))
+			Expect(testutil.ToFloat64(workspaceKindImageConfigWorkspaceCount.WithLabelValues(workspaceKindName, "jupyterlab_scipy_190"))).To(Equal(float64(0)))
+
+			By("asserting the podConfig usage metric")
+			Expect(testutil.ToFloat64(workspaceKindPodConfigWorkspaceCount.WithLabelValues(workspaceKindName, "tiny_cpu"))).To(Equal(float64(1)))
+			Expect(testutil.ToFloat64(workspaceKindPodConfigWorkspaceCount.WithLabelValues(workspaceKindName, "small_cpu"))).To(Equal(float64(0)))
+			Expect(testutil.ToFloat64(workspaceKindPodConfigWorkspaceCount.WithLabelValues(workspaceKindName, "big_gpu"))).To(Equal(float64(0)))
+
+			By("deleting the Workspace")
+			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())
+
+			By("waiting for the WorkspaceKind to reconcile the deletion")
+			Eventually(func() int32 {
+				if err := k8sClient.Get(ctx, workspaceKindKey, workspaceKind); err != nil {
+					return -1
+				}
+				return workspaceKind.Status.Workspaces
+			}, timeout, interval).Should(Equal(int32(0)))
+
+			By("asserting workspace count metric drops to zero")
+			Expect(testutil.ToFloat64(workspaceKindWorkspaceCount.WithLabelValues(workspaceKindName))).To(Equal(float64(0)))
+
+			By("asserting imageConfig metric drops to zero")
+			Expect(testutil.ToFloat64(workspaceKindImageConfigWorkspaceCount.WithLabelValues(workspaceKindName, "jupyterlab_scipy_180"))).To(Equal(float64(0)))
+
+			By("deleting the WorkspaceKind")
+			Expect(k8sClient.Delete(ctx, workspaceKind)).To(Succeed())
+			Expect(k8sClient.Get(ctx, workspaceKindKey, workspaceKind)).NotTo(Succeed())
+
+			By("asserting metrics are cleared after WorkspaceKind deletion")
+			Expect(testutil.ToFloat64(workspaceKindWorkspaceCount.WithLabelValues(workspaceKindName))).To(Equal(float64(0)))
 		})
 	})
 })


### PR DESCRIPTION
Implements three GaugeVec metrics (Workspace count per kind, imageConfig usage and podConfig usage).

Depends on #1140 for testing
Fixes https://github.com/kubeflow/notebooks/issues/1163

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
