### PR TITLE
fix: strip path prefix in VirtualService when removePathPrefix is true

### DIFF
--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -992,10 +992,12 @@ func (r *WorkspaceReconciler) generateVirtualServiceHTTPRoute(
 	matchUriPrefix := getWorkspaceConnectPath(workspace.Namespace, workspace.Name, imageConfigPort.Id)
 
 	// determine rewrite configuration
+	//  - when removePathPrefix is true, rewrite the matched prefix to "/" so the
+	//    upstream receives the path with the connect prefix stripped
 	var httpRouteRewrite *networkingv1.HTTPRewrite
-	if podTemplatePort.HTTPProxy != nil && !ptr.Deref(podTemplatePort.HTTPProxy.RemovePathPrefix, false) {
+	if podTemplatePort.HTTPProxy != nil && ptr.Deref(podTemplatePort.HTTPProxy.RemovePathPrefix, false) {
 		httpRouteRewrite = &networkingv1.HTTPRewrite{
-			Uri: matchUriPrefix,
+			Uri: "/",
 		}
 	}
 

--- a/workspaces/controller/internal/controller/workspace_controller_test.go
+++ b/workspaces/controller/internal/controller/workspace_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	"github.com/kubeflow/notebooks/workspaces/controller/internal/config"
 )
 
 var _ = Describe("Workspace Controller", func() {
@@ -220,6 +221,111 @@ var _ = Describe("Workspace Controller", func() {
 			//        - invalid WorkspaceKind (with bad option redirect - circular / missing) results in error state
 			//        - multiple owned StatefulSets / Services results in error state
 			//
+		})
+	})
+
+	Context("When generating a VirtualService for a Workspace", func() {
+
+		// Define utility variables for object names.
+		// NOTE: to avoid conflicts between parallel tests, resource names are unique to each test
+		var (
+			workspaceName     string
+			workspaceKindName string
+		)
+
+		// NOTE: these tests call the generate functions directly and do not create any
+		//       resources in the cluster, so no teardown is required.
+		// TODO: once Istio CRDs are installed in EnvTest (`UseIstio: true` in suite_test.go),
+		//       add specs which ensure the VirtualService is actually created by the controller.
+		var (
+			reconciler      *WorkspaceReconciler
+			workspace       *kubefloworgv1beta1.Workspace
+			workspaceKind   *kubefloworgv1beta1.WorkspaceKind
+			service         *corev1.Service
+			imageConfigSpec kubefloworgv1beta1.ImageConfigSpec
+		)
+
+		BeforeEach(func() {
+			uniqueName := "ws-virtualservice-test"
+			workspaceName = fmt.Sprintf("workspace-%s", uniqueName)
+			workspaceKindName = fmt.Sprintf("workspacekind-%s", uniqueName)
+
+			reconciler = &WorkspaceReconciler{
+				Config: &config.EnvConfig{
+					ClusterDomain: "cluster.local",
+				},
+			}
+			workspaceKind = NewExampleWorkspaceKind1(workspaceKindName)
+			workspace = NewExampleWorkspace1(workspaceName, namespaceName, workspaceKindName)
+			service = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ws-%s", workspaceName),
+					Namespace: namespaceName,
+				},
+			}
+			imageConfigSpec = workspaceKind.Spec.PodTemplate.Options.ImageConfig.Values[0].Spec
+		})
+
+		It("should not rewrite the URI when `removePathPrefix` is false", func() {
+			By("generating the VirtualService")
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RemovePathPrefix = ptr.To(false)
+			virtualService, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the HTTP route has no rewrite")
+			Expect(virtualService.Spec.Http).To(HaveLen(1))
+			Expect(virtualService.Spec.Http[0].Rewrite).To(BeNil())
+		})
+
+		It("should rewrite the URI to '/' when `removePathPrefix` is true", func() {
+			By("generating the VirtualService")
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RemovePathPrefix = ptr.To(true)
+			virtualService, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the HTTP route rewrites the URI to '/'")
+			Expect(virtualService.Spec.Http).To(HaveLen(1))
+			Expect(virtualService.Spec.Http[0].Rewrite).NotTo(BeNil())
+			Expect(virtualService.Spec.Http[0].Rewrite.Uri).To(Equal("/"))
+		})
+
+		It("should not rewrite the URI when `httpProxy` is not set", func() {
+			By("generating the VirtualService")
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy = nil
+			virtualService, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the HTTP route has no rewrite")
+			Expect(virtualService.Spec.Http).To(HaveLen(1))
+			Expect(virtualService.Spec.Http[0].Rewrite).To(BeNil())
+		})
+
+		It("should render go templates in `requestHeaders` values", func() {
+			By("generating the VirtualService")
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RequestHeaders = &kubefloworgv1beta1.IstioHeaderOperations{
+				Set: map[string]string{
+					"X-RStudio-Root-Path": `{{ httpPathPrefix "jupyterlab" }}`,
+				},
+			}
+			virtualService, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the rendered header value")
+			Expect(virtualService.Spec.Http).To(HaveLen(1))
+			Expect(virtualService.Spec.Http[0].Headers.Request.Set).To(HaveKeyWithValue(
+				"X-RStudio-Root-Path", getWorkspaceConnectPath(workspace.Namespace, workspace.Name, "jupyterlab"),
+			))
+		})
+
+		It("should fail to generate when a `requestHeaders` value has an invalid go template", func() {
+			By("generating the VirtualService")
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RequestHeaders = &kubefloworgv1beta1.IstioHeaderOperations{
+				Set: map[string]string{
+					"X-RStudio-Root-Path": `{{ httpPathPrefix 'jupyterlab' }}`,
+				},
+			}
+			_, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
The rewrite logic in `generateVirtualServiceHTTPRoute()` was accidentially inverted: When `removePathPrefix` was `true`, no rewrite was emitted, so Istio forwarded the full '/workspace/connect/{namespace}/{name}/{port_id}/' path to the upstream container unchanged.

Now a `rewrite: {uri: "/"}` is emitted when `removePathPrefix` is `true`, so the matched prefix is actually stripped. When `removePathPrefix` is false, no rewrite is needed at all, since Istio forwards the original URI by default (the previous rewrite of the matched prefix to itself was a no-op).

Fixes https://github.com/kubeflow/notebooks/issues/1172

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
