### PR TITLE
feat: Allow Admin to Edit WorkspaceKind Via Yaml

### DIFF
--- a/workspaces/frontend/config/webpack.dev.js
+++ b/workspaces/frontend/config/webpack.dev.js
@@ -140,6 +140,7 @@ module.exports = smp.wrap(
                 RELATIVE_DIRNAME,
                 'node_modules/mod-arch-shared/node_modules/@patternfly',
               ),
+              path.resolve(RELATIVE_DIRNAME, 'node_modules/monaco-editor'),
             ],
             use: ['style-loader', 'css-loader'],
           },

--- a/workspaces/frontend/config/webpack.prod.js
+++ b/workspaces/frontend/config/webpack.prod.js
@@ -53,6 +53,7 @@ module.exports = merge(
             COMMON_DIR,
             path.resolve(RELATIVE_DIRNAME, 'node_modules/@patternfly'),
             path.resolve(RELATIVE_DIRNAME, 'node_modules/mod-arch-shared/node_modules/@patternfly'),
+            path.resolve(RELATIVE_DIRNAME, 'node_modules/monaco-editor'),
           ],
           use: [MiniCssExtractPlugin.loader, 'css-loader'],
         },

--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "mod-arch-core": "^1.16.1",
         "mod-arch-kubeflow": "^1.16.1",
         "mod-arch-shared": "^1.16.1",
+        "monaco-yaml": "^5.5.0",
         "react": "^18",
         "react-dom": "^18",
         "react-router": "^7.5.2",
@@ -9816,6 +9817,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -23873,6 +23880,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -25702,6 +25715,94 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
+      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0",
+        "vscode-uri": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-marker-data-provider": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.5.tgz",
+      "integrity": "sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.2.tgz",
+      "integrity": "sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-worker-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
+      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-yaml": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.5.0.tgz",
+      "integrity": "sha512-FEJezTYwzL3VFCWnA98mPp0AmPERoiQNN54ycllF0LorUeTXPN2YzJzu9jfzwVn2CxX1qajEornAr4CrZffuMQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "path-browserify": "^1.0.0",
+        "prettier": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
+      }
+    },
+    "node_modules/monaco-yaml/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -26867,6 +26968,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -27664,7 +27771,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "devOptional": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -31777,19 +31883,42 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@monaco-editor/react": "^4.7.0",
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-catalog-view-extension": "^6.2.0",
         "@patternfly/react-code-editor": "^6.4.0",
@@ -30,6 +31,7 @@
         "mod-arch-core": "^1.16.1",
         "mod-arch-kubeflow": "^1.16.1",
         "mod-arch-shared": "^1.16.1",
+        "monaco-editor": "^0.52.2",
         "monaco-yaml": "^5.5.0",
         "react": "^18",
         "react-dom": "^18",
@@ -73,6 +75,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "junit-report-merger": "^7.0.1",
         "mini-css-extract-plugin": "^2.9.0",
+        "monaco-editor-webpack-plugin": "^7.1.1",
         "postcss": "^8.4.49",
         "prettier": "^3.3.3",
         "prop-types": "^15.8.1",
@@ -7059,29 +7062,26 @@
       }
     },
     "node_modules/@monaco-editor/loader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
       "license": "MIT",
       "dependencies": {
         "state-local": "^1.0.6"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.21.0 < 1"
       }
     },
     "node_modules/@monaco-editor/react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
-      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "license": "MIT",
       "dependencies": {
-        "@monaco-editor/loader": "^1.4.0"
+        "@monaco-editor/loader": "^1.5.0"
       },
       "peerDependencies": {
         "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -25712,8 +25712,21 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
+    "node_modules/monaco-editor-webpack-plugin": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.1.1.tgz",
+      "integrity": "sha512-WxdbFHS3Wtz4V9hzhe/Xog5hQRSMxmDLkEEYZwqMDHgJlkZo00HVFZR0j5d0nKypjTUkkygH3dDSXERLG4757A==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "loader-utils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.31.0",
+        "webpack": "^4.5.0 || 5.x"
+      }
     },
     "node_modules/monaco-languageserver-types": {
       "version": "0.4.0",

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -136,6 +136,7 @@
     "mod-arch-core": "^1.16.1",
     "mod-arch-kubeflow": "^1.16.1",
     "mod-arch-shared": "^1.16.1",
+    "monaco-yaml": "^5.5.0",
     "react": "^18",
     "react-dom": "^18",
     "react-router": "^7.5.2",

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -88,6 +88,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "junit-report-merger": "^7.0.1",
     "mini-css-extract-plugin": "^2.9.0",
+    "monaco-editor-webpack-plugin": "^7.1.1",
     "postcss": "^8.4.49",
     "prettier": "^3.3.3",
     "prop-types": "^15.8.1",
@@ -117,6 +118,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@monaco-editor/react": "^4.7.0",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-catalog-view-extension": "^6.2.0",
     "@patternfly/react-code-editor": "^6.4.0",
@@ -136,6 +138,7 @@
     "mod-arch-core": "^1.16.1",
     "mod-arch-kubeflow": "^1.16.1",
     "mod-arch-shared": "^1.16.1",
+    "monaco-editor": "^0.52.2",
     "monaco-yaml": "^5.5.0",
     "react": "^18",
     "react-dom": "^18",

--- a/workspaces/frontend/scripts/generate-api.sh
+++ b/workspaces/frontend/scripts/generate-api.sh
@@ -24,4 +24,7 @@ swagger-typescript-api generate \
   --unwrap-response-data \
   --modular
 
+SCHEMA_OUTPUT="./src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json"
+node ./scripts/generate-schema.js "$TMP_SWAGGER" "$SCHEMA_OUTPUT"
+
 rm "$TMP_SWAGGER"

--- a/workspaces/frontend/scripts/generate-schema.js
+++ b/workspaces/frontend/scripts/generate-schema.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Extracts a self-contained JSON Schema for WorkspaceKindUpdate from the
+ * backend's Swagger spec. Used by monaco-yaml in the YAML editor for
+ * autocompletion and validation.
+ *
+ * Usage: node scripts/generate-schema.js <swagger.json> <output.json>
+ */
+
+const fs = require('fs');
+
+const [swaggerPath, outputPath] = process.argv.slice(2);
+
+if (!swaggerPath || !outputPath) {
+  console.error('Usage: node generate-schema.js <swagger.json> <output.json>');
+  process.exit(1);
+}
+
+const ROOT_DEFINITION = 'workspacekinds.WorkspaceKindUpdate';
+
+const swagger = JSON.parse(fs.readFileSync(swaggerPath, 'utf8'));
+const definitions = swagger.definitions;
+
+const needed = new Set();
+
+function collect(name) {
+  if (needed.has(name)) {
+    return;
+  }
+  needed.add(name);
+  const def = definitions[name];
+  if (!def) {
+    return;
+  }
+  const refs = [...JSON.stringify(def).matchAll(/"\$ref":\s*"#\/definitions\/([^"]+)"/g)];
+  for (const match of refs) {
+    collect(match[1]);
+  }
+}
+
+collect(ROOT_DEFINITION);
+
+const defs = {};
+for (const name of needed) {
+  const rewritten = JSON.stringify(definitions[name]).replace(
+    /"#\/definitions\//g,
+    '"#/$defs/',
+  );
+  defs[name] = JSON.parse(rewritten);
+}
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $ref: `#/$defs/${ROOT_DEFINITION}`,
+  $defs: defs,
+};
+
+fs.writeFileSync(outputPath, JSON.stringify(schema, null, 2) + '\n');
+console.log(`Generated ${ROOT_DEFINITION} JSON Schema (${needed.size} definitions)`);

--- a/workspaces/frontend/scripts/generate-schema.js
+++ b/workspaces/frontend/scripts/generate-schema.js
@@ -43,10 +43,7 @@ collect(ROOT_DEFINITION);
 
 const defs = {};
 for (const name of needed) {
-  const rewritten = JSON.stringify(definitions[name]).replace(
-    /"#\/definitions\//g,
-    '"#/$defs/',
-  );
+  const rewritten = JSON.stringify(definitions[name]).replace(/"#\/definitions\//g, '"#/$defs/');
   defs[name] = JSON.parse(rewritten);
 }
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -1167,7 +1167,7 @@ class EditWorkspaceKind {
   }
 
   assertYamlEditorNotVisible() {
-    this.findYamlEditor().should('not.exist');
+    this.findYamlEditor().should('not.be.visible');
   }
 
   findYamlParseError() {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -1127,6 +1127,61 @@ class EditWorkspaceKind {
     cy.findByTestId('workspace-kind-form-error').should('be.visible');
   }
 
+  // View mode tabs (Form / YAML)
+  findFormTab() {
+    return cy.findByTestId('form-tab');
+  }
+
+  findYamlTab() {
+    return cy.findByTestId('yaml-tab');
+  }
+
+  clickFormTab() {
+    this.findFormTab().click();
+  }
+
+  clickYamlTab() {
+    this.findYamlTab().click();
+  }
+
+  assertFormTabActive() {
+    this.findFormTab().should('have.attr', 'aria-selected', 'true');
+  }
+
+  assertYamlTabActive() {
+    this.findYamlTab().should('have.attr', 'aria-selected', 'true');
+  }
+
+  assertTabsVisible() {
+    this.findFormTab().should('be.visible');
+    this.findYamlTab().should('be.visible');
+  }
+
+  // YAML editor
+  findYamlEditor() {
+    return cy.findByTestId('yaml-editor');
+  }
+
+  assertYamlEditorVisible() {
+    this.findYamlEditor().should('be.visible');
+  }
+
+  assertYamlEditorNotVisible() {
+    this.findYamlEditor().should('not.exist');
+  }
+
+  findYamlParseError() {
+    return cy.findByTestId('yaml-parse-error');
+  }
+
+  assertYamlParseErrorVisible() {
+    this.findYamlParseError().should('be.visible');
+  }
+
+  assertYamlParseErrorNotVisible() {
+    this.findYamlParseError().should('not.exist');
+  }
+
   private wait() {
     this.findPageTitle();
     cy.testA11y();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -1182,6 +1182,19 @@ class EditWorkspaceKind {
     this.findYamlParseError().should('not.exist');
   }
 
+  // Revert button
+  findRevertButton() {
+    return cy.findByTestId('revert-button');
+  }
+
+  clickRevert() {
+    this.findRevertButton().click();
+  }
+
+  assertRevertButtonVisible() {
+    this.findRevertButton().should('be.visible');
+  }
+
   private wait() {
     this.findPageTitle();
     cy.testA11y();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
@@ -1395,6 +1395,14 @@ describe('Edit workspace kind', () => {
       editWorkspaceKind.assertYamlEditorNotVisible();
     });
 
+    it('should have Save disabled when no changes are made in Form tab', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.assertSubmitButtonDisabled(true);
+    });
+
     it('should have Save disabled in YAML tab when no changes are made', () => {
       const { mockWorkspaceKind } = setupEditWorkspaceKind();
 
@@ -1405,71 +1413,62 @@ describe('Edit workspace kind', () => {
       editWorkspaceKind.assertSubmitButtonDisabled(true);
     });
 
-    it('should call update API when saving valid YAML', () => {
+    it('should show form sections when switching from YAML back to Form', () => {
       const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      cy.interceptApi(
-        'PUT /api/:apiVersion/workspacekinds/:kind',
-        { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: mockWorkspaceKind.name } },
-        mockModArchResponse(buildMockWorkspaceKindUpdate(mockWorkspaceKind)),
-      ).as('updateWorkspaceKindYaml');
 
       visitEditWorkspaceKind(mockWorkspaceKind.name);
 
       editWorkspaceKind.clickYamlTab();
+      editWorkspaceKind.assertYamlEditorVisible();
 
-      // Type into the Monaco editor to trigger a change
-      editWorkspaceKind
-        .findYamlEditor()
-        .find('.monaco-editor textarea')
-        .first()
-        .click({ force: true });
-      editWorkspaceKind
-        .findYamlEditor()
-        .find('.monaco-editor textarea')
-        .first()
-        .type('{end}{enter}# edited', { force: true });
+      editWorkspaceKind.clickFormTab();
 
-      editWorkspaceKind.assertSubmitButtonDisabled(false);
-      editWorkspaceKind.clickSubmit();
+      editWorkspaceKind.assertPropertiesSectionVisible();
+      editWorkspaceKind.assertImageConfigSectionVisible();
+      editWorkspaceKind.assertPodConfigSectionVisible();
+      editWorkspaceKind.assertPodTemplateSectionVisible();
+    });
+  });
 
-      cy.wait('@updateWorkspaceKindYaml');
-      workspaceKinds.verifyPageURL();
+  describe('Revert button', () => {
+    it('should display revert button in edit mode', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.assertRevertButtonVisible();
     });
 
-    it('should display error when update API fails from YAML tab', () => {
+    it('should revert form changes when clicked', () => {
       const { mockWorkspaceKind } = setupEditWorkspaceKind();
-
-      cy.interceptApi(
-        'PUT /api/:apiVersion/workspacekinds/:kind',
-        { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: mockWorkspaceKind.name } },
-        {
-          error: {
-            code: '500',
-            message: 'Internal server error',
-          },
-        },
-      ).as('updateWorkspaceKindYamlError');
 
       visitEditWorkspaceKind(mockWorkspaceKind.name);
 
-      editWorkspaceKind.clickYamlTab();
+      editWorkspaceKind.expandPropertiesSection();
+      editWorkspaceKind.typeDescription('Modified description');
 
-      editWorkspaceKind
-        .findYamlEditor()
-        .find('.monaco-editor textarea')
-        .first()
-        .click({ force: true });
-      editWorkspaceKind
-        .findYamlEditor()
-        .find('.monaco-editor textarea')
-        .first()
-        .type('{end}{enter}# edited', { force: true });
+      editWorkspaceKind.assertSubmitButtonDisabled(false);
 
-      editWorkspaceKind.clickSubmit();
+      editWorkspaceKind.clickRevert();
 
-      cy.wait('@updateWorkspaceKindYamlError');
-      editWorkspaceKind.assertErrorAlertVisible();
+      editWorkspaceKind.assertSubmitButtonDisabled(true);
+      editWorkspaceKind.expandPropertiesSection();
+      editWorkspaceKind.assertDescription(mockWorkspaceKind.description);
+    });
+
+    it('should disable Save after reverting changes', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.expandPropertiesSection();
+      editWorkspaceKind.typeWorkspaceKindName('Changed Name');
+
+      editWorkspaceKind.assertSubmitButtonDisabled(false);
+
+      editWorkspaceKind.clickRevert();
+
+      editWorkspaceKind.assertSubmitButtonDisabled(true);
     });
   });
 });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
@@ -1350,4 +1350,126 @@ describe('Edit workspace kind', () => {
       editWorkspaceKind.verifyPageURL(mockWorkspaceKind.name);
     });
   });
