### PR TITLE
chore: remove `DISABLE_AUTH` from backend

### DIFF
--- a/developing/Tiltfile
+++ b/developing/Tiltfile
@@ -142,7 +142,6 @@ for o in backend_objects:
             "SWAGGER_SCHEME": "https",
             "SWAGGER_HOST": "localhost:8443",
             "SWAGGER_BASE_PATH": "/workspaces/api/v1",
-            "DISABLE_AUTH": "false",  # TODO: remove once DISABLE_AUTH is removed from backend
         }
 
         # Replace existing keys and add missing ones

--- a/workspaces/backend/api/auth.go
+++ b/workspaces/backend/api/auth.go
@@ -29,15 +29,9 @@ import (
 // requireAuth verifies that the request is authenticated and authorized to take the actions specified by the given policies.
 // If this method returns false, the request has been handled and the caller should return immediately.
 // If this method returns true, the request is authenticated and authorized to proceed.
-// user.Info is the authenticated user, or nil if auth is disabled.
 // This method should only be called once per request.
 func (a *App) requireAuth(w http.ResponseWriter, r *http.Request, policies []*auth.ResourcePolicy) (user.Info, bool) {
 	ctx := r.Context()
-
-	// if auth is disabled, allow the request to proceed (no user information available)
-	if a.Config.DisableAuth {
-		return nil, true
-	}
 
 	// authenticate the request (extract user and groups from the request headers)
 	res, ok, err := a.RequestAuthN.AuthenticateRequest(r)

--- a/workspaces/backend/cmd/main.go
+++ b/workspaces/backend/cmd/main.go
@@ -67,13 +67,6 @@ func main() {
 		getEnvAsInt("CLIENT_BURST", 100),
 		"Maximum Burst configuration passed to rest.Client",
 	)
-	flag.BoolVar(
-		// TODO: remove before GA
-		&cfg.DisableAuth,
-		"disable-auth",
-		getEnvAsBool("DISABLE_AUTH", true),
-		"Disable authentication and authorization",
-	)
 	flag.StringVar(
 		&cfg.UserIdHeader,
 		"userid-header",

--- a/workspaces/backend/internal/config/environment.go
+++ b/workspaces/backend/internal/config/environment.go
@@ -22,8 +22,6 @@ type EnvConfig struct {
 	ClientQPS   float64
 	ClientBurst int
 
-	DisableAuth bool
-
 	UserIdHeader string
 	UserIdPrefix string
 	GroupsHeader string

--- a/workspaces/backend/manifests/kustomize/base/deployment.yaml
+++ b/workspaces/backend/manifests/kustomize/base/deployment.yaml
@@ -36,9 +36,6 @@ spec:
         env:
         - name: PORT
           value: "4000"
-        # TODO: remove before GA
-        - name: DISABLE_AUTH
-          value: "false"
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
Auth is now always enabled following #1110 which wired up mock authentication in the dev environment. Remove the flag, env var and config variable along with the comments that tracked this.
