### PR TITLE
chore: bump frontend Node.js from 20 to 24 LTS

### DIFF
--- a/.github/workflows/ws-frontend-test.yml
+++ b/.github/workflows/ws-frontend-test.yml
@@ -32,16 +32,6 @@ jobs:
           node-version-file: workspaces/frontend/package.json
           cache-dependency-path: workspaces/frontend/package-lock.json
 
-      # TODO: Remove this once it is possible to specify a npm version for
-      # `actions/setup-node` or the node version that we're using is new enough
-      # to ship with npm >= 11
-      #
-      # https://github.com/actions/setup-node/issues/529#issuecomment-4179457319
-      - name: Upgrade npm
-        working-directory: workspaces/frontend
-        # npm pkg get engines.npm -> "^11.10.0"
-        run: npm install --global npm@$(npm pkg get engines.npm | tr --delete '"')
-
       - name: Install dependencies
         working-directory: workspaces/frontend
         run: npm ci

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -282,7 +282,7 @@ If you prefer to develop without Tilt, you can set up your environment to build 
 Before developing locally, ensure you have the following installed:
 
 - [Go](https://golang.org/doc/install) - v1.21.0 or later (for controller and backend)
-- [Node.js](https://nodejs.org/) - v20.0.0 or later (for frontend)
+- [Node.js](https://nodejs.org/) - v24.0.0 or later (for frontend)
 
 ### Local - Quick Start
 

--- a/workspaces/frontend/Dockerfile
+++ b/workspaces/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # ---------- Builder stage ----------
-FROM --platform=$BUILDPLATFORM node:20-slim AS builder
+FROM --platform=$BUILDPLATFORM node:24-slim AS builder
 
 # Set working directory
 WORKDIR /usr/src/app

--- a/workspaces/frontend/Dockerfile.dev
+++ b/workspaces/frontend/Dockerfile.dev
@@ -7,7 +7,7 @@
 # Environment is configured via DEV_ENV=tilt which sets up appropriate
 # defaults for development. Container-specific overrides are set below.
 
-FROM node:20-slim
+FROM node:24-slim
 
 # Create app directory with correct ownership, then switch to non-root user
 RUN mkdir /app && chown 1000:1000 /app

--- a/workspaces/frontend/README.md
+++ b/workspaces/frontend/README.md
@@ -13,8 +13,8 @@ The Kubeflow Workspaces Frontend is the web user interface used to monitor and m
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `20.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `24.0.0`
+  - NPM recommended version -> `11.10.0`
 
 ## Development
 

--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -99,7 +99,7 @@
         "webpack-merge": "^6.0.1"
       },
       "engines": {
-        "node": "^20",
+        "node": "^24",
         "npm": "^11.10.0"
       },
       "optionalDependencies": {

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -17,7 +17,7 @@
   },
   "engines": {
     "npm": "^11.10.0",
-    "node": "^20"
+    "node": "^24"
   },
   "scripts": {
     "build": "run-s build:prod",


### PR DESCRIPTION
Node 24 entered LTS in October 2025 and ships with a new enough npm
that the manual upgrade step in CI is no longer needed.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