+
+  describe('YAML editor tab', () => {
+    it('should display Form and YAML tabs in edit mode', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.assertTabsVisible();
+    });
+
+    it('should show Form tab as active by default', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.assertFormTabActive();
+      editWorkspaceKind.assertFormPropertiesVisible();
+      editWorkspaceKind.assertYamlEditorNotVisible();
+    });
+
+    it('should switch to YAML tab and show editor', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.clickYamlTab();
+
+      editWorkspaceKind.assertYamlTabActive();
+      editWorkspaceKind.assertYamlEditorVisible();
+    });
+
+    it('should switch back to Form tab and hide editor', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.clickYamlTab();
+      editWorkspaceKind.assertYamlEditorVisible();
+
+      editWorkspaceKind.clickFormTab();
+      editWorkspaceKind.assertFormTabActive();
+      editWorkspaceKind.assertFormPropertiesVisible();
+      editWorkspaceKind.assertYamlEditorNotVisible();
+    });
+
+    it('should have Save disabled in YAML tab when no changes are made', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.clickYamlTab();
+
+      editWorkspaceKind.assertSubmitButtonDisabled(true);
+    });
+
+    it('should call update API when saving valid YAML', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspacekinds/:kind',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: mockWorkspaceKind.name } },
+        mockModArchResponse(buildMockWorkspaceKindUpdate(mockWorkspaceKind)),
+      ).as('updateWorkspaceKindYaml');
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.clickYamlTab();
+
+      // Type into the Monaco editor to trigger a change
+      editWorkspaceKind
+        .findYamlEditor()
+        .find('.monaco-editor textarea')
+        .first()
+        .click({ force: true });
+      editWorkspaceKind
+        .findYamlEditor()
+        .find('.monaco-editor textarea')
+        .first()
+        .type('{end}{enter}# edited', { force: true });
+
+      editWorkspaceKind.assertSubmitButtonDisabled(false);
+      editWorkspaceKind.clickSubmit();
+
+      cy.wait('@updateWorkspaceKindYaml');
+      workspaceKinds.verifyPageURL();
+    });
+
+    it('should display error when update API fails from YAML tab', () => {
+      const { mockWorkspaceKind } = setupEditWorkspaceKind();
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspacekinds/:kind',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: mockWorkspaceKind.name } },
+        {
+          error: {
+            code: '500',
+            message: 'Internal server error',
+          },
+        },
+      ).as('updateWorkspaceKindYamlError');
+
+      visitEditWorkspaceKind(mockWorkspaceKind.name);
+
+      editWorkspaceKind.clickYamlTab();
+
+      editWorkspaceKind
+        .findYamlEditor()
+        .find('.monaco-editor textarea')
+        .first()
+        .click({ force: true });
+      editWorkspaceKind
+        .findYamlEditor()
+        .find('.monaco-editor textarea')
+        .first()
+        .type('{end}{enter}# edited', { force: true });
+
+      editWorkspaceKind.clickSubmit();
+
+      cy.wait('@updateWorkspaceKindYamlError');
+      editWorkspaceKind.assertErrorAlertVisible();
+    });
+  });
 });

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -454,8 +454,9 @@ export const WorkspaceKindForm: React.FC = () => {
                 eventKey={YAML_TAB_KEY}
                 activeKey={activeTabKey}
                 hidden={activeTabKey !== YAML_TAB_KEY}
+                style={{ flex: 1 }}
               >
-                <TabContentBody>
+                <TabContentBody style={{ height: '100%' }}>
                   <WorkspaceKindYamlEditor
                     value={editYamlValue}
                     onChange={handleYamlChange}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -7,6 +7,7 @@ import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { PageGroup, PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
 import { Tabs, Tab, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
+import { UndoIcon } from '@patternfly/react-icons/dist/esm/icons/undo-icon';
 import { useNotification } from 'mod-arch-core';
 import useGenericObjectState from 'mod-arch-core/dist/utilities/useGenericObjectState';
 import useWorkspaceKindByName from '~/app/hooks/useWorkspaceKindByName';
@@ -195,6 +196,19 @@ export const WorkspaceKindForm: React.FC = () => {
     },
     [activeTabKey, data, initialFormData],
   );
+
+  const handleRevert = useCallback(() => {
+    if (initialFormData) {
+      const converted = convertToFormData(initialFormData);
+      replaceData(converted);
+      setOriginalFormData(converted);
+      const yamlStr = yaml.dump(initialFormData, { noRefs: true });
+      setOriginalYaml(yamlStr);
+      setEditYamlValue(yamlStr);
+      setYamlParseError(null);
+      setError(null);
+    }
+  }, [initialFormData, replaceData]);
 
   const handleYamlChange = useCallback((value: string) => {
     setEditYamlValue(value);
@@ -445,6 +459,14 @@ export const WorkspaceKindForm: React.FC = () => {
               {mode === 'create' ? 'Create' : 'Save'}
             </Button>
           </FlexItem>
+          {mode === 'edit' && (
+            <FlexItem>
+              <Button variant="link" onClick={handleRevert} data-testid="revert-button">
+                <UndoIcon />
+                Revert
+              </Button>
+            </FlexItem>
+          )}
           <FlexItem>
             <Button variant="link" onClick={cancel} data-testid="cancel-button">
               Cancel

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import isEqual from 'lodash-es/isEqual';
+import yaml from 'js-yaml';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { PageGroup, PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { Tabs, Tab, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
 import { useNotification } from 'mod-arch-core';
 import useGenericObjectState from 'mod-arch-core/dist/utilities/useGenericObjectState';
 import useWorkspaceKindByName from '~/app/hooks/useWorkspaceKindByName';
@@ -29,7 +31,12 @@ import { WorkspaceKindFormProperties } from './properties/WorkspaceKindFormPrope
 import { WorkspaceKindFormImage } from './image/WorkspaceKindFormImage';
 import { WorkspaceKindFormPodConfig } from './podConfig/WorkspaceKindFormPodConfig';
 import { WorkspaceKindFormPodTemplate } from './podTemplate/WorkspaceKindFormPodTemplate';
-import { convertFormDataToUpdate, EMPTY_WORKSPACE_KIND_FORM_DATA } from './helpers';
+import {
+  convertFormDataToUpdate,
+  EMPTY_WORKSPACE_KIND_FORM_DATA,
+  isValidWorkspaceKindUpdate,
+} from './helpers';
+import { WorkspaceKindYamlEditor } from './yamlEditor/WorkspaceKindYamlEditor';
 
 export enum WorkspaceKindFormView {
   Form,
@@ -138,6 +145,12 @@ export const WorkspaceKindForm: React.FC = () => {
   // TODO: Detect mode by route
   const [yamlValue, setYamlValue] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const FORM_TAB_KEY = 0;
+  const YAML_TAB_KEY = 1;
+  const [activeTabKey, setActiveTabKey] = useState<number>(FORM_TAB_KEY);
+  const [editYamlValue, setEditYamlValue] = useState('');
+  const [originalYaml, setOriginalYaml] = useState('');
+  const [yamlParseError, setYamlParseError] = useState<string | null>(null);
   const mode: FormMode = useCurrentRouteKey() === 'workspaceKindCreate' ? 'create' : 'edit';
   const [validated, setValidated] = useState<ValidationStatus>(
     mode === 'edit' ? 'success' : 'default',
@@ -161,7 +174,37 @@ export const WorkspaceKindForm: React.FC = () => {
     const converted = convertToFormData(initialFormData);
     replaceData(converted);
     setOriginalFormData(converted);
+    const yamlStr = yaml.dump(initialFormData, { noRefs: true });
+    setOriginalYaml(yamlStr);
+    setEditYamlValue(yamlStr);
   }, [initialFormData, initialFormDataLoaded, mode, replaceData]);
+
+  const handleTabSelect = useCallback(
+    (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, tabKey: string | number) => {
+      const newTab = tabKey as number;
+      if (newTab === YAML_TAB_KEY && activeTabKey === FORM_TAB_KEY) {
+        const updateObj = convertFormDataToUpdate(
+          data,
+          initialFormData as WorkspacekindsWorkspaceKindUpdate,
+        );
+        const yamlStr = yaml.dump(updateObj, { noRefs: true });
+        setEditYamlValue(yamlStr);
+        setYamlParseError(null);
+      }
+      setActiveTabKey(newTab);
+    },
+    [activeTabKey, data, initialFormData],
+  );
+
+  const handleYamlChange = useCallback((value: string) => {
+    setEditYamlValue(value);
+    try {
+      yaml.load(value);
+      setYamlParseError(null);
+    } catch (e) {
+      setYamlParseError((e as Error).message);
+    }
+  }, []);
 
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
@@ -184,6 +227,22 @@ export const WorkspaceKindForm: React.FC = () => {
         notification.success(
           `Workspace kind '${createResult.result.data.name}' created successfully`,
         );
+      } else if (activeTabKey === YAML_TAB_KEY) {
+        const parsed = yaml.load(editYamlValue);
+        if (!isValidWorkspaceKindUpdate(parsed)) {
+          throw new Error(
+            'Invalid WorkspaceKind update structure: must include revision, spawner, and podTemplate',
+          );
+        }
+        const updateResult = await safeApiCall(() =>
+          api.workspaceKinds.updateWorkspaceKind(routeParams?.kind || '', {
+            data: parsed as WorkspacekindsWorkspaceKindUpdate,
+          }),
+        );
+        if (!updateResult.ok) {
+          throw updateResult.errorEnvelope;
+        }
+        notification.success(`Workspace kind '${routeParams?.kind || ''}' updated successfully`);
       } else {
         const updateResult = await safeApiCall(() =>
           api.workspaceKinds.updateWorkspaceKind(routeParams?.kind || '', {
@@ -209,6 +268,7 @@ export const WorkspaceKindForm: React.FC = () => {
     }
   }, [
     mode,
+    activeTabKey,
     api.workspaceKinds,
     routeParams?.kind,
     data,
@@ -216,17 +276,28 @@ export const WorkspaceKindForm: React.FC = () => {
     navigate,
     notification,
     yamlValue,
+    editYamlValue,
   ]);
 
-  const hasChanges = useMemo(
-    () => originalFormData !== null && !isEqual(data, originalFormData),
-    [data, originalFormData],
-  );
+  const hasChanges = useMemo(() => {
+    if (mode === 'edit' && activeTabKey === YAML_TAB_KEY) {
+      return editYamlValue !== originalYaml;
+    }
+    return originalFormData !== null && !isEqual(data, originalFormData);
+  }, [mode, activeTabKey, editYamlValue, originalYaml, data, originalFormData]);
 
-  const canSubmit = useMemo(
-    () => !isSubmitting && validated === 'success' && (mode === 'create' || hasChanges),
-    [isSubmitting, validated, mode, hasChanges],
-  );
+  const canSubmit = useMemo(() => {
+    if (isSubmitting) {
+      return false;
+    }
+    if (mode === 'create') {
+      return validated === 'success';
+    }
+    if (activeTabKey === YAML_TAB_KEY) {
+      return hasChanges && yamlParseError === null;
+    }
+    return validated === 'success' && hasChanges;
+  }, [isSubmitting, validated, mode, hasChanges, activeTabKey, yamlParseError]);
 
   const cancel = useCallback(() => {
     navigate('workspaceKinds');
@@ -292,38 +363,71 @@ export const WorkspaceKindForm: React.FC = () => {
           )}
           {mode === 'edit' && (
             <>
-              <StackItem data-testid="workspace-kind-form-properties">
-                <WorkspaceKindFormProperties
-                  mode={mode}
-                  properties={data.properties}
-                  updateField={(properties) => setData('properties', properties)}
-                />
-              </StackItem>
               <StackItem>
-                <WorkspaceKindFormImage
-                  mode={mode}
-                  imageConfig={data.imageConfig}
-                  updateImageConfig={(imageInput) => {
-                    setData('imageConfig', imageInput);
-                  }}
-                />
+                <Tabs
+                  activeKey={activeTabKey}
+                  onSelect={handleTabSelect}
+                  aria-label="Edit workspace kind view tabs"
+                >
+                  <Tab
+                    eventKey={FORM_TAB_KEY}
+                    title={<TabTitleText>Form</TabTitleText>}
+                    aria-label="Form editor"
+                    data-testid="form-tab"
+                  />
+                  <Tab
+                    eventKey={YAML_TAB_KEY}
+                    title={<TabTitleText>YAML</TabTitleText>}
+                    aria-label="YAML editor"
+                    data-testid="yaml-tab"
+                  />
+                </Tabs>
               </StackItem>
-              <StackItem>
-                <WorkspaceKindFormPodConfig
-                  podConfig={data.podConfig}
-                  updatePodConfig={(podConfig) => {
-                    setData('podConfig', podConfig);
-                  }}
-                />
-              </StackItem>
-              <StackItem>
-                <WorkspaceKindFormPodTemplate
-                  podTemplate={data.podTemplate}
-                  updatePodTemplate={(podTemplate) => {
-                    setData('podTemplate', podTemplate);
-                  }}
-                />
-              </StackItem>
+              {activeTabKey === FORM_TAB_KEY && (
+                <>
+                  <StackItem data-testid="workspace-kind-form-properties">
+                    <WorkspaceKindFormProperties
+                      mode={mode}
+                      properties={data.properties}
+                      updateField={(properties) => setData('properties', properties)}
+                    />
+                  </StackItem>
+                  <StackItem>
+                    <WorkspaceKindFormImage
+                      mode={mode}
+                      imageConfig={data.imageConfig}
+                      updateImageConfig={(imageInput) => {
+                        setData('imageConfig', imageInput);
+                      }}
+                    />
+                  </StackItem>
+                  <StackItem>
+                    <WorkspaceKindFormPodConfig
+                      podConfig={data.podConfig}
+                      updatePodConfig={(podConfig) => {
+                        setData('podConfig', podConfig);
+                      }}
+                    />
+                  </StackItem>
+                  <StackItem>
+                    <WorkspaceKindFormPodTemplate
+                      podTemplate={data.podTemplate}
+                      updatePodTemplate={(podTemplate) => {
+                        setData('podTemplate', podTemplate);
+                      }}
+                    />
+                  </StackItem>
+                </>
+              )}
+              {activeTabKey === YAML_TAB_KEY && (
+                <StackItem isFilled>
+                  <WorkspaceKindYamlEditor
+                    value={editYamlValue}
+                    onChange={handleYamlChange}
+                    error={yamlParseError}
+                  />
+                </StackItem>
+              )}
             </>
           )}
         </Stack>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -6,7 +6,13 @@ import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/compon
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { PageGroup, PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
+import {
+  Tabs,
+  Tab,
+  TabTitleText,
+  TabContent,
+  TabContentBody,
+} from '@patternfly/react-core/dist/esm/components/Tabs';
 import { UndoIcon } from '@patternfly/react-icons/dist/esm/icons/undo-icon';
 import { useNotification } from 'mod-arch-core';
 import useGenericObjectState from 'mod-arch-core/dist/utilities/useGenericObjectState';
@@ -190,6 +196,7 @@ export const WorkspaceKindForm: React.FC = () => {
         );
         const yamlStr = yaml.dump(updateObj, { noRefs: true });
         setEditYamlValue(yamlStr);
+        setOriginalYaml(yamlStr);
         setYamlParseError(null);
       }
       setActiveTabKey(newTab);
@@ -387,61 +394,75 @@ export const WorkspaceKindForm: React.FC = () => {
                     eventKey={FORM_TAB_KEY}
                     title={<TabTitleText>Form</TabTitleText>}
                     aria-label="Form editor"
+                    tabContentId="form-tab-content"
                     data-testid="form-tab"
                   />
                   <Tab
                     eventKey={YAML_TAB_KEY}
                     title={<TabTitleText>YAML</TabTitleText>}
                     aria-label="YAML editor"
+                    tabContentId="yaml-tab-content"
                     data-testid="yaml-tab"
                   />
                 </Tabs>
               </StackItem>
-              {activeTabKey === FORM_TAB_KEY && (
-                <>
-                  <StackItem data-testid="workspace-kind-form-properties">
-                    <WorkspaceKindFormProperties
-                      mode={mode}
-                      properties={data.properties}
-                      updateField={(properties) => setData('properties', properties)}
-                    />
-                  </StackItem>
-                  <StackItem>
-                    <WorkspaceKindFormImage
-                      mode={mode}
-                      imageConfig={data.imageConfig}
-                      updateImageConfig={(imageInput) => {
-                        setData('imageConfig', imageInput);
-                      }}
-                    />
-                  </StackItem>
-                  <StackItem>
-                    <WorkspaceKindFormPodConfig
-                      podConfig={data.podConfig}
-                      updatePodConfig={(podConfig) => {
-                        setData('podConfig', podConfig);
-                      }}
-                    />
-                  </StackItem>
-                  <StackItem>
-                    <WorkspaceKindFormPodTemplate
-                      podTemplate={data.podTemplate}
-                      updatePodTemplate={(podTemplate) => {
-                        setData('podTemplate', podTemplate);
-                      }}
-                    />
-                  </StackItem>
-                </>
-              )}
-              {activeTabKey === YAML_TAB_KEY && (
-                <StackItem isFilled>
+              <TabContent
+                id="form-tab-content"
+                eventKey={FORM_TAB_KEY}
+                activeKey={activeTabKey}
+                hidden={activeTabKey !== FORM_TAB_KEY}
+              >
+                <TabContentBody>
+                  <Stack hasGutter>
+                    <StackItem data-testid="workspace-kind-form-properties">
+                      <WorkspaceKindFormProperties
+                        mode={mode}
+                        properties={data.properties}
+                        updateField={(properties) => setData('properties', properties)}
+                      />
+                    </StackItem>
+                    <StackItem>
+                      <WorkspaceKindFormImage
+                        mode={mode}
+                        imageConfig={data.imageConfig}
+                        updateImageConfig={(imageInput) => {
+                          setData('imageConfig', imageInput);
+                        }}
+                      />
+                    </StackItem>
+                    <StackItem>
+                      <WorkspaceKindFormPodConfig
+                        podConfig={data.podConfig}
+                        updatePodConfig={(podConfig) => {
+                          setData('podConfig', podConfig);
+                        }}
+                      />
+                    </StackItem>
+                    <StackItem>
+                      <WorkspaceKindFormPodTemplate
+                        podTemplate={data.podTemplate}
+                        updatePodTemplate={(podTemplate) => {
+                          setData('podTemplate', podTemplate);
+                        }}
+                      />
+                    </StackItem>
+                  </Stack>
+                </TabContentBody>
+              </TabContent>
+              <TabContent
+                id="yaml-tab-content"
+                eventKey={YAML_TAB_KEY}
+                activeKey={activeTabKey}
+                hidden={activeTabKey !== YAML_TAB_KEY}
+              >
+                <TabContentBody>
                   <WorkspaceKindYamlEditor
                     value={editYamlValue}
                     onChange={handleYamlChange}
                     error={yamlParseError}
                   />
-                </StackItem>
-              )}
+                </TabContentBody>
+              </TabContent>
             </>
           )}
         </Stack>
@@ -462,7 +483,7 @@ export const WorkspaceKindForm: React.FC = () => {
           {mode === 'edit' && (
             <FlexItem>
               <Button variant="link" onClick={handleRevert} data-testid="revert-button">
-                <UndoIcon />
+                <UndoIcon className="pf-v6-u-mr-sm" />
                 Revert
               </Button>
             </FlexItem>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -327,6 +327,7 @@ export const WorkspaceKindForm: React.FC = () => {
   if (mode === 'edit' && initialFormDataError) {
     return <LoadError title="Failed to load workspace kind data" error={initialFormDataError} />;
   }
+  //TODO: Remove warning edit warning when we have a way to reflect changes in the form from the YAML
   return (
     <>
       <PageGroup isFilled={false} stickyOnBreakpoint={{ default: 'top' }}>
@@ -348,8 +349,8 @@ export const WorkspaceKindForm: React.FC = () => {
                       repository.
                     </p>
                   ) : (
-                    `View and edit the Workspace Kind's information. Some fields may not be
-                      represented in this form`
+                    `View and edit the Workspace Kind using the form or the YAML editor.
+                      Changing the form will affect the YAML, but edits to the YAML will not affect the form.`
                   )}
                 </Content>
               </FlexItem>
@@ -483,7 +484,12 @@ export const WorkspaceKindForm: React.FC = () => {
           </FlexItem>
           {mode === 'edit' && (
             <FlexItem>
-              <Button variant="link" onClick={handleRevert} data-testid="revert-button">
+              <Button
+                variant="link"
+                isDisabled={!hasChanges}
+                onClick={handleRevert}
+                data-testid="revert-button"
+              >
                 <UndoIcon className="pf-v6-u-mr-sm" />
                 Revert
               </Button>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -89,6 +89,48 @@ export const isValidWorkspaceKindYaml = (data: any): boolean => {
   return true;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+export const isValidWorkspaceKindUpdate = (data: any): boolean => {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+
+  if (typeof obj.revision !== 'string' || !obj.revision) {
+    return false;
+  }
+
+  if (
+    typeof obj.spawner !== 'object' ||
+    !obj.spawner ||
+    typeof (obj.spawner as Record<string, unknown>).displayName !== 'string' ||
+    typeof (obj.spawner as Record<string, unknown>).description !== 'string'
+  ) {
+    return false;
+  }
+
+  if (typeof obj.podTemplate !== 'object' || !obj.podTemplate) {
+    return false;
+  }
+
+  const podTemplate = obj.podTemplate as Record<string, unknown>;
+  if (typeof podTemplate.options !== 'object' || !podTemplate.options) {
+    return false;
+  }
+
+  const options = podTemplate.options as Record<string, unknown>;
+  if (
+    typeof options.imageConfig !== 'object' ||
+    !options.imageConfig ||
+    typeof options.podConfig !== 'object' ||
+    !options.podConfig
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 export const emptyImage = {
   id: '',
   displayName: '',

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -262,57 +262,69 @@ export const convertFormDataToUpdate = (
     options: {
       imageConfig: {
         spawner: { default: formData.imageConfig.default },
-        values: (formData.imageConfig.values ?? []).map((v) => ({
-          id: v.id,
-          redirect: convertRedirectToApi(v.redirect),
-          spawner: {
-            displayName: v.displayName,
-            description: v.description || undefined,
-            hidden: v.hidden,
-            labels: v.labels?.map((l) => ({ key: l.key, value: l.value })),
-          },
-          spec: {
-            image: v.image ?? '',
-            imagePullPolicy: (v.imagePullPolicy ??
-              ImagePullPolicy.IfNotPresent) as unknown as V1PullPolicy,
-            ports: (v.ports ?? []).map((p) => ({
-              id: p.id,
-              displayName: p.displayName || undefined,
-              port: p.port,
-            })),
-          },
-        })),
+        values: (formData.imageConfig.values ?? []).map((v) => {
+          const originalValue = original.podTemplate.options.imageConfig.values.find(
+            (ov) => ov.id === v.id,
+          );
+          return {
+            id: v.id,
+            redirect: convertRedirectToApi(v.redirect),
+            spawner: {
+              displayName: v.displayName,
+              description: v.description || undefined,
+              hidden: v.hidden,
+              labels: v.labels?.map((l) => ({ key: l.key, value: l.value })),
+            },
+            spec: {
+              ...originalValue?.spec,
+              image: v.image ?? '',
+              imagePullPolicy: (v.imagePullPolicy ??
+                ImagePullPolicy.IfNotPresent) as unknown as V1PullPolicy,
+              ports: (v.ports ?? []).map((p) => ({
+                id: p.id,
+                displayName: p.displayName || undefined,
+                port: p.port,
+              })),
+            },
+          };
+        }),
       },
       podConfig: {
         spawner: { default: formData.podConfig.default },
-        values: (formData.podConfig.values ?? []).map((v) => ({
-          id: v.id,
-          redirect: convertRedirectToApi(v.redirect),
-          spawner: {
-            displayName: v.displayName,
-            description: v.description || undefined,
-            hidden: v.hidden,
-            labels: v.labels?.map((l) => ({ key: l.key, value: l.value })),
-          },
-          spec: {
-            resources: v.resources
-              ? {
-                  requests: v.resources.requests as V1ResourceList,
-                  limits: v.resources.limits as V1ResourceList,
-                }
-              : undefined,
-            nodeSelector: v.nodeSelector,
-            tolerations: v.tolerations?.map(
-              (t): V1Toleration => ({
-                operator: t.operator,
-                effect: t.effect,
-                key: t.key,
-                value: t.value,
-                tolerationSeconds: t.tolerationSeconds,
-              }),
-            ),
-          },
-        })),
+        values: (formData.podConfig.values ?? []).map((v) => {
+          const originalValue = original.podTemplate.options.podConfig.values.find(
+            (ov) => ov.id === v.id,
+          );
+          return {
+            id: v.id,
+            redirect: convertRedirectToApi(v.redirect),
+            spawner: {
+              displayName: v.displayName,
+              description: v.description || undefined,
+              hidden: v.hidden,
+              labels: v.labels?.map((l) => ({ key: l.key, value: l.value })),
+            },
+            spec: {
+              ...originalValue?.spec,
+              resources: v.resources
+                ? {
+                    requests: v.resources.requests as V1ResourceList,
+                    limits: v.resources.limits as V1ResourceList,
+                  }
+                : undefined,
+              nodeSelector: v.nodeSelector,
+              tolerations: v.tolerations?.map(
+                (t): V1Toleration => ({
+                  operator: t.operator,
+                  effect: t.effect,
+                  key: t.key,
+                  value: t.value,
+                  tolerationSeconds: t.tolerationSeconds,
+                }),
+              ),
+            },
+          };
+        }),
       },
     },
   },

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/WorkspaceKindYamlEditor.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/WorkspaceKindYamlEditor.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useRef } from 'react';
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import { configureMonacoYaml } from 'monaco-yaml';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import workspaceKindUpdateSchema from './workspaceKindUpdateSchema.json';
+
+type WorkspaceKindYamlEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  error: string | null;
+};
+
+const SCHEMA_URI = 'https://kubeflow.org/schemas/workspacekind-update.json';
+const MODEL_URI = 'file:///workspacekind-update.yaml';
+
+export const WorkspaceKindYamlEditor: React.FC<WorkspaceKindYamlEditorProps> = ({
+  value,
+  onChange,
+  error,
+}) => {
+  const monacoYamlRef = useRef<ReturnType<typeof configureMonacoYaml> | null>(null);
+
+  const handleBeforeMount = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (monaco: any) => {
+      window.MonacoEnvironment = {
+        getWorker(_moduleId: string, label: string) {
+          if (label === 'yaml') {
+            return new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url));
+          }
+          return new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url));
+        },
+      };
+
+      monacoYamlRef.current?.dispose();
+      monacoYamlRef.current = configureMonacoYaml(monaco, {
+        enableSchemaRequest: false,
+        hover: true,
+        completion: true,
+        validate: true,
+        schemas: [
+          {
+            uri: SCHEMA_URI,
+            fileMatch: [MODEL_URI],
+            schema: workspaceKindUpdateSchema,
+          },
+        ],
+      });
+    },
+    [],
+  );
+
+  return (
+    <Stack hasGutter data-testid="yaml-editor">
+      <StackItem isFilled style={{ minHeight: '500px' }}>
+        <CodeEditor
+          isLineNumbersVisible
+          isLanguageLabelVisible={false}
+          height="100%"
+          code={value}
+          onChange={onChange}
+          language={Language.yaml}
+          editorProps={{
+            beforeMount: handleBeforeMount,
+            path: MODEL_URI,
+          }}
+          options={{
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+          }}
+        />
+      </StackItem>
+      {error && (
+        <StackItem>
+          <HelperText data-testid="yaml-parse-error">
+            <HelperTextItem variant="error">{error}</HelperTextItem>
+          </HelperText>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/WorkspaceKindYamlEditor.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/WorkspaceKindYamlEditor.tsx
@@ -3,6 +3,7 @@ import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { configureMonacoYaml } from 'monaco-yaml';
 import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { WORKSPACE_KIND_EXAMPLES_URL } from '~/shared/utilities/const';
 import workspaceKindUpdateSchema from './workspaceKindUpdateSchema.json';
 
 type WorkspaceKindYamlEditorProps = {
@@ -11,7 +12,6 @@ type WorkspaceKindYamlEditorProps = {
   error: string | null;
 };
 
-const SCHEMA_URI = 'https://kubeflow.org/schemas/workspacekind-update.json';
 const MODEL_URI = 'file:///workspacekind-update.yaml';
 
 export const WorkspaceKindYamlEditor: React.FC<WorkspaceKindYamlEditorProps> = ({
@@ -23,25 +23,16 @@ export const WorkspaceKindYamlEditor: React.FC<WorkspaceKindYamlEditorProps> = (
 
   const handleBeforeMount = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (monaco: any) => {
-      window.MonacoEnvironment = {
-        getWorker(_moduleId: string, label: string) {
-          if (label === 'yaml') {
-            return new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url));
-          }
-          return new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url));
-        },
-      };
-
+    (monacoInstance: any) => {
       monacoYamlRef.current?.dispose();
-      monacoYamlRef.current = configureMonacoYaml(monaco, {
+      monacoYamlRef.current = configureMonacoYaml(monacoInstance, {
         enableSchemaRequest: false,
         hover: true,
         completion: true,
         validate: true,
         schemas: [
           {
-            uri: SCHEMA_URI,
+            uri: WORKSPACE_KIND_EXAMPLES_URL,
             fileMatch: [MODEL_URI],
             schema: workspaceKindUpdateSchema,
           },

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/WorkspaceKindYamlEditor.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/WorkspaceKindYamlEditor.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { configureMonacoYaml } from 'monaco-yaml';
 import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
-import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { WORKSPACE_KIND_EXAMPLES_URL } from '~/shared/utilities/const';
 import workspaceKindUpdateSchema from './workspaceKindUpdateSchema.json';
 
@@ -43,12 +43,16 @@ export const WorkspaceKindYamlEditor: React.FC<WorkspaceKindYamlEditorProps> = (
   );
 
   return (
-    <Stack hasGutter data-testid="yaml-editor">
-      <StackItem isFilled style={{ minHeight: '500px' }}>
+    <Flex
+      direction={{ default: 'column' }}
+      style={{ height: '100%', minHeight: '500px' }}
+      data-testid="yaml-editor"
+    >
+      <FlexItem flex={{ default: 'flex_1' }}>
         <CodeEditor
           isLineNumbersVisible
           isLanguageLabelVisible={false}
-          height="100%"
+          isFullHeight
           code={value}
           onChange={onChange}
           language={Language.yaml}
@@ -61,14 +65,14 @@ export const WorkspaceKindYamlEditor: React.FC<WorkspaceKindYamlEditorProps> = (
             scrollBeyondLastLine: false,
           }}
         />
-      </StackItem>
+      </FlexItem>
       {error && (
-        <StackItem>
+        <FlexItem>
           <HelperText data-testid="yaml-parse-error">
             <HelperTextItem variant="error">{error}</HelperTextItem>
           </HelperText>
-        </StackItem>
+        </FlexItem>
       )}
-    </Stack>
+    </Flex>
   );
 };

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json
@@ -4,11 +4,7 @@
   "$defs": {
     "workspacekinds.WorkspaceKindUpdate": {
       "type": "object",
-      "required": [
-        "podTemplate",
-        "revision",
-        "spawner"
-      ],
+      "required": ["podTemplate", "revision", "spawner"],
       "properties": {
         "podTemplate": {
           "$ref": "#/$defs/v1beta1.WorkspaceKindPodTemplate"
@@ -24,12 +20,7 @@
     },
     "v1beta1.WorkspaceKindPodTemplate": {
       "type": "object",
-      "required": [
-        "options",
-        "ports",
-        "serviceAccount",
-        "volumeMounts"
-      ],
+      "required": ["options", "ports", "serviceAccount", "volumeMounts"],
       "properties": {
         "containerSecurityContext": {
           "description": "container security context for Workspace Pods (MUTABLE)\n+kubebuilder:validation:Optional",
@@ -204,9 +195,7 @@
     },
     "v1.AppArmorProfile": {
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "localhostProfile": {
           "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".\n+optional",
@@ -224,11 +213,7 @@
     },
     "v1.AppArmorProfileType": {
       "type": "string",
-      "enum": [
-        "Unconfined",
-        "RuntimeDefault",
-        "Localhost"
-      ],
+      "enum": ["Unconfined", "RuntimeDefault", "Localhost"],
       "x-enum-varnames": [
         "AppArmorProfileTypeUnconfined",
         "AppArmorProfileTypeRuntimeDefault",
@@ -256,14 +241,8 @@
     },
     "v1.ProcMountType": {
       "type": "string",
-      "enum": [
-        "Default",
-        "Unmasked"
-      ],
-      "x-enum-varnames": [
-        "DefaultProcMount",
-        "UnmaskedProcMount"
-      ]
+      "enum": ["Default", "Unmasked"],
+      "x-enum-varnames": ["DefaultProcMount", "UnmaskedProcMount"]
     },
     "v1.SELinuxOptions": {
       "type": "object",
@@ -288,9 +267,7 @@
     },
     "v1.SeccompProfile": {
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "localhostProfile": {
           "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.\n+optional",
@@ -308,11 +285,7 @@
     },
     "v1.SeccompProfileType": {
       "type": "string",
-      "enum": [
-        "Unconfined",
-        "RuntimeDefault",
-        "Localhost"
-      ],
+      "enum": ["Unconfined", "RuntimeDefault", "Localhost"],
       "x-enum-varnames": [
         "SeccompProfileTypeUnconfined",
         "SeccompProfileTypeRuntimeDefault",
@@ -342,9 +315,7 @@
     },
     "v1beta1.WorkspaceKindCullingConfig": {
       "type": "object",
-      "required": [
-        "activityProbe"
-      ],
+      "required": ["activityProbe"],
       "properties": {
         "activityProbe": {
           "description": "the probe used to determine if the Workspace is active",
@@ -387,9 +358,7 @@
     },
     "v1beta1.ActivityProbeExec": {
       "type": "object",
-      "required": [
-        "command"
-      ],
+      "required": ["command"],
       "properties": {
         "command": {
           "description": "the command to run\n+kubebuilder:validation:MinItems:=1\n+kubebuilder:example={\"bash\", \"-c\", \"exit 0\"}",
@@ -402,9 +371,7 @@
     },
     "v1beta1.ActivityProbeJupyter": {
       "type": "object",
-      "required": [
-        "lastActivity"
-      ],
+      "required": ["lastActivity"],
       "properties": {
         "lastActivity": {
           "description": "if the Jupyter-specific probe is enabled\n+kubebuilder:example=true",
@@ -414,9 +381,7 @@
     },
     "v1.EnvVar": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -475,9 +440,7 @@
     },
     "v1.ConfigMapKeySelector": {
       "type": "object",
-      "required": [
-        "key"
-      ],
+      "required": ["key"],
       "properties": {
         "key": {
           "description": "The key to select.",
@@ -495,9 +458,7 @@
     },
     "v1.ObjectFieldSelector": {
       "type": "object",
-      "required": [
-        "fieldPath"
-      ],
+      "required": ["fieldPath"],
       "properties": {
         "apiVersion": {
           "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".\n+optional",
@@ -511,9 +472,7 @@
     },
     "v1.ResourceFieldSelector": {
       "type": "object",
-      "required": [
-        "resource"
-      ],
+      "required": ["resource"],
       "properties": {
         "containerName": {
           "description": "Container name: required for volumes, optional for env vars\n+optional",
@@ -538,34 +497,20 @@
       "properties": {
         "Format": {
           "type": "string",
-          "enum": [
-            "DecimalExponent",
-            "BinarySI",
-            "DecimalSI"
-          ],
+          "enum": ["DecimalExponent", "BinarySI", "DecimalSI"],
           "x-enum-comments": {
             "BinarySI": "e.g., 12Mi (12 * 2^20)",
             "DecimalExponent": "e.g., 12e6",
             "DecimalSI": "e.g., 12M  (12 * 10^6)"
           },
-          "x-enum-descriptions": [
-            "e.g., 12e6",
-            "e.g., 12Mi (12 * 2^20)",
-            "e.g., 12M  (12 * 10^6)"
-          ],
-          "x-enum-varnames": [
-            "DecimalExponent",
-            "BinarySI",
-            "DecimalSI"
-          ]
+          "x-enum-descriptions": ["e.g., 12e6", "e.g., 12Mi (12 * 2^20)", "e.g., 12M  (12 * 10^6)"],
+          "x-enum-varnames": ["DecimalExponent", "BinarySI", "DecimalSI"]
         }
       }
     },
     "v1.SecretKeySelector": {
       "type": "object",
-      "required": [
-        "key"
-      ],
+      "required": ["key"],
       "properties": {
         "key": {
           "description": "The key of the secret to select from.  Must be a valid secret key.",
@@ -583,10 +528,7 @@
     },
     "v1.VolumeMount": {
       "type": "object",
-      "required": [
-        "mountPath",
-        "name"
-      ],
+      "required": ["mountPath", "name"],
       "properties": {
         "mountPath": {
           "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
@@ -628,11 +570,7 @@
     },
     "v1.MountPropagationMode": {
       "type": "string",
-      "enum": [
-        "None",
-        "HostToContainer",
-        "Bidirectional"
-      ],
+      "enum": ["None", "HostToContainer", "Bidirectional"],
       "x-enum-varnames": [
         "MountPropagationNone",
         "MountPropagationHostToContainer",
@@ -641,11 +579,7 @@
     },
     "v1.RecursiveReadOnlyMode": {
       "type": "string",
-      "enum": [
-        "Disabled",
-        "IfPossible",
-        "Enabled"
-      ],
+      "enum": ["Disabled", "IfPossible", "Enabled"],
       "x-enum-varnames": [
         "RecursiveReadOnlyDisabled",
         "RecursiveReadOnlyIfPossible",
@@ -654,9 +588,7 @@
     },
     "v1.Volume": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "awsElasticBlockStore": {
           "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\n+optional",
@@ -906,9 +838,7 @@
     },
     "v1.AWSElasticBlockStoreVolumeSource": {
       "type": "object",
-      "required": [
-        "volumeID"
-      ],
+      "required": ["volumeID"],
       "properties": {
         "fsType": {
           "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
@@ -930,10 +860,7 @@
     },
     "v1.AzureDiskVolumeSource": {
       "type": "object",
-      "required": [
-        "diskName",
-        "diskURI"
-      ],
+      "required": ["diskName", "diskURI"],
       "properties": {
         "cachingMode": {
           "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.\n+optional\n+default=ref(AzureDataDiskCachingReadWrite)",
@@ -971,11 +898,7 @@
     },
     "v1.AzureDataDiskCachingMode": {
       "type": "string",
-      "enum": [
-        "None",
-        "ReadOnly",
-        "ReadWrite"
-      ],
+      "enum": ["None", "ReadOnly", "ReadWrite"],
       "x-enum-varnames": [
         "AzureDataDiskCachingNone",
         "AzureDataDiskCachingReadOnly",
@@ -984,23 +907,12 @@
     },
     "v1.AzureDataDiskKind": {
       "type": "string",
-      "enum": [
-        "Shared",
-        "Dedicated",
-        "Managed"
-      ],
-      "x-enum-varnames": [
-        "AzureSharedBlobDisk",
-        "AzureDedicatedBlobDisk",
-        "AzureManagedDisk"
-      ]
+      "enum": ["Shared", "Dedicated", "Managed"],
+      "x-enum-varnames": ["AzureSharedBlobDisk", "AzureDedicatedBlobDisk", "AzureManagedDisk"]
     },
     "v1.AzureFileVolumeSource": {
       "type": "object",
-      "required": [
-        "secretName",
-        "shareName"
-      ],
+      "required": ["secretName", "shareName"],
       "properties": {
         "readOnly": {
           "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
@@ -1018,9 +930,7 @@
     },
     "v1.CephFSVolumeSource": {
       "type": "object",
-      "required": [
-        "monitors"
-      ],
+      "required": ["monitors"],
       "properties": {
         "monitors": {
           "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it\n+listType=atomic",
@@ -1066,9 +976,7 @@
     },
     "v1.CinderVolumeSource": {
       "type": "object",
-      "required": [
-        "volumeID"
-      ],
+      "required": ["volumeID"],
       "properties": {
         "fsType": {
           "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md\n+optional",
@@ -1118,10 +1026,7 @@
     },
     "v1.KeyToPath": {
       "type": "object",
-      "required": [
-        "key",
-        "path"
-      ],
+      "required": ["key", "path"],
       "properties": {
         "key": {
           "description": "key is the key to project.",
@@ -1139,9 +1044,7 @@
     },
     "v1.CSIVolumeSource": {
       "type": "object",
-      "required": [
-        "driver"
-      ],
+      "required": ["driver"],
       "properties": {
         "driver": {
           "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
@@ -1190,9 +1093,7 @@
     },
     "v1.DownwardAPIVolumeFile": {
       "type": "object",
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "properties": {
         "fieldRef": {
           "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.\n+optional",
@@ -1243,12 +1144,7 @@
     },
     "v1.StorageMedium": {
       "type": "string",
-      "enum": [
-        "",
-        "Memory",
-        "HugePages",
-        "HugePages-"
-      ],
+      "enum": ["", "Memory", "HugePages", "HugePages-"],
       "x-enum-comments": {
         "StorageMediumDefault": "use whatever the default is for the node, assume anything we don't explicitly handle is this",
         "StorageMediumHugePages": "use hugepages",
@@ -1283,9 +1179,7 @@
     },
     "v1.PersistentVolumeClaimTemplate": {
       "type": "object",
-      "required": [
-        "spec"
-      ],
+      "required": ["spec"],
       "properties": {
         "metadata": {
           "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.\n\n+optional",
@@ -1431,23 +1325,12 @@
     },
     "v1.ManagedFieldsOperationType": {
       "type": "string",
-      "enum": [
-        "Apply",
-        "Update"
-      ],
-      "x-enum-varnames": [
-        "ManagedFieldsOperationApply",
-        "ManagedFieldsOperationUpdate"
-      ]
+      "enum": ["Apply", "Update"],
+      "x-enum-varnames": ["ManagedFieldsOperationApply", "ManagedFieldsOperationUpdate"]
     },
     "v1.OwnerReference": {
       "type": "object",
-      "required": [
-        "apiVersion",
-        "kind",
-        "name",
-        "uid"
-      ],
+      "required": ["apiVersion", "kind", "name", "uid"],
       "properties": {
         "apiVersion": {
           "description": "API version of the referent.",
@@ -1541,26 +1424,12 @@
     },
     "v1.PersistentVolumeAccessMode": {
       "type": "string",
-      "enum": [
-        "ReadWriteOnce",
-        "ReadOnlyMany",
-        "ReadWriteMany",
-        "ReadWriteOncePod"
-      ],
-      "x-enum-varnames": [
-        "ReadWriteOnce",
-        "ReadOnlyMany",
-        "ReadWriteMany",
-        "ReadWriteOncePod"
-      ]
+      "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"],
+      "x-enum-varnames": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
     },
     "v1.TypedLocalObjectReference": {
       "type": "object",
-      "required": [
-        "apiGroup",
-        "kind",
-        "name"
-      ],
+      "required": ["apiGroup", "kind", "name"],
       "properties": {
         "apiGroup": {
           "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.\n+optional",
@@ -1578,11 +1447,7 @@
     },
     "v1.TypedObjectReference": {
       "type": "object",
-      "required": [
-        "apiGroup",
-        "kind",
-        "name"
-      ],
+      "required": ["apiGroup", "kind", "name"],
       "properties": {
         "apiGroup": {
           "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.\n+optional",
@@ -1650,10 +1515,7 @@
     },
     "v1.LabelSelectorRequirement": {
       "type": "object",
-      "required": [
-        "key",
-        "operator"
-      ],
+      "required": ["key", "operator"],
       "properties": {
         "key": {
           "description": "key is the label key that the selector applies to.",
@@ -1678,12 +1540,7 @@
     },
     "v1.LabelSelectorOperator": {
       "type": "string",
-      "enum": [
-        "In",
-        "NotIn",
-        "Exists",
-        "DoesNotExist"
-      ],
+      "enum": ["In", "NotIn", "Exists", "DoesNotExist"],
       "x-enum-varnames": [
         "LabelSelectorOpIn",
         "LabelSelectorOpNotIn",
@@ -1693,14 +1550,8 @@
     },
     "v1.PersistentVolumeMode": {
       "type": "string",
-      "enum": [
-        "Block",
-        "Filesystem"
-      ],
-      "x-enum-varnames": [
-        "PersistentVolumeBlock",
-        "PersistentVolumeFilesystem"
-      ]
+      "enum": ["Block", "Filesystem"],
+      "x-enum-varnames": ["PersistentVolumeBlock", "PersistentVolumeFilesystem"]
     },
     "v1.FCVolumeSource": {
       "type": "object",
@@ -1735,9 +1586,7 @@
     },
     "v1.FlexVolumeSource": {
       "type": "object",
-      "required": [
-        "driver"
-      ],
+      "required": ["driver"],
       "properties": {
         "driver": {
           "description": "driver is the name of the driver to use for this volume.",
@@ -1783,9 +1632,7 @@
     },
     "v1.GCEPersistentDiskVolumeSource": {
       "type": "object",
-      "required": [
-        "pdName"
-      ],
+      "required": ["pdName"],
       "properties": {
         "fsType": {
           "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
@@ -1807,9 +1654,7 @@
     },
     "v1.GitRepoVolumeSource": {
       "type": "object",
-      "required": [
-        "repository"
-      ],
+      "required": ["repository"],
       "properties": {
         "directory": {
           "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.\n+optional",
@@ -1827,10 +1672,7 @@
     },
     "v1.GlusterfsVolumeSource": {
       "type": "object",
-      "required": [
-        "endpoints",
-        "path"
-      ],
+      "required": ["endpoints", "path"],
       "properties": {
         "endpoints": {
           "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
@@ -1848,9 +1690,7 @@
     },
     "v1.HostPathVolumeSource": {
       "type": "object",
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "properties": {
         "path": {
           "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
@@ -1908,24 +1748,12 @@
     },
     "v1.PullPolicy": {
       "type": "string",
-      "enum": [
-        "Always",
-        "Never",
-        "IfNotPresent"
-      ],
-      "x-enum-varnames": [
-        "PullAlways",
-        "PullNever",
-        "PullIfNotPresent"
-      ]
+      "enum": ["Always", "Never", "IfNotPresent"],
+      "x-enum-varnames": ["PullAlways", "PullNever", "PullIfNotPresent"]
     },
     "v1.ISCSIVolumeSource": {
       "type": "object",
-      "required": [
-        "iqn",
-        "lun",
-        "targetPortal"
-      ],
+      "required": ["iqn", "lun", "targetPortal"],
       "properties": {
         "chapAuthDiscovery": {
           "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication\n+optional",
@@ -1982,10 +1810,7 @@
     },
     "v1.NFSVolumeSource": {
       "type": "object",
-      "required": [
-        "path",
-        "server"
-      ],
+      "required": ["path", "server"],
       "properties": {
         "path": {
           "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
@@ -2003,9 +1828,7 @@
     },
     "v1.PersistentVolumeClaimVolumeSource": {
       "type": "object",
-      "required": [
-        "claimName"
-      ],
+      "required": ["claimName"],
       "properties": {
         "claimName": {
           "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
@@ -2019,9 +1842,7 @@
     },
     "v1.PhotonPersistentDiskVolumeSource": {
       "type": "object",
-      "required": [
-        "pdID"
-      ],
+      "required": ["pdID"],
       "properties": {
         "fsType": {
           "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -2035,9 +1856,7 @@
     },
     "v1.PortworxVolumeSource": {
       "type": "object",
-      "required": [
-        "volumeID"
-      ],
+      "required": ["volumeID"],
       "properties": {
         "fsType": {
           "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -2055,9 +1874,7 @@
     },
     "v1.ProjectedVolumeSource": {
       "type": "object",
-      "required": [
-        "sources"
-      ],
+      "required": ["sources"],
       "properties": {
         "defaultMode": {
           "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
@@ -2119,9 +1936,7 @@
     },
     "v1.ClusterTrustBundleProjection": {
       "type": "object",
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "properties": {
         "labelSelector": {
           "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".\n+optional",
@@ -2203,9 +2018,7 @@
     },
     "v1.ServiceAccountTokenProjection": {
       "type": "object",
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "properties": {
         "audience": {
           "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.\n+optional",
@@ -2223,10 +2036,7 @@
     },
     "v1.QuobyteVolumeSource": {
       "type": "object",
-      "required": [
-        "registry",
-        "volume"
-      ],
+      "required": ["registry", "volume"],
       "properties": {
         "group": {
           "description": "group to map volume access to\nDefault is no group\n+optional",
@@ -2256,10 +2066,7 @@
     },
     "v1.RBDVolumeSource": {
       "type": "object",
-      "required": [
-        "image",
-        "monitors"
-      ],
+      "required": ["image", "monitors"],
       "properties": {
         "fsType": {
           "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
@@ -2304,11 +2111,7 @@
     },
     "v1.ScaleIOVolumeSource": {
       "type": "object",
-      "required": [
-        "gateway",
-        "secretRef",
-        "system"
-      ],
+      "required": ["gateway", "secretRef", "system"],
       "properties": {
         "fsType": {
           "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".\n+optional\n+default=\"xfs\"",
@@ -2411,9 +2214,7 @@
     },
     "v1.VsphereVirtualDiskVolumeSource": {
       "type": "object",
-      "required": [
-        "volumePath"
-      ],
+      "required": ["volumePath"],
       "properties": {
         "fsType": {
           "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\n+optional",
@@ -2435,10 +2236,7 @@
     },
     "v1beta1.WorkspaceKindPodOptions": {
       "type": "object",
-      "required": [
-        "imageConfig",
-        "podConfig"
-      ],
+      "required": ["imageConfig", "podConfig"],
       "properties": {
         "imageConfig": {
           "description": "imageConfig options",
@@ -2460,10 +2258,7 @@
     },
     "v1beta1.ImageConfig": {
       "type": "object",
-      "required": [
-        "spawner",
-        "values"
-      ],
+      "required": ["spawner", "values"],
       "properties": {
         "spawner": {
           "description": "spawner ui configs",
@@ -2484,9 +2279,7 @@
     },
     "v1beta1.OptionsSpawnerConfig": {
       "type": "object",
-      "required": [
-        "default"
-      ],
+      "required": ["default"],
       "properties": {
         "default": {
           "description": "the id of the default option\n - this will be selected by default in the spawner ui\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example=\"jupyterlab_scipy_190\"",
@@ -2496,11 +2289,7 @@
     },
     "v1beta1.ImageConfigValue": {
       "type": "object",
-      "required": [
-        "id",
-        "spawner",
-        "spec"
-      ],
+      "required": ["id", "spawner", "spec"],
       "properties": {
         "id": {
           "description": "the id of this image config\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example:=\"jupyterlab_scipy_190\"",
@@ -2534,9 +2323,7 @@
     },
     "v1beta1.OptionRedirect": {
       "type": "object",
-      "required": [
-        "to"
-      ],
+      "required": ["to"],
       "properties": {
         "message": {
           "description": "information about the redirect\n+kubebuilder:validation:Optional",
@@ -2554,10 +2341,7 @@
     },
     "v1beta1.RedirectMessage": {
       "type": "object",
-      "required": [
-        "level",
-        "text"
-      ],
+      "required": ["level", "text"],
       "properties": {
         "level": {
           "description": "the importance level of the message\n+kubebuilder:example:=\"Info\"",
@@ -2575,11 +2359,7 @@
     },
     "v1beta1.RedirectMessageLevel": {
       "type": "string",
-      "enum": [
-        "Info",
-        "Warning",
-        "Danger"
-      ],
+      "enum": ["Info", "Warning", "Danger"],
       "x-enum-varnames": [
         "RedirectMessageLevelInfo",
         "RedirectMessageLevelWarning",
@@ -2588,9 +2368,7 @@
     },
     "v1beta1.OptionSpawnerInfo": {
       "type": "object",
-      "required": [
-        "displayName"
-      ],
+      "required": ["displayName"],
       "properties": {
         "description": {
           "description": "a description of the option\n+kubebuilder:validation:Optional\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=1024",
@@ -2615,10 +2393,7 @@
     },
     "v1beta1.OptionSpawnerLabel": {
       "type": "object",
-      "required": [
-        "key",
-        "value"
-      ],
+      "required": ["key", "value"],
       "properties": {
         "key": {
           "description": "the key of the label\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=64",
@@ -2632,11 +2407,7 @@
     },
     "v1beta1.ImageConfigSpec": {
       "type": "object",
-      "required": [
-        "image",
-        "imagePullPolicy",
-        "ports"
-      ],
+      "required": ["image", "imagePullPolicy", "ports"],
       "properties": {
         "image": {
           "description": "the container image to use\n+kubebuilder:validation:MinLength:=2\n+kubeflow:example=\"ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.7.0\"",
@@ -2661,10 +2432,7 @@
     },
     "v1beta1.ImagePort": {
       "type": "object",
-      "required": [
-        "id",
-        "port"
-      ],
+      "required": ["id", "port"],
       "properties": {
         "displayName": {
           "description": "the display name of the port\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=64\n+kubebuilder:validation:Optional",
@@ -2682,10 +2450,7 @@
     },
     "v1beta1.PodConfig": {
       "type": "object",
-      "required": [
-        "spawner",
-        "values"
-      ],
+      "required": ["spawner", "values"],
       "properties": {
         "spawner": {
           "description": "spawner ui configs",
@@ -2706,11 +2471,7 @@
     },
     "v1beta1.PodConfigValue": {
       "type": "object",
-      "required": [
-        "id",
-        "spawner",
-        "spec"
-      ],
+      "required": ["id", "spawner", "spec"],
       "properties": {
         "id": {
           "description": "the id of this pod config\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example=\"big_gpu\"",
@@ -2828,10 +2589,7 @@
     },
     "v1.PreferredSchedulingTerm": {
       "type": "object",
-      "required": [
-        "preference",
-        "weight"
-      ],
+      "required": ["preference", "weight"],
       "properties": {
         "preference": {
           "description": "A node selector term, associated with the corresponding weight.",
@@ -2868,10 +2626,7 @@
     },
     "v1.NodeSelectorRequirement": {
       "type": "object",
-      "required": [
-        "key",
-        "operator"
-      ],
+      "required": ["key", "operator"],
       "properties": {
         "key": {
           "description": "The label key that the selector applies to.",
@@ -2896,14 +2651,7 @@
     },
     "v1.NodeSelectorOperator": {
       "type": "string",
-      "enum": [
-        "In",
-        "NotIn",
-        "Exists",
-        "DoesNotExist",
-        "Gt",
-        "Lt"
-      ],
+      "enum": ["In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"],
       "x-enum-varnames": [
         "NodeSelectorOpIn",
         "NodeSelectorOpNotIn",
@@ -2915,9 +2663,7 @@
     },
     "v1.NodeSelector": {
       "type": "object",
-      "required": [
-        "nodeSelectorTerms"
-      ],
+      "required": ["nodeSelectorTerms"],
       "properties": {
         "nodeSelectorTerms": {
           "description": "Required. A list of node selector terms. The terms are ORed.\n+listType=atomic",
@@ -2949,10 +2695,7 @@
     },
     "v1.WeightedPodAffinityTerm": {
       "type": "object",
-      "required": [
-        "podAffinityTerm",
-        "weight"
-      ],
+      "required": ["podAffinityTerm", "weight"],
       "properties": {
         "podAffinityTerm": {
           "description": "Required. A pod affinity term, associated with the corresponding weight.",
@@ -2970,9 +2713,7 @@
     },
     "v1.PodAffinityTerm": {
       "type": "object",
-      "required": [
-        "topologyKey"
-      ],
+      "required": ["topologyKey"],
       "properties": {
         "labelSelector": {
           "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.\n+optional",
@@ -3066,9 +2807,7 @@
     },
     "v1.ResourceClaim": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
@@ -3115,11 +2854,7 @@
     },
     "v1.TaintEffect": {
       "type": "string",
-      "enum": [
-        "NoSchedule",
-        "PreferNoSchedule",
-        "NoExecute"
-      ],
+      "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"],
       "x-enum-varnames": [
         "TaintEffectNoSchedule",
         "TaintEffectPreferNoSchedule",
@@ -3128,14 +2863,8 @@
     },
     "v1.TolerationOperator": {
       "type": "string",
-      "enum": [
-        "Exists",
-        "Equal"
-      ],
-      "x-enum-varnames": [
-        "TolerationOpExists",
-        "TolerationOpEqual"
-      ]
+      "enum": ["Exists", "Equal"],
+      "x-enum-varnames": ["TolerationOpExists", "TolerationOpEqual"]
     },
     "v1beta1.WorkspaceKindPodMetadata": {
       "type": "object",
@@ -3158,11 +2887,7 @@
     },
     "v1beta1.WorkspaceKindPort": {
       "type": "object",
-      "required": [
-        "defaultDisplayName",
-        "id",
-        "protocol"
-      ],
+      "required": ["defaultDisplayName", "id", "protocol"],
       "properties": {
         "defaultDisplayName": {
           "description": "the default display name of the port\n- note, this can be overridden on a per image config value basis\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=64\n+kubebuilder:example:=\"JupyterLab\"",
@@ -3235,12 +2960,8 @@
     },
     "v1beta1.ImagePortProtocol": {
       "type": "string",
-      "enum": [
-        "HTTP"
-      ],
-      "x-enum-varnames": [
-        "ImagePortProtocolHTTP"
-      ]
+      "enum": ["HTTP"],
+      "x-enum-varnames": ["ImagePortProtocolHTTP"]
     },
     "v1beta1.WorkspaceKindProbes": {
       "type": "object",
@@ -3346,10 +3067,7 @@
     },
     "v1.GRPCAction": {
       "type": "object",
-      "required": [
-        "port",
-        "service"
-      ],
+      "required": ["port", "service"],
       "properties": {
         "port": {
           "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -3363,9 +3081,7 @@
     },
     "v1.HTTPGetAction": {
       "type": "object",
-      "required": [
-        "port"
-      ],
+      "required": ["port"],
       "properties": {
         "host": {
           "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.\n+optional",
@@ -3402,10 +3118,7 @@
     },
     "v1.HTTPHeader": {
       "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
+      "required": ["name", "value"],
       "properties": {
         "name": {
           "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
@@ -3419,11 +3132,7 @@
     },
     "intstr.IntOrString": {
       "type": "object",
-      "required": [
-        "intVal",
-        "strVal",
-        "type"
-      ],
+      "required": ["intVal", "strVal", "type"],
       "properties": {
         "intVal": {
           "type": "integer"
@@ -3439,39 +3148,22 @@
     "intstr.Type": {
       "type": "integer",
       "format": "int64",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "x-enum-comments": {
         "Int": "The IntOrString holds an int.",
         "String": "The IntOrString holds a string."
       },
-      "x-enum-descriptions": [
-        "The IntOrString holds an int.",
-        "The IntOrString holds a string."
-      ],
-      "x-enum-varnames": [
-        "Int",
-        "String"
-      ]
+      "x-enum-descriptions": ["The IntOrString holds an int.", "The IntOrString holds a string."],
+      "x-enum-varnames": ["Int", "String"]
     },
     "v1.URIScheme": {
       "type": "string",
-      "enum": [
-        "HTTP",
-        "HTTPS"
-      ],
-      "x-enum-varnames": [
-        "URISchemeHTTP",
-        "URISchemeHTTPS"
-      ]
+      "enum": ["HTTP", "HTTPS"],
+      "x-enum-varnames": ["URISchemeHTTP", "URISchemeHTTPS"]
     },
     "v1.TCPSocketAction": {
       "type": "object",
-      "required": [
-        "port"
-      ],
+      "required": ["port"],
       "properties": {
         "host": {
           "description": "Optional: Host name to connect to, defaults to the pod IP.\n+optional",
@@ -3572,32 +3264,17 @@
     },
     "v1.PodFSGroupChangePolicy": {
       "type": "string",
-      "enum": [
-        "OnRootMismatch",
-        "Always"
-      ],
-      "x-enum-varnames": [
-        "FSGroupChangeOnRootMismatch",
-        "FSGroupChangeAlways"
-      ]
+      "enum": ["OnRootMismatch", "Always"],
+      "x-enum-varnames": ["FSGroupChangeOnRootMismatch", "FSGroupChangeAlways"]
     },
     "v1.SupplementalGroupsPolicy": {
       "type": "string",
-      "enum": [
-        "Merge",
-        "Strict"
-      ],
-      "x-enum-varnames": [
-        "SupplementalGroupsPolicyMerge",
-        "SupplementalGroupsPolicyStrict"
-      ]
+      "enum": ["Merge", "Strict"],
+      "x-enum-varnames": ["SupplementalGroupsPolicyMerge", "SupplementalGroupsPolicyStrict"]
     },
     "v1.Sysctl": {
       "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
+      "required": ["name", "value"],
       "properties": {
         "name": {
           "description": "Name of a property to set",
@@ -3611,9 +3288,7 @@
     },
     "v1beta1.WorkspaceKindServiceAccount": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "description": "the name of the ServiceAccount (NOT MUTABLE)\n - this Service Account MUST already exist in the Namespace\n   of the Workspace, the controller will NOT create it\n - we will not show this WorkspaceKind in the Spawner UI\n   if the SA does not exist in the Namespace\n+kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"ServiceAccount 'name' is immutable\"\n+kubebuilder:example=\"default-editor\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -3623,9 +3298,7 @@
     },
     "v1beta1.WorkspaceKindVolumeMounts": {
       "type": "object",
-      "required": [
-        "home"
-      ],
+      "required": ["home"],
       "properties": {
         "home": {
           "description": "the path to mount the home PVC (NOT MUTABLE)\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=4096\n+kubebuilder:validation:Pattern:=^/[^/].*$\n+kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"mount path of 'home' is immutable\"\n+kubebuilder:example:=\"/home/jovyan\"",
@@ -3635,12 +3308,7 @@
     },
     "v1beta1.WorkspaceKindSpawner": {
       "type": "object",
-      "required": [
-        "description",
-        "displayName",
-        "icon",
-        "logo"
-      ],
+      "required": ["description", "displayName", "icon", "logo"],
       "properties": {
         "deprecated": {
           "description": "if this WorkspaceKind is deprecated\n+kubebuilder:validation:Optional\n+kubebuilder:default:=false",
@@ -3699,12 +3367,7 @@
     },
     "v1beta1.WorkspaceKindAssetConfigMap": {
       "type": "object",
-      "required": [
-        "key",
-        "mediaType",
-        "name",
-        "namespace"
-      ],
+      "required": ["key", "mediaType", "name", "namespace"],
       "properties": {
         "key": {
           "description": "the key in the ConfigMap which contains the data\n+kubebuilder:example=\"jupyterlab-logo.svg\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[-._a-zA-Z0-9]+$",
@@ -3730,12 +3393,8 @@
     },
     "v1beta1.WorkspaceKindAssetMediaType": {
       "type": "string",
-      "enum": [
-        "image/svg+xml"
-      ],
-      "x-enum-varnames": [
-        "WorkspaceKindAssetMediaTypeSVG"
-      ]
+      "enum": ["image/svg+xml"],
+      "x-enum-varnames": ["WorkspaceKindAssetMediaTypeSVG"]
     }
   }
 }

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json
@@ -1,0 +1,3741 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/$defs/workspacekinds.WorkspaceKindUpdate",
+  "$defs": {
+    "workspacekinds.WorkspaceKindUpdate": {
+      "type": "object",
+      "required": [
+        "podTemplate",
+        "revision",
+        "spawner"
+      ],
+      "properties": {
+        "podTemplate": {
+          "$ref": "#/$defs/v1beta1.WorkspaceKindPodTemplate"
+        },
+        "revision": {
+          "description": "RevisionString is an opaque token that can be treated like an etag.\n  - Clients receive this value from GET requests and must include it\n    in update requests to ensure they are updating the expected version.\n  - Clients must not parse, interpret, or compare revision values\n    other than for equality, as the format is not guaranteed to be stable.",
+          "type": "string"
+        },
+        "spawner": {
+          "$ref": "#/$defs/v1beta1.WorkspaceKindSpawner"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindPodTemplate": {
+      "type": "object",
+      "required": [
+        "options",
+        "ports",
+        "serviceAccount",
+        "volumeMounts"
+      ],
+      "properties": {
+        "containerSecurityContext": {
+          "description": "container security context for Workspace Pods (MUTABLE)\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SecurityContext"
+            }
+          ]
+        },
+        "culling": {
+          "description": "culling configs for pausing inactive Workspaces (MUTABLE)\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindCullingConfig"
+            }
+          ]
+        },
+        "extraEnv": {
+          "description": "environment variables for Workspace Pods (MUTABLE)\n - the following go template functions are available:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"NB_PREFIX\": \"{{ httpPathPrefix 'jupyterlab' }}\" }\n+listType:=\"map\"\n+listMapKey:=\"name\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.EnvVar"
+          }
+        },
+        "extraVolumeMounts": {
+          "description": "extra volume mounts for Workspace Pods (MUTABLE)\n+kubebuilder:validation:Optional\n+listType:=\"map\"\n+listMapKey:=\"mountPath\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.VolumeMount"
+          }
+        },
+        "extraVolumes": {
+          "description": "extra volumes for Workspace Pods (MUTABLE)\n+kubebuilder:validation:Optional\n+listType:=\"map\"\n+listMapKey:=\"name\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.Volume"
+          }
+        },
+        "options": {
+          "description": "options are the user-selectable fields, they determine the PodSpec of the Workspace",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindPodOptions"
+            }
+          ]
+        },
+        "podMetadata": {
+          "description": "metadata for Workspace Pods (MUTABLE)\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindPodMetadata"
+            }
+          ]
+        },
+        "ports": {
+          "description": "port definitions which can be referenced in image config values\n- think of port definitions as the \"types\" of services which could be provided by a specific image\n- a port definition has a common id (URL path) for consistency if the listening TCP port changes\n- ports are referenced in image config values by their `id` and their definition here establishes\n  their protocol type, and default display name in the UI\n+kubebuilder:validation:MinItems:=1\n+listType:=\"map\"\n+listMapKey:=\"id\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1beta1.WorkspaceKindPort"
+          }
+        },
+        "probes": {
+          "description": "standard probes to determine Container health (MUTABLE)\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindProbes"
+            }
+          ]
+        },
+        "securityContext": {
+          "description": "security context for Workspace Pods (MUTABLE)\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PodSecurityContext"
+            }
+          ]
+        },
+        "serviceAccount": {
+          "description": "service account configs for Workspace Pods",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindServiceAccount"
+            }
+          ]
+        },
+        "volumeMounts": {
+          "description": "volume mount paths",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindVolumeMounts"
+            }
+          ]
+        }
+      }
+    },
+    "v1.SecurityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "boolean"
+        },
+        "appArmorProfile": {
+          "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AppArmorProfile"
+            }
+          ]
+        },
+        "capabilities": {
+          "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.Capabilities"
+            }
+          ]
+        },
+        "privileged": {
+          "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "boolean"
+        },
+        "procMount": {
+          "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ProcMountType"
+            }
+          ]
+        },
+        "readOnlyRootFilesystem": {
+          "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\n+optional",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SELinuxOptions"
+            }
+          ]
+        },
+        "seccompProfile": {
+          "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SeccompProfile"
+            }
+          ]
+        },
+        "windowsOptions": {
+          "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.WindowsSecurityContextOptions"
+            }
+          ]
+        }
+      }
+    },
+    "v1.AppArmorProfile": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "localhostProfile": {
+          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".\n+optional",
+          "type": "string"
+        },
+        "type": {
+          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.\n+unionDiscriminator",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AppArmorProfileType"
+            }
+          ]
+        }
+      }
+    },
+    "v1.AppArmorProfileType": {
+      "type": "string",
+      "enum": [
+        "Unconfined",
+        "RuntimeDefault",
+        "Localhost"
+      ],
+      "x-enum-varnames": [
+        "AppArmorProfileTypeUnconfined",
+        "AppArmorProfileTypeRuntimeDefault",
+        "AppArmorProfileTypeLocalhost"
+      ]
+    },
+    "v1.Capabilities": {
+      "type": "object",
+      "properties": {
+        "add": {
+          "description": "Added capabilities\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "drop": {
+          "description": "Removed capabilities\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.ProcMountType": {
+      "type": "string",
+      "enum": [
+        "Default",
+        "Unmasked"
+      ],
+      "x-enum-varnames": [
+        "DefaultProcMount",
+        "UnmaskedProcMount"
+      ]
+    },
+    "v1.SELinuxOptions": {
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "Level is SELinux level label that applies to the container.\n+optional",
+          "type": "string"
+        },
+        "role": {
+          "description": "Role is a SELinux role label that applies to the container.\n+optional",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is a SELinux type label that applies to the container.\n+optional",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is a SELinux user label that applies to the container.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.SeccompProfile": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "localhostProfile": {
+          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.\n+optional",
+          "type": "string"
+        },
+        "type": {
+          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.\n+unionDiscriminator",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SeccompProfileType"
+            }
+          ]
+        }
+      }
+    },
+    "v1.SeccompProfileType": {
+      "type": "string",
+      "enum": [
+        "Unconfined",
+        "RuntimeDefault",
+        "Localhost"
+      ],
+      "x-enum-varnames": [
+        "SeccompProfileTypeUnconfined",
+        "SeccompProfileTypeRuntimeDefault",
+        "SeccompProfileTypeLocalhost"
+      ]
+    },
+    "v1.WindowsSecurityContextOptions": {
+      "type": "object",
+      "properties": {
+        "gmsaCredentialSpec": {
+          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.\n+optional",
+          "type": "string"
+        },
+        "gmsaCredentialSpecName": {
+          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.\n+optional",
+          "type": "string"
+        },
+        "hostProcess": {
+          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.\n+optional",
+          "type": "boolean"
+        },
+        "runAsUserName": {
+          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindCullingConfig": {
+      "type": "object",
+      "required": [
+        "activityProbe"
+      ],
+      "properties": {
+        "activityProbe": {
+          "description": "the probe used to determine if the Workspace is active",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.ActivityProbe"
+            }
+          ]
+        },
+        "enabled": {
+          "description": "if the culling feature is enabled\n+kubebuilder:validation:Optional\n+kubebuilder:default=true",
+          "type": "boolean"
+        },
+        "maxInactiveSeconds": {
+          "description": "the maximum number of seconds a Workspace can be inactive\n+kubebuilder:validation:Optional\n+kubebuilder:validation:Minimum:=60\n+kubebuilder:default=86400",
+          "type": "integer"
+        }
+      }
+    },
+    "v1beta1.ActivityProbe": {
+      "type": "object",
+      "properties": {
+        "exec": {
+          "description": "a shell command probe\n - if the Workspace had activity in the last 60 seconds this command\n   should return status 0, otherwise it should return status 1\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.ActivityProbeExec"
+            }
+          ]
+        },
+        "jupyter": {
+          "description": "a Jupyter-specific probe\n - will poll the `/api/status` endpoint of the Jupyter API, and use the `last_activity` field\n - note, users need to be careful that their other probes don't trigger a \"last_activity\" update\n   e.g. they should only check the health of Jupyter using the `/api/status` endpoint\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.ActivityProbeJupyter"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.ActivityProbeExec": {
+      "type": "object",
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "description": "the command to run\n+kubebuilder:validation:MinItems:=1\n+kubebuilder:example={\"bash\", \"-c\", \"exit 0\"}",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1beta1.ActivityProbeJupyter": {
+      "type": "object",
+      "required": [
+        "lastActivity"
+      ],
+      "properties": {
+        "lastActivity": {
+          "description": "if the Jupyter-specific probe is enabled\n+kubebuilder:example=true",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.EnvVar": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".\n+optional",
+          "type": "string"
+        },
+        "valueFrom": {
+          "description": "Source for the environment variable's value. Cannot be used if value is not empty.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.EnvVarSource"
+            }
+          ]
+        }
+      }
+    },
+    "v1.EnvVarSource": {
+      "type": "object",
+      "properties": {
+        "configMapKeyRef": {
+          "description": "Selects a key of a ConfigMap.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ConfigMapKeySelector"
+            }
+          ]
+        },
+        "fieldRef": {
+          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ObjectFieldSelector"
+            }
+          ]
+        },
+        "resourceFieldRef": {
+          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceFieldSelector"
+            }
+          ]
+        },
+        "secretKeyRef": {
+          "description": "Selects a key of a secret in the pod's namespace\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SecretKeySelector"
+            }
+          ]
+        }
+      }
+    },
+    "v1.ConfigMapKeySelector": {
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "description": "The key to select.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional\n+default=\"\"\n+kubebuilder:default=\"\"\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap or its key must be defined\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.ObjectFieldSelector": {
+      "type": "object",
+      "required": [
+        "fieldPath"
+      ],
+      "properties": {
+        "apiVersion": {
+          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".\n+optional",
+          "type": "string"
+        },
+        "fieldPath": {
+          "description": "Path of the field to select in the specified API version.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.ResourceFieldSelector": {
+      "type": "object",
+      "required": [
+        "resource"
+      ],
+      "properties": {
+        "containerName": {
+          "description": "Container name: required for volumes, optional for env vars\n+optional",
+          "type": "string"
+        },
+        "divisor": {
+          "description": "Specifies the output format of the exposed resources, defaults to \"1\"\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/resource.Quantity"
+            }
+          ]
+        },
+        "resource": {
+          "description": "Required: resource to select",
+          "type": "string"
+        }
+      }
+    },
+    "resource.Quantity": {
+      "type": "object",
+      "properties": {
+        "Format": {
+          "type": "string",
+          "enum": [
+            "DecimalExponent",
+            "BinarySI",
+            "DecimalSI"
+          ],
+          "x-enum-comments": {
+            "BinarySI": "e.g., 12Mi (12 * 2^20)",
+            "DecimalExponent": "e.g., 12e6",
+            "DecimalSI": "e.g., 12M  (12 * 10^6)"
+          },
+          "x-enum-descriptions": [
+            "e.g., 12e6",
+            "e.g., 12Mi (12 * 2^20)",
+            "e.g., 12M  (12 * 10^6)"
+          ],
+          "x-enum-varnames": [
+            "DecimalExponent",
+            "BinarySI",
+            "DecimalSI"
+          ]
+        }
+      }
+    },
+    "v1.SecretKeySelector": {
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "description": "The key of the secret to select from.  Must be a valid secret key.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional\n+default=\"\"\n+kubebuilder:default=\"\"\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret or its key must be defined\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.VolumeMount": {
+      "type": "object",
+      "required": [
+        "mountPath",
+        "name"
+      ],
+      "properties": {
+        "mountPath": {
+          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+          "type": "string"
+        },
+        "mountPropagation": {
+          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.MountPropagationMode"
+            }
+          ]
+        },
+        "name": {
+          "description": "This must match the Name of a Volume.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.\n+optional",
+          "type": "boolean"
+        },
+        "recursiveReadOnly": {
+          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.\n\n+featureGate=RecursiveReadOnlyMounts\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.RecursiveReadOnlyMode"
+            }
+          ]
+        },
+        "subPath": {
+          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).\n+optional",
+          "type": "string"
+        },
+        "subPathExpr": {
+          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.MountPropagationMode": {
+      "type": "string",
+      "enum": [
+        "None",
+        "HostToContainer",
+        "Bidirectional"
+      ],
+      "x-enum-varnames": [
+        "MountPropagationNone",
+        "MountPropagationHostToContainer",
+        "MountPropagationBidirectional"
+      ]
+    },
+    "v1.RecursiveReadOnlyMode": {
+      "type": "string",
+      "enum": [
+        "Disabled",
+        "IfPossible",
+        "Enabled"
+      ],
+      "x-enum-varnames": [
+        "RecursiveReadOnlyDisabled",
+        "RecursiveReadOnlyIfPossible",
+        "RecursiveReadOnlyEnabled"
+      ]
+    },
+    "v1.Volume": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "awsElasticBlockStore": {
+          "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AWSElasticBlockStoreVolumeSource"
+            }
+          ]
+        },
+        "azureDisk": {
+          "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AzureDiskVolumeSource"
+            }
+          ]
+        },
+        "azureFile": {
+          "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AzureFileVolumeSource"
+            }
+          ]
+        },
+        "cephfs": {
+          "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.CephFSVolumeSource"
+            }
+          ]
+        },
+        "cinder": {
+          "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.CinderVolumeSource"
+            }
+          ]
+        },
+        "configMap": {
+          "description": "configMap represents a configMap that should populate this volume\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ConfigMapVolumeSource"
+            }
+          ]
+        },
+        "csi": {
+          "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.CSIVolumeSource"
+            }
+          ]
+        },
+        "downwardAPI": {
+          "description": "downwardAPI represents downward API about the pod that should populate this volume\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.DownwardAPIVolumeSource"
+            }
+          ]
+        },
+        "emptyDir": {
+          "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.EmptyDirVolumeSource"
+            }
+          ]
+        },
+        "ephemeral": {
+          "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.\n\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.EphemeralVolumeSource"
+            }
+          ]
+        },
+        "fc": {
+          "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.FCVolumeSource"
+            }
+          ]
+        },
+        "flexVolume": {
+          "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.FlexVolumeSource"
+            }
+          ]
+        },
+        "flocker": {
+          "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.FlockerVolumeSource"
+            }
+          ]
+        },
+        "gcePersistentDisk": {
+          "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.GCEPersistentDiskVolumeSource"
+            }
+          ]
+        },
+        "gitRepo": {
+          "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.GitRepoVolumeSource"
+            }
+          ]
+        },
+        "glusterfs": {
+          "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.GlusterfsVolumeSource"
+            }
+          ]
+        },
+        "hostPath": {
+          "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.HostPathVolumeSource"
+            }
+          ]
+        },
+        "image": {
+          "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.\n+featureGate=ImageVolume\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ImageVolumeSource"
+            }
+          ]
+        },
+        "iscsi": {
+          "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ISCSIVolumeSource"
+            }
+          ]
+        },
+        "name": {
+          "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "nfs": {
+          "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.NFSVolumeSource"
+            }
+          ]
+        },
+        "persistentVolumeClaim": {
+          "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PersistentVolumeClaimVolumeSource"
+            }
+          ]
+        },
+        "photonPersistentDisk": {
+          "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PhotonPersistentDiskVolumeSource"
+            }
+          ]
+        },
+        "portworxVolume": {
+          "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PortworxVolumeSource"
+            }
+          ]
+        },
+        "projected": {
+          "description": "projected items for all in one resources secrets, configmaps, and downward API",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ProjectedVolumeSource"
+            }
+          ]
+        },
+        "quobyte": {
+          "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.QuobyteVolumeSource"
+            }
+          ]
+        },
+        "rbd": {
+          "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/rbd/README.md\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.RBDVolumeSource"
+            }
+          ]
+        },
+        "scaleIO": {
+          "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ScaleIOVolumeSource"
+            }
+          ]
+        },
+        "secret": {
+          "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SecretVolumeSource"
+            }
+          ]
+        },
+        "storageos": {
+          "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.StorageOSVolumeSource"
+            }
+          ]
+        },
+        "vsphereVolume": {
+          "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.VsphereVirtualDiskVolumeSource"
+            }
+          ]
+        }
+      }
+    },
+    "v1.AWSElasticBlockStoreVolumeSource": {
+      "type": "object",
+      "required": [
+        "volumeID"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
+          "type": "string"
+        },
+        "partition": {
+          "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\n+optional",
+          "type": "integer"
+        },
+        "readOnly": {
+          "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\n+optional",
+          "type": "boolean"
+        },
+        "volumeID": {
+          "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "string"
+        }
+      }
+    },
+    "v1.AzureDiskVolumeSource": {
+      "type": "object",
+      "required": [
+        "diskName",
+        "diskURI"
+      ],
+      "properties": {
+        "cachingMode": {
+          "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.\n+optional\n+default=ref(AzureDataDiskCachingReadWrite)",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AzureDataDiskCachingMode"
+            }
+          ]
+        },
+        "diskName": {
+          "description": "diskName is the Name of the data disk in the blob storage",
+          "type": "string"
+        },
+        "diskURI": {
+          "description": "diskURI is the URI of data disk in the blob storage",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\n+optional\n+default=\"ext4\"",
+          "type": "string"
+        },
+        "kind": {
+          "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared\n+default=ref(AzureSharedBlobDisk)",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AzureDataDiskKind"
+            }
+          ]
+        },
+        "readOnly": {
+          "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional\n+default=false",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.AzureDataDiskCachingMode": {
+      "type": "string",
+      "enum": [
+        "None",
+        "ReadOnly",
+        "ReadWrite"
+      ],
+      "x-enum-varnames": [
+        "AzureDataDiskCachingNone",
+        "AzureDataDiskCachingReadOnly",
+        "AzureDataDiskCachingReadWrite"
+      ]
+    },
+    "v1.AzureDataDiskKind": {
+      "type": "string",
+      "enum": [
+        "Shared",
+        "Dedicated",
+        "Managed"
+      ],
+      "x-enum-varnames": [
+        "AzureSharedBlobDisk",
+        "AzureDedicatedBlobDisk",
+        "AzureManagedDisk"
+      ]
+    },
+    "v1.AzureFileVolumeSource": {
+      "type": "object",
+      "required": [
+        "secretName",
+        "shareName"
+      ],
+      "properties": {
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+          "type": "string"
+        },
+        "shareName": {
+          "description": "shareName is the azure share Name",
+          "type": "string"
+        }
+      }
+    },
+    "v1.CephFSVolumeSource": {
+      "type": "object",
+      "required": [
+        "monitors"
+      ],
+      "properties": {
+        "monitors": {
+          "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /\n+optional",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it\n+optional",
+          "type": "boolean"
+        },
+        "secretFile": {
+          "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it\n+optional",
+          "type": "string"
+        },
+        "secretRef": {
+          "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "user": {
+          "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.LocalObjectReference": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional\n+default=\"\"\n+kubebuilder:default=\"\"\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.CinderVolumeSource": {
+      "type": "object",
+      "required": [
+        "volumeID"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md\n+optional",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md\n+optional",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "volumeID": {
+          "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": "string"
+        }
+      }
+    },
+    "v1.ConfigMapVolumeSource": {
+      "type": "object",
+      "properties": {
+        "defaultMode": {
+          "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
+          "type": "integer"
+        },
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.KeyToPath"
+          }
+        },
+        "name": {
+          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional\n+default=\"\"\n+kubebuilder:default=\"\"\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "optional specify whether the ConfigMap or its keys must be defined\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.KeyToPath": {
+      "type": "object",
+      "required": [
+        "key",
+        "path"
+      ],
+      "properties": {
+        "key": {
+          "description": "key is the key to project.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
+          "type": "integer"
+        },
+        "path": {
+          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.CSIVolumeSource": {
+      "type": "object",
+      "required": [
+        "driver"
+      ],
+      "properties": {
+        "driver": {
+          "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.\n+optional",
+          "type": "string"
+        },
+        "nodePublishSecretRef": {
+          "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "readOnly": {
+          "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).\n+optional",
+          "type": "boolean"
+        },
+        "volumeAttributes": {
+          "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.\n+optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.DownwardAPIVolumeSource": {
+      "type": "object",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
+          "type": "integer"
+        },
+        "items": {
+          "description": "Items is a list of downward API volume file\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.DownwardAPIVolumeFile"
+          }
+        }
+      }
+    },
+    "v1.DownwardAPIVolumeFile": {
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "fieldRef": {
+          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ObjectFieldSelector"
+            }
+          ]
+        },
+        "mode": {
+          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
+          "type": "integer"
+        },
+        "path": {
+          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+          "type": "string"
+        },
+        "resourceFieldRef": {
+          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceFieldSelector"
+            }
+          ]
+        }
+      }
+    },
+    "v1.EmptyDirVolumeSource": {
+      "type": "object",
+      "properties": {
+        "medium": {
+          "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.StorageMedium"
+            }
+          ]
+        },
+        "sizeLimit": {
+          "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/resource.Quantity"
+            }
+          ]
+        }
+      }
+    },
+    "v1.StorageMedium": {
+      "type": "string",
+      "enum": [
+        "",
+        "Memory",
+        "HugePages",
+        "HugePages-"
+      ],
+      "x-enum-comments": {
+        "StorageMediumDefault": "use whatever the default is for the node, assume anything we don't explicitly handle is this",
+        "StorageMediumHugePages": "use hugepages",
+        "StorageMediumHugePagesPrefix": "prefix for full medium notation HugePages-<size>",
+        "StorageMediumMemory": "use memory (e.g. tmpfs on linux)"
+      },
+      "x-enum-descriptions": [
+        "use whatever the default is for the node, assume anything we don't explicitly handle is this",
+        "use memory (e.g. tmpfs on linux)",
+        "use hugepages",
+        "prefix for full medium notation HugePages-<size>"
+      ],
+      "x-enum-varnames": [
+        "StorageMediumDefault",
+        "StorageMediumMemory",
+        "StorageMediumHugePages",
+        "StorageMediumHugePagesPrefix"
+      ]
+    },
+    "v1.EphemeralVolumeSource": {
+      "type": "object",
+      "properties": {
+        "volumeClaimTemplate": {
+          "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PersistentVolumeClaimTemplate"
+            }
+          ]
+        }
+      }
+    },
+    "v1.PersistentVolumeClaimTemplate": {
+      "type": "object",
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "metadata": {
+          "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.\n\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ObjectMeta"
+            }
+          ]
+        },
+        "spec": {
+          "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PersistentVolumeClaimSpec"
+            }
+          ]
+        }
+      }
+    },
+    "v1.ObjectMeta": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations\n+optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "creationTimestamp": {
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was\ncreated. It is not guaranteed to be set in happens-before order across separate operations.\nClients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system.\nRead-only.\nNull for lists.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n+optional",
+          "type": "string"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before\nit will be removed from the system. Only set when deletionTimestamp is also set.\nMay only be shortened.\nRead-only.\n+optional",
+          "type": "integer"
+        },
+        "deletionTimestamp": {
+          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This\nfield is set by the server when a graceful deletion is requested by the user, and is not\ndirectly settable by a client. The resource is expected to be deleted (no longer visible\nfrom resource lists, and not reachable by name) after the time in this field, once the\nfinalizers list is empty. As long as the finalizers list contains items, deletion is blocked.\nOnce the deletionTimestamp is set, this value may not be unset or be set further into the\nfuture, although it may be shortened or the resource may be deleted prior to this time.\nFor example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react\nby sending a graceful termination signal to the containers in the pod. After that 30 seconds,\nthe Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,\nremove the pod from the API. In the presence of network partitions, this object may still\nexist after this timestamp, until an administrator or automated process can determine the\nresource is fully terminated.\nIf not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested.\nRead-only.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n+optional",
+          "type": "string"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry\nis an identifier for the responsible component that will remove the entry\nfrom the list. If the deletionTimestamp of the object is non-nil, entries\nin this list can only be removed.\nFinalizers may be processed and removed in any order.  Order is NOT enforced\nbecause it introduces significant risk of stuck finalizers.\nfinalizers is a shared field, any actor with permission can reorder it.\nIf the finalizer list is processed in order, then this can lead to a situation\nin which the component responsible for the first finalizer in the list is\nwaiting for a signal (field value, external system, or other) produced by a\ncomponent responsible for a finalizer later in the list, resulting in a deadlock.\nWithout enforced ordering finalizers are free to order amongst themselves and\nare not vulnerable to ordering changes in the list.\n+optional\n+patchStrategy=merge\n+listType=set",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique\nname ONLY IF the Name field has not been provided.\nIf this field is used, the name returned to the client will be different\nthan the name passed. This value will also be combined with a unique suffix.\nThe provided value has the same validation rules as the Name field,\nand may be truncated by the length of the suffix required to make the value\nunique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency\n+optional",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state.\nPopulated by the system. Read-only.\n+optional",
+          "type": "integer"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels\n+optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields\nthat are managed by that workflow. This is mostly for internal\nhousekeeping, and users typically shouldn't need to set or\nunderstand this field. A workflow can be the user's name, a\ncontroller's name, or the name of a specific apply path like\n\"ci-cd\". The set of fields is always in the version that the\nworkflow used when modifying the object.\n\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.ManagedFieldsEntry"
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names\n+optional",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is\nequivalent to the \"default\" namespace, but \"default\" is the canonical representation.\nNot all objects are required to be scoped to a namespace - the value of this field for\nthose objects will be empty.\n\nMust be a DNS_LABEL.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces\n+optional",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have\nbeen deleted, this object will be garbage collected. If this object is managed by a controller,\nthen an entry in this list will point to this controller, with the controller field set to true.\nThere cannot be more than one managing controller.\n+optional\n+patchMergeKey=uid\n+patchStrategy=merge\n+listType=map\n+listMapKey=uid",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.OwnerReference"
+          }
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can\nbe used by clients to determine when objects have changed. May be used for optimistic\nconcurrency, change detection, and the watch operation on a resource or set of resources.\nClients must treat these values as opaque and passed unmodified back to the server.\nThey may only be valid for a particular resource or set of resources.\n\nPopulated by the system.\nRead-only.\nValue must be treated as opaque by clients and .\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency\n+optional",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.\n+optional",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by\nthe server on successful creation of a resource and is not allowed to change on PUT\noperations.\n\nPopulated by the system.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.ManagedFieldsEntry": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the version of this resource that this field set\napplies to. The format is \"group/version\" just like the top-level\nAPIVersion field. It is necessary to track the version of a field\nset because it cannot be automatically converted.",
+          "type": "string"
+        },
+        "fieldsType": {
+          "description": "FieldsType is the discriminator for the different fields format and version.\nThere is currently only one possible value: \"FieldsV1\"",
+          "type": "string"
+        },
+        "fieldsV1": {
+          "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.FieldsV1"
+            }
+          ]
+        },
+        "manager": {
+          "description": "Manager is an identifier of the workflow managing these fields.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created.\nThe only valid values for this field are 'Apply' and 'Update'.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ManagedFieldsOperationType"
+            }
+          ]
+        },
+        "subresource": {
+          "description": "Subresource is the name of the subresource used to update that object, or\nempty string if the object was updated through the main resource. The\nvalue of this field is used to distinguish between managers, even if they\nshare the same name. For example, a status update will be distinct from a\nregular update using the same manager name.\nNote that the APIVersion field is not related to the Subresource field and\nit always corresponds to the version of the main resource.",
+          "type": "string"
+        },
+        "time": {
+          "description": "Time is the timestamp of when the ManagedFields entry was added. The\ntimestamp will also be updated if a field is added, the manager\nchanges any of the owned fields value or removes a field. The\ntimestamp does not update when a field is removed from the entry\nbecause another manager took it over.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.FieldsV1": {
+      "type": "object"
+    },
+    "v1.ManagedFieldsOperationType": {
+      "type": "string",
+      "enum": [
+        "Apply",
+        "Update"
+      ],
+      "x-enum-varnames": [
+        "ManagedFieldsOperationApply",
+        "ManagedFieldsOperationUpdate"
+      ]
+    },
+    "v1.OwnerReference": {
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ],
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent.",
+          "type": "string"
+        },
+        "blockOwnerDeletion": {
+          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then\nthe owner cannot be deleted from the key-value store until this\nreference is removed.\nSee https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion\nfor how the garbage collector interacts with this field and enforces the foreground deletion.\nDefaults to false.\nTo set this field, a user needs \"delete\" permission of the owner,\notherwise 422 (Unprocessable Entity) will be returned.\n+optional",
+          "type": "boolean"
+        },
+        "controller": {
+          "description": "If true, this reference points to the managing controller.\n+optional",
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+          "type": "string"
+        }
+      }
+    },
+    "v1.PersistentVolumeClaimSpec": {
+      "type": "object",
+      "properties": {
+        "accessModes": {
+          "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.PersistentVolumeAccessMode"
+          }
+        },
+        "dataSource": {
+          "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.TypedLocalObjectReference"
+            }
+          ]
+        },
+        "dataSourceRef": {
+          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.TypedObjectReference"
+            }
+          ]
+        },
+        "resources": {
+          "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.VolumeResourceRequirements"
+            }
+          ]
+        },
+        "selector": {
+          "description": "selector is a label query over volumes to consider for binding.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LabelSelector"
+            }
+          ]
+        },
+        "storageClassName": {
+          "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1\n+optional",
+          "type": "string"
+        },
+        "volumeAttributesClassName": {
+          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).\n+featureGate=VolumeAttributesClass\n+optional",
+          "type": "string"
+        },
+        "volumeMode": {
+          "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PersistentVolumeMode"
+            }
+          ]
+        },
+        "volumeName": {
+          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.PersistentVolumeAccessMode": {
+      "type": "string",
+      "enum": [
+        "ReadWriteOnce",
+        "ReadOnlyMany",
+        "ReadWriteMany",
+        "ReadWriteOncePod"
+      ],
+      "x-enum-varnames": [
+        "ReadWriteOnce",
+        "ReadOnlyMany",
+        "ReadWriteMany",
+        "ReadWriteOncePod"
+      ]
+    },
+    "v1.TypedLocalObjectReference": {
+      "type": "object",
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.\n+optional",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      }
+    },
+    "v1.TypedObjectReference": {
+      "type": "object",
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.\n+optional",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.\n+featureGate=CrossNamespaceVolumeDataSource\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.VolumeResourceRequirements": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceList"
+            }
+          ]
+        },
+        "requests": {
+          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceList"
+            }
+          ]
+        }
+      }
+    },
+    "v1.ResourceList": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/resource.Quantity"
+      }
+    },
+    "v1.LabelSelector": {
+      "type": "object",
+      "properties": {
+        "matchExpressions": {
+          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.LabelSelectorRequirement"
+          }
+        },
+        "matchLabels": {
+          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.\n+optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.LabelSelectorRequirement": {
+      "type": "object",
+      "required": [
+        "key",
+        "operator"
+      ],
+      "properties": {
+        "key": {
+          "description": "key is the label key that the selector applies to.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LabelSelectorOperator"
+            }
+          ]
+        },
+        "values": {
+          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.LabelSelectorOperator": {
+      "type": "string",
+      "enum": [
+        "In",
+        "NotIn",
+        "Exists",
+        "DoesNotExist"
+      ],
+      "x-enum-varnames": [
+        "LabelSelectorOpIn",
+        "LabelSelectorOpNotIn",
+        "LabelSelectorOpExists",
+        "LabelSelectorOpDoesNotExist"
+      ]
+    },
+    "v1.PersistentVolumeMode": {
+      "type": "string",
+      "enum": [
+        "Block",
+        "Filesystem"
+      ],
+      "x-enum-varnames": [
+        "PersistentVolumeBlock",
+        "PersistentVolumeFilesystem"
+      ]
+    },
+    "v1.FCVolumeSource": {
+      "type": "object",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
+          "type": "string"
+        },
+        "lun": {
+          "description": "lun is Optional: FC target lun number\n+optional",
+          "type": "integer"
+        },
+        "readOnly": {
+          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
+          "type": "boolean"
+        },
+        "targetWWNs": {
+          "description": "targetWWNs is Optional: FC target worldwide names (WWNs)\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "wwids": {
+          "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.FlexVolumeSource": {
+      "type": "object",
+      "required": [
+        "driver"
+      ],
+      "properties": {
+        "driver": {
+          "description": "driver is the name of the driver to use for this volume.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.\n+optional",
+          "type": "string"
+        },
+        "options": {
+          "description": "options is Optional: this field holds extra command options if any.\n+optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "readOnly": {
+          "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        }
+      }
+    },
+    "v1.FlockerVolumeSource": {
+      "type": "object",
+      "properties": {
+        "datasetName": {
+          "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated\n+optional",
+          "type": "string"
+        },
+        "datasetUUID": {
+          "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.GCEPersistentDiskVolumeSource": {
+      "type": "object",
+      "required": [
+        "pdName"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
+          "type": "string"
+        },
+        "partition": {
+          "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\n+optional",
+          "type": "integer"
+        },
+        "pdName": {
+          "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.GitRepoVolumeSource": {
+      "type": "object",
+      "required": [
+        "repository"
+      ],
+      "properties": {
+        "directory": {
+          "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.\n+optional",
+          "type": "string"
+        },
+        "repository": {
+          "description": "repository is the URL",
+          "type": "string"
+        },
+        "revision": {
+          "description": "revision is the commit hash for the specified revision.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.GlusterfsVolumeSource": {
+      "type": "object",
+      "required": [
+        "endpoints",
+        "path"
+      ],
+      "properties": {
+        "endpoints": {
+          "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "path": {
+          "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.HostPathVolumeSource": {
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": "string"
+        },
+        "type": {
+          "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.HostPathType"
+            }
+          ]
+        }
+      }
+    },
+    "v1.HostPathType": {
+      "type": "string",
+      "enum": [
+        "",
+        "DirectoryOrCreate",
+        "Directory",
+        "FileOrCreate",
+        "File",
+        "Socket",
+        "CharDevice",
+        "BlockDevice"
+      ],
+      "x-enum-varnames": [
+        "HostPathUnset",
+        "HostPathDirectoryOrCreate",
+        "HostPathDirectory",
+        "HostPathFileOrCreate",
+        "HostPathFile",
+        "HostPathSocket",
+        "HostPathCharDev",
+        "HostPathBlockDev"
+      ]
+    },
+    "v1.ImageVolumeSource": {
+      "type": "object",
+      "properties": {
+        "pullPolicy": {
+          "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PullPolicy"
+            }
+          ]
+        },
+        "reference": {
+          "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.PullPolicy": {
+      "type": "string",
+      "enum": [
+        "Always",
+        "Never",
+        "IfNotPresent"
+      ],
+      "x-enum-varnames": [
+        "PullAlways",
+        "PullNever",
+        "PullIfNotPresent"
+      ]
+    },
+    "v1.ISCSIVolumeSource": {
+      "type": "object",
+      "required": [
+        "iqn",
+        "lun",
+        "targetPortal"
+      ],
+      "properties": {
+        "chapAuthDiscovery": {
+          "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication\n+optional",
+          "type": "boolean"
+        },
+        "chapAuthSession": {
+          "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication\n+optional",
+          "type": "boolean"
+        },
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
+          "type": "string"
+        },
+        "initiatorName": {
+          "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.\n+optional",
+          "type": "string"
+        },
+        "iqn": {
+          "description": "iqn is the target iSCSI Qualified Name.",
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).\n+optional\n+default=\"default\"",
+          "type": "string"
+        },
+        "lun": {
+          "description": "lun represents iSCSI Target Lun number.",
+          "type": "integer"
+        },
+        "portals": {
+          "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\n+optional",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "targetPortal": {
+          "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+          "type": "string"
+        }
+      }
+    },
+    "v1.NFSVolumeSource": {
+      "type": "object",
+      "required": [
+        "path",
+        "server"
+      ],
+      "properties": {
+        "path": {
+          "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs\n+optional",
+          "type": "boolean"
+        },
+        "server": {
+          "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        }
+      }
+    },
+    "v1.PersistentVolumeClaimVolumeSource": {
+      "type": "object",
+      "required": [
+        "claimName"
+      ],
+      "properties": {
+        "claimName": {
+          "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.PhotonPersistentDiskVolumeSource": {
+      "type": "object",
+      "required": [
+        "pdID"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "pdID": {
+          "description": "pdID is the ID that identifies Photon Controller persistent disk",
+          "type": "string"
+        }
+      }
+    },
+    "v1.PortworxVolumeSource": {
+      "type": "object",
+      "required": [
+        "volumeID"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
+          "type": "boolean"
+        },
+        "volumeID": {
+          "description": "volumeID uniquely identifies a Portworx volume",
+          "type": "string"
+        }
+      }
+    },
+    "v1.ProjectedVolumeSource": {
+      "type": "object",
+      "required": [
+        "sources"
+      ],
+      "properties": {
+        "defaultMode": {
+          "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
+          "type": "integer"
+        },
+        "sources": {
+          "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.VolumeProjection"
+          }
+        }
+      }
+    },
+    "v1.VolumeProjection": {
+      "type": "object",
+      "properties": {
+        "clusterTrustBundle": {
+          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.\n\n+featureGate=ClusterTrustBundleProjection\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ClusterTrustBundleProjection"
+            }
+          ]
+        },
+        "configMap": {
+          "description": "configMap information about the configMap data to project\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ConfigMapProjection"
+            }
+          ]
+        },
+        "downwardAPI": {
+          "description": "downwardAPI information about the downwardAPI data to project\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.DownwardAPIProjection"
+            }
+          ]
+        },
+        "secret": {
+          "description": "secret information about the secret data to project\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SecretProjection"
+            }
+          ]
+        },
+        "serviceAccountToken": {
+          "description": "serviceAccountToken is information about the serviceAccountToken data to project\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ServiceAccountTokenProjection"
+            }
+          ]
+        }
+      }
+    },
+    "v1.ClusterTrustBundleProjection": {
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "labelSelector": {
+          "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LabelSelector"
+            }
+          ]
+        },
+        "name": {
+          "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.\n+optional",
+          "type": "string"
+        },
+        "optional": {
+          "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.\n+optional",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "Relative path from the volume root to write the bundle.",
+          "type": "string"
+        },
+        "signerName": {
+          "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.ConfigMapProjection": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.KeyToPath"
+          }
+        },
+        "name": {
+          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional\n+default=\"\"\n+kubebuilder:default=\"\"\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "optional specify whether the ConfigMap or its keys must be defined\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.DownwardAPIProjection": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "Items is a list of DownwardAPIVolume file\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.DownwardAPIVolumeFile"
+          }
+        }
+      }
+    },
+    "v1.SecretProjection": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.KeyToPath"
+          }
+        },
+        "name": {
+          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional\n+default=\"\"\n+kubebuilder:default=\"\"\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "optional field specify whether the Secret or its key must be defined\n+optional",
+          "type": "boolean"
+        }
+      }
+    },
+    "v1.ServiceAccountTokenProjection": {
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "audience": {
+          "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.\n+optional",
+          "type": "string"
+        },
+        "expirationSeconds": {
+          "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.\n+optional",
+          "type": "integer"
+        },
+        "path": {
+          "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.QuobyteVolumeSource": {
+      "type": "object",
+      "required": [
+        "registry",
+        "volume"
+      ],
+      "properties": {
+        "group": {
+          "description": "group to map volume access to\nDefault is no group\n+optional",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.\n+optional",
+          "type": "boolean"
+        },
+        "registry": {
+          "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin\n+optional",
+          "type": "string"
+        },
+        "user": {
+          "description": "user to map volume access to\nDefaults to serivceaccount user\n+optional",
+          "type": "string"
+        },
+        "volume": {
+          "description": "volume is a string that references an already created Quobyte volume by name.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.RBDVolumeSource": {
+      "type": "object",
+      "required": [
+        "image",
+        "monitors"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine\n+optional",
+          "type": "string"
+        },
+        "image": {
+          "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "keyring": {
+          "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it\n+optional\n+default=\"/etc/ceph/keyring\"",
+          "type": "string"
+        },
+        "monitors": {
+          "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pool": {
+          "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it\n+optional\n+default=\"rbd\"",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it\n+optional",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "user": {
+          "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it\n+optional\n+default=\"admin\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1.ScaleIOVolumeSource": {
+      "type": "object",
+      "required": [
+        "gateway",
+        "secretRef",
+        "system"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".\n+optional\n+default=\"xfs\"",
+          "type": "string"
+        },
+        "gateway": {
+          "description": "gateway is the host address of the ScaleIO API Gateway.",
+          "type": "string"
+        },
+        "protectionDomain": {
+          "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.\n+optional",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "sslEnabled": {
+          "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false\n+optional",
+          "type": "boolean"
+        },
+        "storageMode": {
+          "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.\n+optional\n+default=\"ThinProvisioned\"",
+          "type": "string"
+        },
+        "storagePool": {
+          "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.\n+optional",
+          "type": "string"
+        },
+        "system": {
+          "description": "system is the name of the storage system as configured in ScaleIO.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.SecretVolumeSource": {
+      "type": "object",
+      "properties": {
+        "defaultMode": {
+          "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.\n+optional",
+          "type": "integer"
+        },
+        "items": {
+          "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.KeyToPath"
+          }
+        },
+        "optional": {
+          "description": "optional field specify whether the Secret or its keys must be defined\n+optional",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.StorageOSVolumeSource": {
+      "type": "object",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\n+optional",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\n+optional",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LocalObjectReference"
+            }
+          ]
+        },
+        "volumeName": {
+          "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+          "type": "string"
+        },
+        "volumeNamespace": {
+          "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.VsphereVirtualDiskVolumeSource": {
+      "type": "object",
+      "required": [
+        "volumePath"
+      ],
+      "properties": {
+        "fsType": {
+          "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\n+optional",
+          "type": "string"
+        },
+        "storagePolicyID": {
+          "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.\n+optional",
+          "type": "string"
+        },
+        "storagePolicyName": {
+          "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.\n+optional",
+          "type": "string"
+        },
+        "volumePath": {
+          "description": "volumePath is the path that identifies vSphere volume vmdk",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindPodOptions": {
+      "type": "object",
+      "required": [
+        "imageConfig",
+        "podConfig"
+      ],
+      "properties": {
+        "imageConfig": {
+          "description": "imageConfig options",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.ImageConfig"
+            }
+          ]
+        },
+        "podConfig": {
+          "description": "podConfig options",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.PodConfig"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.ImageConfig": {
+      "type": "object",
+      "required": [
+        "spawner",
+        "values"
+      ],
+      "properties": {
+        "spawner": {
+          "description": "spawner ui configs",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.OptionsSpawnerConfig"
+            }
+          ]
+        },
+        "values": {
+          "description": "the list of image configs that are available\n+kubebuilder:validation:MinItems:=1\n+listType:=\"map\"\n+listMapKey:=\"id\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1beta1.ImageConfigValue"
+          }
+        }
+      }
+    },
+    "v1beta1.OptionsSpawnerConfig": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "properties": {
+        "default": {
+          "description": "the id of the default option\n - this will be selected by default in the spawner ui\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example=\"jupyterlab_scipy_190\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.ImageConfigValue": {
+      "type": "object",
+      "required": [
+        "id",
+        "spawner",
+        "spec"
+      ],
+      "properties": {
+        "id": {
+          "description": "the id of this image config\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example:=\"jupyterlab_scipy_190\"",
+          "type": "string"
+        },
+        "redirect": {
+          "description": "redirect configs\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.OptionRedirect"
+            }
+          ]
+        },
+        "spawner": {
+          "description": "information for the spawner ui",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.OptionSpawnerInfo"
+            }
+          ]
+        },
+        "spec": {
+          "description": "the spec of the image config",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.ImageConfigSpec"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.OptionRedirect": {
+      "type": "object",
+      "required": [
+        "to"
+      ],
+      "properties": {
+        "message": {
+          "description": "information about the redirect\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.RedirectMessage"
+            }
+          ]
+        },
+        "to": {
+          "description": "the id of the option to redirect to\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example:=\"jupyterlab_scipy_190\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.RedirectMessage": {
+      "type": "object",
+      "required": [
+        "level",
+        "text"
+      ],
+      "properties": {
+        "level": {
+          "description": "the importance level of the message\n+kubebuilder:example:=\"Info\"",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.RedirectMessageLevel"
+            }
+          ]
+        },
+        "text": {
+          "description": "the text of the message to show\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=1024\n+kubebuilder:example:=\"This update will increase the version of JupyterLab to v1.7.1\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.RedirectMessageLevel": {
+      "type": "string",
+      "enum": [
+        "Info",
+        "Warning",
+        "Danger"
+      ],
+      "x-enum-varnames": [
+        "RedirectMessageLevelInfo",
+        "RedirectMessageLevelWarning",
+        "RedirectMessageLevelDanger"
+      ]
+    },
+    "v1beta1.OptionSpawnerInfo": {
+      "type": "object",
+      "required": [
+        "displayName"
+      ],
+      "properties": {
+        "description": {
+          "description": "a description of the option\n+kubebuilder:validation:Optional\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=1024",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "the display name of the option\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=128",
+          "type": "string"
+        },
+        "hidden": {
+          "description": "if this option should be hidden from the Workspace Spawner UI\n+kubebuilder:validation:Optional\n+kubebuilder:default:=false",
+          "type": "boolean"
+        },
+        "labels": {
+          "description": "labels for the option\n+kubebuilder:validation:Optional\n+kubebuilder:validation:MaxItems:=32\n+listType:=\"map\"\n+listMapKey:=\"key\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1beta1.OptionSpawnerLabel"
+          }
+        }
+      }
+    },
+    "v1beta1.OptionSpawnerLabel": {
+      "type": "object",
+      "required": [
+        "key",
+        "value"
+      ],
+      "properties": {
+        "key": {
+          "description": "the key of the label\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=64",
+          "type": "string"
+        },
+        "value": {
+          "description": "the value of the label\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=64",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.ImageConfigSpec": {
+      "type": "object",
+      "required": [
+        "image",
+        "imagePullPolicy",
+        "ports"
+      ],
+      "properties": {
+        "image": {
+          "description": "the container image to use\n+kubebuilder:validation:MinLength:=2\n+kubeflow:example=\"ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.7.0\"",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "the pull policy for the container image\n+kubebuilder:validation:Optional\n+kubebuilder:default:=\"IfNotPresent\"\n+kubebuilder:validation:Enum:={\"Always\",\"IfNotPresent\",\"Never\"}",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PullPolicy"
+            }
+          ]
+        },
+        "ports": {
+          "description": "ports that the container listens on\n  - if multiple ports are defined, the user will see multiple \"Connect\" buttons\n    in a dropdown menu on the Workspace overview page\n+kubebuilder:validation:MinItems:=1\n+listType:=\"map\"\n+listMapKey:=\"id\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1beta1.ImagePort"
+          }
+        }
+      }
+    },
+    "v1beta1.ImagePort": {
+      "type": "object",
+      "required": [
+        "id",
+        "port"
+      ],
+      "properties": {
+        "displayName": {
+          "description": "the display name of the port\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=64\n+kubebuilder:validation:Optional",
+          "type": "string"
+        },
+        "id": {
+          "description": "the id of the port\n - this is NOT used as the Container or Service port name, but as part of the HTTP path\n+kubebuilder:example=\"jupyterlab\"",
+          "type": "string"
+        },
+        "port": {
+          "description": "the port number\n+kubebuilder:validation:Minimum:=1\n+kubebuilder:validation:Maximum:=65535\n+kubebuilder:example:=8888",
+          "type": "integer"
+        }
+      }
+    },
+    "v1beta1.PodConfig": {
+      "type": "object",
+      "required": [
+        "spawner",
+        "values"
+      ],
+      "properties": {
+        "spawner": {
+          "description": "spawner ui configs",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.OptionsSpawnerConfig"
+            }
+          ]
+        },
+        "values": {
+          "description": "the list of pod configs that are available\n+kubebuilder:validation:MinItems:=1\n+listType:=\"map\"\n+listMapKey:=\"id\"",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1beta1.PodConfigValue"
+          }
+        }
+      }
+    },
+    "v1beta1.PodConfigValue": {
+      "type": "object",
+      "required": [
+        "id",
+        "spawner",
+        "spec"
+      ],
+      "properties": {
+        "id": {
+          "description": "the id of this pod config\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example=\"big_gpu\"",
+          "type": "string"
+        },
+        "redirect": {
+          "description": "redirect configs\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.OptionRedirect"
+            }
+          ]
+        },
+        "spawner": {
+          "description": "information for the spawner ui",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.OptionSpawnerInfo"
+            }
+          ]
+        },
+        "spec": {
+          "description": "the spec of the pod config",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.PodConfigSpec"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.PodConfigSpec": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "description": "affinity configs for the pod\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.Affinity"
+            }
+          ]
+        },
+        "nodeSelector": {
+          "description": "node selector configs for the pod\n+kubebuilder:validation:Optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "description": "resource configs for the \"main\" container in the pod\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceRequirements"
+            }
+          ]
+        },
+        "tolerations": {
+          "description": "toleration configs for the pod\n+kubebuilder:validation:Optional",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.Toleration"
+          }
+        }
+      }
+    },
+    "v1.Affinity": {
+      "type": "object",
+      "properties": {
+        "nodeAffinity": {
+          "description": "Describes node affinity scheduling rules for the pod.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.NodeAffinity"
+            }
+          ]
+        },
+        "podAffinity": {
+          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PodAffinity"
+            }
+          ]
+        },
+        "podAntiAffinity": {
+          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PodAntiAffinity"
+            }
+          ]
+        }
+      }
+    },
+    "v1.NodeAffinity": {
+      "type": "object",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.PreferredSchedulingTerm"
+          }
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.NodeSelector"
+            }
+          ]
+        }
+      }
+    },
+    "v1.PreferredSchedulingTerm": {
+      "type": "object",
+      "required": [
+        "preference",
+        "weight"
+      ],
+      "properties": {
+        "preference": {
+          "description": "A node selector term, associated with the corresponding weight.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.NodeSelectorTerm"
+            }
+          ]
+        },
+        "weight": {
+          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+          "type": "integer"
+        }
+      }
+    },
+    "v1.NodeSelectorTerm": {
+      "type": "object",
+      "properties": {
+        "matchExpressions": {
+          "description": "A list of node selector requirements by node's labels.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.NodeSelectorRequirement"
+          }
+        },
+        "matchFields": {
+          "description": "A list of node selector requirements by node's fields.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.NodeSelectorRequirement"
+          }
+        }
+      }
+    },
+    "v1.NodeSelectorRequirement": {
+      "type": "object",
+      "required": [
+        "key",
+        "operator"
+      ],
+      "properties": {
+        "key": {
+          "description": "The label key that the selector applies to.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.NodeSelectorOperator"
+            }
+          ]
+        },
+        "values": {
+          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.NodeSelectorOperator": {
+      "type": "string",
+      "enum": [
+        "In",
+        "NotIn",
+        "Exists",
+        "DoesNotExist",
+        "Gt",
+        "Lt"
+      ],
+      "x-enum-varnames": [
+        "NodeSelectorOpIn",
+        "NodeSelectorOpNotIn",
+        "NodeSelectorOpExists",
+        "NodeSelectorOpDoesNotExist",
+        "NodeSelectorOpGt",
+        "NodeSelectorOpLt"
+      ]
+    },
+    "v1.NodeSelector": {
+      "type": "object",
+      "required": [
+        "nodeSelectorTerms"
+      ],
+      "properties": {
+        "nodeSelectorTerms": {
+          "description": "Required. A list of node selector terms. The terms are ORed.\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.NodeSelectorTerm"
+          }
+        }
+      }
+    },
+    "v1.PodAffinity": {
+      "type": "object",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.WeightedPodAffinityTerm"
+          }
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.PodAffinityTerm"
+          }
+        }
+      }
+    },
+    "v1.WeightedPodAffinityTerm": {
+      "type": "object",
+      "required": [
+        "podAffinityTerm",
+        "weight"
+      ],
+      "properties": {
+        "podAffinityTerm": {
+          "description": "Required. A pod affinity term, associated with the corresponding weight.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PodAffinityTerm"
+            }
+          ]
+        },
+        "weight": {
+          "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+          "type": "integer"
+        }
+      }
+    },
+    "v1.PodAffinityTerm": {
+      "type": "object",
+      "required": [
+        "topologyKey"
+      ],
+      "properties": {
+        "labelSelector": {
+          "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LabelSelector"
+            }
+          ]
+        },
+        "matchLabelKeys": {
+          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).\n\n+listType=atomic\n+optional",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mismatchLabelKeys": {
+          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).\n\n+listType=atomic\n+optional",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "namespaceSelector": {
+          "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.LabelSelector"
+            }
+          ]
+        },
+        "namespaces": {
+          "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topologyKey": {
+          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+          "type": "string"
+        }
+      }
+    },
+    "v1.PodAntiAffinity": {
+      "type": "object",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.WeightedPodAffinityTerm"
+          }
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.PodAffinityTerm"
+          }
+        }
+      }
+    },
+    "v1.ResourceRequirements": {
+      "type": "object",
+      "properties": {
+        "claims": {
+          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.\n\n+listType=map\n+listMapKey=name\n+featureGate=DynamicResourceAllocation\n+optional",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.ResourceClaim"
+          }
+        },
+        "limits": {
+          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceList"
+            }
+          ]
+        },
+        "requests": {
+          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ResourceList"
+            }
+          ]
+        }
+      }
+    },
+    "v1.ResourceClaim": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+          "type": "string"
+        },
+        "request": {
+          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.\n\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.Toleration": {
+      "type": "object",
+      "properties": {
+        "effect": {
+          "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.TaintEffect"
+            }
+          ]
+        },
+        "key": {
+          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.\n+optional",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.TolerationOperator"
+            }
+          ]
+        },
+        "tolerationSeconds": {
+          "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.\n+optional",
+          "type": "integer"
+        },
+        "value": {
+          "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.\n+optional",
+          "type": "string"
+        }
+      }
+    },
+    "v1.TaintEffect": {
+      "type": "string",
+      "enum": [
+        "NoSchedule",
+        "PreferNoSchedule",
+        "NoExecute"
+      ],
+      "x-enum-varnames": [
+        "TaintEffectNoSchedule",
+        "TaintEffectPreferNoSchedule",
+        "TaintEffectNoExecute"
+      ]
+    },
+    "v1.TolerationOperator": {
+      "type": "string",
+      "enum": [
+        "Exists",
+        "Equal"
+      ],
+      "x-enum-varnames": [
+        "TolerationOpExists",
+        "TolerationOpEqual"
+      ]
+    },
+    "v1beta1.WorkspaceKindPodMetadata": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "annotations to be applied to the Pod resource\n+kubebuilder:validation:Optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "labels": {
+          "description": "labels to be applied to the Pod resource\n+kubebuilder:validation:Optional",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindPort": {
+      "type": "object",
+      "required": [
+        "defaultDisplayName",
+        "id",
+        "protocol"
+      ],
+      "properties": {
+        "defaultDisplayName": {
+          "description": "the default display name of the port\n- note, this can be overridden on a per image config value basis\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=64\n+kubebuilder:example:=\"JupyterLab\"",
+          "type": "string"
+        },
+        "httpProxy": {
+          "description": "the http proxy config for the port (MUTABLE)\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.HTTPProxy"
+            }
+          ]
+        },
+        "id": {
+          "description": "the id of the port\n- identifier for the port in `imageconfig` ports.[].id\n+kubebuilder:example=\"jupyterlab\"",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "the protocol of the port\n+kubebuilder:example:=\"HTTP\"",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.ImagePortProtocol"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.HTTPProxy": {
+      "type": "object",
+      "properties": {
+        "removePathPrefix": {
+          "description": "if the path prefix is stripped from incoming HTTP requests\n - if true, the '/workspace/connect/{profile_name}/{workspace_name}/' path prefix\n   is stripped from incoming requests, the application sees the request\n   as if it was made to '/...'\n - this only works if the application serves RELATIVE URLs for its assets\n+kubebuilder:validation:Optional\n+kubebuilder:default:=false",
+          "type": "boolean"
+        },
+        "requestHeaders": {
+          "description": "header manipulation rules for incoming HTTP requests\n - sets the `spec.http[].headers.request` of the Istio VirtualService\n   https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.IstioHeaderOperations"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.IstioHeaderOperations": {
+      "type": "object",
+      "properties": {
+        "add": {
+          "description": "append the given values to the headers specified by keys (will create a comma-separated list of values)\n - the following go template functions are available in the values:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"My-Header\": \"value-to-append\" }",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "remove": {
+          "description": "remove the specified headers\n+kubebuilder:validation:Optional\n+kubebuilder:example:={\"Header-To-Remove\"}",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "set": {
+          "description": "overwrite the headers specified by key with the given values\n - the following go template functions are available in the values:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"X-RStudio-Root-Path\": \"{{ httpPathPrefix 'rstudio' }}\" }",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1beta1.ImagePortProtocol": {
+      "type": "string",
+      "enum": [
+        "HTTP"
+      ],
+      "x-enum-varnames": [
+        "ImagePortProtocolHTTP"
+      ]
+    },
+    "v1beta1.WorkspaceKindProbes": {
+      "type": "object",
+      "properties": {
+        "livenessProbe": {
+          "description": "the liveness probe for the main container\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.Probe"
+            }
+          ]
+        },
+        "readinessProbe": {
+          "description": "the readiness probe for the main container\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.Probe"
+            }
+          ]
+        },
+        "startupProbe": {
+          "description": "the startup probe for the main container\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.Probe"
+            }
+          ]
+        }
+      }
+    },
+    "v1.Probe": {
+      "type": "object",
+      "properties": {
+        "exec": {
+          "description": "Exec specifies the action to take.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.ExecAction"
+            }
+          ]
+        },
+        "failureThreshold": {
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.\n+optional",
+          "type": "integer"
+        },
+        "grpc": {
+          "description": "GRPC specifies an action involving a GRPC port.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.GRPCAction"
+            }
+          ]
+        },
+        "httpGet": {
+          "description": "HTTPGet specifies the http request to perform.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.HTTPGetAction"
+            }
+          ]
+        },
+        "initialDelaySeconds": {
+          "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n+optional",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.\n+optional",
+          "type": "integer"
+        },
+        "successThreshold": {
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.\n+optional",
+          "type": "integer"
+        },
+        "tcpSocket": {
+          "description": "TCPSocket specifies an action involving a TCP port.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.TCPSocketAction"
+            }
+          ]
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.\n+optional",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n+optional",
+          "type": "integer"
+        }
+      }
+    },
+    "v1.ExecAction": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1.GRPCAction": {
+      "type": "object",
+      "required": [
+        "port",
+        "service"
+      ],
+      "properties": {
+        "port": {
+          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+          "type": "integer"
+        },
+        "service": {
+          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.\n+optional\n+default=\"\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1.HTTPGetAction": {
+      "type": "object",
+      "required": [
+        "port"
+      ],
+      "properties": {
+        "host": {
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.\n+optional",
+          "type": "string"
+        },
+        "httpHeaders": {
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.HTTPHeader"
+          }
+        },
+        "path": {
+          "description": "Path to access on the HTTP server.\n+optional",
+          "type": "string"
+        },
+        "port": {
+          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/intstr.IntOrString"
+            }
+          ]
+        },
+        "scheme": {
+          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.URIScheme"
+            }
+          ]
+        }
+      }
+    },
+    "v1.HTTPHeader": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The header field value",
+          "type": "string"
+        }
+      }
+    },
+    "intstr.IntOrString": {
+      "type": "object",
+      "required": [
+        "intVal",
+        "strVal",
+        "type"
+      ],
+      "properties": {
+        "intVal": {
+          "type": "integer"
+        },
+        "strVal": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/$defs/intstr.Type"
+        }
+      }
+    },
+    "intstr.Type": {
+      "type": "integer",
+      "format": "int64",
+      "enum": [
+        0,
+        1
+      ],
+      "x-enum-comments": {
+        "Int": "The IntOrString holds an int.",
+        "String": "The IntOrString holds a string."
+      },
+      "x-enum-descriptions": [
+        "The IntOrString holds an int.",
+        "The IntOrString holds a string."
+      ],
+      "x-enum-varnames": [
+        "Int",
+        "String"
+      ]
+    },
+    "v1.URIScheme": {
+      "type": "string",
+      "enum": [
+        "HTTP",
+        "HTTPS"
+      ],
+      "x-enum-varnames": [
+        "URISchemeHTTP",
+        "URISchemeHTTPS"
+      ]
+    },
+    "v1.TCPSocketAction": {
+      "type": "object",
+      "required": [
+        "port"
+      ],
+      "properties": {
+        "host": {
+          "description": "Optional: Host name to connect to, defaults to the pod IP.\n+optional",
+          "type": "string"
+        },
+        "port": {
+          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/intstr.IntOrString"
+            }
+          ]
+        }
+      }
+    },
+    "v1.PodSecurityContext": {
+      "type": "object",
+      "properties": {
+        "appArmorProfile": {
+          "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.AppArmorProfile"
+            }
+          ]
+        },
+        "fsGroup": {
+          "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.PodFSGroupChangePolicy"
+            }
+          ]
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\n+optional",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SELinuxOptions"
+            }
+          ]
+        },
+        "seccompProfile": {
+          "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SeccompProfile"
+            }
+          ]
+        },
+        "supplementalGroups": {
+          "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "supplementalGroupsPolicy": {
+          "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.\nTODO: update the default value to \"Merge\" when spec.os.name is not windows in v1.34\n+featureGate=SupplementalGroupsPolicy\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.SupplementalGroupsPolicy"
+            }
+          ]
+        },
+        "sysctls": {
+          "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.\n+optional\n+listType=atomic",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/v1.Sysctl"
+          }
+        },
+        "windowsOptions": {
+          "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.\n+optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1.WindowsSecurityContextOptions"
+            }
+          ]
+        }
+      }
+    },
+    "v1.PodFSGroupChangePolicy": {
+      "type": "string",
+      "enum": [
+        "OnRootMismatch",
+        "Always"
+      ],
+      "x-enum-varnames": [
+        "FSGroupChangeOnRootMismatch",
+        "FSGroupChangeAlways"
+      ]
+    },
+    "v1.SupplementalGroupsPolicy": {
+      "type": "string",
+      "enum": [
+        "Merge",
+        "Strict"
+      ],
+      "x-enum-varnames": [
+        "SupplementalGroupsPolicyMerge",
+        "SupplementalGroupsPolicyStrict"
+      ]
+    },
+    "v1.Sysctl": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of a property to set",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of a property to set",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindServiceAccount": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "the name of the ServiceAccount (NOT MUTABLE)\n - this Service Account MUST already exist in the Namespace\n   of the Workspace, the controller will NOT create it\n - we will not show this WorkspaceKind in the Spawner UI\n   if the SA does not exist in the Namespace\n+kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"ServiceAccount 'name' is immutable\"\n+kubebuilder:example=\"default-editor\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindVolumeMounts": {
+      "type": "object",
+      "required": [
+        "home"
+      ],
+      "properties": {
+        "home": {
+          "description": "the path to mount the home PVC (NOT MUTABLE)\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=4096\n+kubebuilder:validation:Pattern:=^/[^/].*$\n+kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"mount path of 'home' is immutable\"\n+kubebuilder:example:=\"/home/jovyan\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindSpawner": {
+      "type": "object",
+      "required": [
+        "description",
+        "displayName",
+        "icon",
+        "logo"
+      ],
+      "properties": {
+        "deprecated": {
+          "description": "if this WorkspaceKind is deprecated\n+kubebuilder:validation:Optional\n+kubebuilder:default:=false",
+          "type": "boolean"
+        },
+        "deprecationMessage": {
+          "description": "a message to show in Workspace Spawner UI when the WorkspaceKind is deprecated\n+kubebuilder:validation:Optional\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=256\n+kubebuilder:example:=\"This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind.\"",
+          "type": "string"
+        },
+        "description": {
+          "description": "the description of the WorkspaceKind\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=4096\n+kubebuilder:example:=\"A Workspace which runs JupyterLab in a Pod\"",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "the display name of the WorkspaceKind\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=128\n+kubebuilder:example:=\"JupyterLab Notebook\"",
+          "type": "string"
+        },
+        "hidden": {
+          "description": "if this WorkspaceKind should be hidden from the Workspace Spawner UI\n+kubebuilder:validation:Optional\n+kubebuilder:default:=false",
+          "type": "boolean"
+        },
+        "icon": {
+          "description": "the icon of the WorkspaceKind\n - a small (favicon-sized) icon used in the Workspace Spawner UI",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindAsset"
+            }
+          ]
+        },
+        "logo": {
+          "description": "the logo of the WorkspaceKind\n - a 1:1 (card size) logo used in the Workspace Spawner UI",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindAsset"
+            }
+          ]
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindAsset": {
+      "type": "object",
+      "properties": {
+        "configMap": {
+          "description": "the ConfigMap reference for the asset\n+kubebuilder:validation:Optional",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindAssetConfigMap"
+            }
+          ]
+        },
+        "url": {
+          "description": "the URL of the asset\n+kubebuilder:validation:Optional\n+kubebuilder:example=\"https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindAssetConfigMap": {
+      "type": "object",
+      "required": [
+        "key",
+        "mediaType",
+        "name",
+        "namespace"
+      ],
+      "properties": {
+        "key": {
+          "description": "the key in the ConfigMap which contains the data\n+kubebuilder:example=\"jupyterlab-logo.svg\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[-._a-zA-Z0-9]+$",
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "the media type of the asset data in the ConfigMap\n+kubebuilder:example=\"image/svg+xml\"",
+          "allOf": [
+            {
+              "$ref": "#/$defs/v1beta1.WorkspaceKindAssetMediaType"
+            }
+          ]
+        },
+        "name": {
+          "description": "the name of the ConfigMap\n+kubebuilder:example=\"my-logos\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "the namespace of the ConfigMap\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=63\n+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\n+kubebuilder:example=\"kubeflow\"",
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.WorkspaceKindAssetMediaType": {
+      "type": "string",
+      "enum": [
+        "image/svg+xml"
+      ],
+      "x-enum-varnames": [
+        "WorkspaceKindAssetMediaTypeSVG"
+      ]
+    }
+  }
+}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/yamlEditor/workspaceKindUpdateSchema.json
@@ -39,7 +39,7 @@
           ]
         },
         "extraEnv": {
-          "description": "environment variables for Workspace Pods (MUTABLE)\n - the following go template functions are available:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"NB_PREFIX\": \"{{ httpPathPrefix 'jupyterlab' }}\" }\n+listType:=\"map\"\n+listMapKey:=\"name\"",
+          "description": "environment variables for Workspace Pods (MUTABLE)\n - the following go template functions are available:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+listType:=\"map\"\n+listMapKey:=\"name\"",
           "type": "array",
           "items": {
             "$ref": "#/$defs/v1.EnvVar"
@@ -2923,7 +2923,7 @@
           "type": "boolean"
         },
         "requestHeaders": {
-          "description": "header manipulation rules for incoming HTTP requests\n - sets the `spec.http[].headers.request` of the Istio VirtualService\n   https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations\n+kubebuilder:validation:Optional",
+          "description": "header manipulation rules for incoming HTTP requests\n - sets the `spec.http[].headers.request` of the Istio VirtualService\n   https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations\n - the following string templates are available:\n    - `.PathPrefix`: the path prefix of the Workspace (e.g. '/workspace/connect/{profile_name}/{workspace_name}/')\n+kubebuilder:validation:Optional",
           "allOf": [
             {
               "$ref": "#/$defs/v1beta1.IstioHeaderOperations"
@@ -2936,7 +2936,7 @@
       "type": "object",
       "properties": {
         "add": {
-          "description": "append the given values to the headers specified by keys (will create a comma-separated list of values)\n - the following go template functions are available in the values:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"My-Header\": \"value-to-append\" }",
+          "description": "append the given values to the headers specified by keys (will create a comma-separated list of values)\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"My-Header\": \"value-to-append\" }",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -2950,7 +2950,7 @@
           }
         },
         "set": {
-          "description": "overwrite the headers specified by key with the given values\n - the following go template functions are available in the values:\n    - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"X-RStudio-Root-Path\": \"{{ httpPathPrefix 'rstudio' }}\" }",
+          "description": "overwrite the headers specified by key with the given values\n+kubebuilder:validation:Optional\n+kubebuilder:example:={ \"X-RStudio-Root-Path\": \"{{ .PathPrefix }}\" }",
           "type": "object",
           "additionalProperties": {
             "type": "string"

--- a/workspaces/frontend/src/index.tsx
+++ b/workspaces/frontend/src/index.tsx
@@ -1,6 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
+import * as monaco from 'monaco-editor';
+import { loader } from '@monaco-editor/react';
+
+window.MonacoEnvironment = {
+  getWorker(_moduleId: string, label: string) {
+    if (label === 'yaml') {
+      return new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url));
+    }
+    return new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url));
+  },
+};
+
+loader.config({ monaco });
 import {
   BrowserStorageContextProvider,
   ModularArchConfig,


### PR DESCRIPTION
 closes: #1105

### YAML Editor
  - Add Form/YAML tab toggle on the edit page using PatternFly Tabs with proper TabContent for a11y compliance
  - New WorkspaceKindYamlEditor component wrapping @patternfly/react-code-editor with monaco-yaml for autocomplete, hover docs, and inline
  validation
  - JSON Schema extracted from backend/openapi/swagger.json provides type-aware suggestions for all WorkspaceKindUpdate fields including nested
  Kubernetes types

 ### Form→YAML Sync
  - Switching to the YAML tab generates YAML from the current form state
  - Switching back to the Form tab preserves form state independently (no lossy round-trip)
  - Preserve original spec fields for imageConfig/podConfig values during Form→Update conversion to prevent phantom changes on in-use configs

###  Revert Button
  - Add "Revert" button in the footer that resets both form and YAML state to the original API data

###  Monaco Setup
  - Configure @monaco-editor/react loader to use local monaco-editor package instead of CDN
  - Set up MonacoEnvironment.getWorker for the YAML worker at app entrypoint
  - Add monaco-editor to webpack CSS includes for dev and prod builds

###  Schema Generation
  - Add scripts/generate-schema.js to extract and bundle the JSON Schema from the Swagger spec
  - Integrate into scripts/generate-api.sh so the schema regenerates alongside the TypeScript API client