### PR TITLE
feat: Implement Update Flow on Redirect Modal and Render Redirect Chains from Workspace Options

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
@@ -493,6 +493,10 @@ class StartModal {
     return this.find().findByTestId('start-button');
   }
 
+  findUpdateAndStartButton() {
+    return this.find().findByTestId('update-and-start-button');
+  }
+
   findCancelButton() {
     return this.find().findByTestId('cancel-button');
   }
@@ -521,6 +525,10 @@ class StopModal {
 
   findStopButton() {
     return this.find().findByTestId('stop-button');
+  }
+
+  findUpdateAndStopButton() {
+    return this.find().findByTestId('update-and-stop-button');
   }
 
   findCancelButton() {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceRedirects.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceRedirects.cy.ts
@@ -1,9 +1,14 @@
 import { mockModArchResponse } from 'mod-arch-core';
-import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
+import {
+  startModal,
+  stopModal,
+  workspaces,
+} from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
 import {
   buildMockNamespace,
   buildMockWorkspace,
   buildMockWorkspaceKindInfo,
+  buildMockWorkspaceUpdateFromWorkspace,
   buildMockPodTemplate,
   buildPodTemplateOptions,
   buildMockImageConfig,
@@ -550,6 +555,164 @@ describe('Workspace Redirects', () => {
       );
 
       workspaces.assertRedirectPopoverHasDividers(1);
+    });
+  });
+
+  describe('Update and Start/Stop Actions', () => {
+    const TEST_WORKSPACE_NAME = 'workspace-with-redirects';
+    const REDIRECT_TARGET_IMAGE_ID = 'jupyterlab_scipy_210';
+
+    const setupUpdateActionTest = (state: V1Beta1WorkspaceState) => {
+      const mockNamespace = buildMockNamespace({ name: DEFAULT_NAMESPACE });
+      const mockWorkspace = buildMockWorkspace({
+        name: TEST_WORKSPACE_NAME,
+        namespace: mockNamespace.name,
+        workspaceKind: buildMockWorkspaceKindInfo({ name: 'jupyterlab' }),
+        state,
+        pendingRestart: true,
+        podTemplate: buildMockPodTemplate({
+          options: buildPodTemplateOptions({
+            imageConfig: buildMockImageConfig({
+              current: buildMockOptionInfo({
+                id: 'jupyterlab_scipy_180',
+                displayName: 'jupyter-scipy:v1.8.0',
+              }),
+              redirectChain: buildImageRedirectChain({
+                startVersion: '1.8.0',
+                endVersion: '2.1.0',
+              }),
+            }),
+            podConfig: buildMockPodConfig({}),
+          }),
+        }),
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/namespaces',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([mockNamespace]),
+      ).as('getNamespaces');
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspaces/:namespace',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
+        mockModArchResponse([mockWorkspace]),
+      ).as('getWorkspaces');
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspaces/:namespace/:workspaceName',
+        {
+          path: {
+            apiVersion: NOTEBOOKS_API_VERSION,
+            namespace: mockNamespace.name,
+            workspaceName: TEST_WORKSPACE_NAME,
+          },
+        },
+        mockModArchResponse(buildMockWorkspaceUpdateFromWorkspace({ workspace: mockWorkspace })),
+      ).as('getWorkspace');
+
+      return { mockNamespace, mockWorkspace };
+    };
+
+    it('should update and start workspace with redirect targets', () => {
+      const { mockNamespace } = setupUpdateActionTest(V1Beta1WorkspaceState.WorkspaceStatePaused);
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspaces/:namespace/:workspaceName',
+        {
+          path: {
+            apiVersion: NOTEBOOKS_API_VERSION,
+            namespace: mockNamespace.name,
+            workspaceName: TEST_WORKSPACE_NAME,
+          },
+        },
+        mockModArchResponse(buildMockWorkspaceUpdateFromWorkspace({})),
+      ).as('updateWorkspace');
+
+      workspaces.visit();
+      cy.wait('@getNamespaces');
+      navBar.selectNamespace(mockNamespace.name);
+      cy.wait('@getWorkspaces');
+
+      workspaces.findAction({ action: 'start', workspaceName: TEST_WORKSPACE_NAME }).click();
+      startModal.findUpdateAndStartButton().click();
+
+      cy.wait('@getWorkspace');
+      cy.wait('@updateWorkspace').then((interception) => {
+        const { body } = interception.request;
+        expect(body.data.paused).to.equal(false);
+        expect(body.data.podTemplate.options.imageConfig).to.equal(REDIRECT_TARGET_IMAGE_ID);
+      });
+
+      startModal.assertModalNotExists();
+    });
+
+    it('should update and stop workspace with redirect targets', () => {
+      const { mockNamespace } = setupUpdateActionTest(V1Beta1WorkspaceState.WorkspaceStateRunning);
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspaces/:namespace/:workspaceName',
+        {
+          path: {
+            apiVersion: NOTEBOOKS_API_VERSION,
+            namespace: mockNamespace.name,
+            workspaceName: TEST_WORKSPACE_NAME,
+          },
+        },
+        mockModArchResponse(buildMockWorkspaceUpdateFromWorkspace({})),
+      ).as('updateWorkspace');
+
+      workspaces.visit();
+      cy.wait('@getNamespaces');
+      navBar.selectNamespace(mockNamespace.name);
+      cy.wait('@getWorkspaces');
+
+      workspaces.findAction({ action: 'stop', workspaceName: TEST_WORKSPACE_NAME }).click();
+      stopModal.findUpdateAndStopButton().click();
+
+      cy.wait('@getWorkspace');
+      cy.wait('@updateWorkspace').then((interception) => {
+        const { body } = interception.request;
+        expect(body.data.paused).to.equal(true);
+        expect(body.data.podTemplate.options.imageConfig).to.equal(REDIRECT_TARGET_IMAGE_ID);
+      });
+
+      stopModal.assertModalNotExists();
+    });
+
+    it('should display error when update and start fails', () => {
+      setupUpdateActionTest(V1Beta1WorkspaceState.WorkspaceStatePaused);
+
+      cy.interceptApi(
+        'PUT /api/:apiVersion/workspaces/:namespace/:workspaceName',
+        {
+          path: {
+            apiVersion: NOTEBOOKS_API_VERSION,
+            namespace: DEFAULT_NAMESPACE,
+            workspaceName: TEST_WORKSPACE_NAME,
+          },
+        },
+        {
+          error: {
+            code: '500',
+            message: 'Failed to update workspace',
+          },
+        },
+      ).as('updateWorkspaceError');
+
+      workspaces.visit();
+      cy.wait('@getNamespaces');
+      navBar.selectNamespace(DEFAULT_NAMESPACE);
+      cy.wait('@getWorkspaces');
+
+      workspaces.findAction({ action: 'start', workspaceName: TEST_WORKSPACE_NAME }).click();
+      startModal.findUpdateAndStartButton().click();
+
+      cy.wait('@getWorkspace');
+      cy.wait('@updateWorkspaceError');
+
+      startModal.assertModalExists();
+      startModal.assertErrorAlertContainsMessage('Error: Failed to update workspace');
     });
   });
 });

--- a/workspaces/frontend/src/app/context/WorkspaceActionsContext.tsx
+++ b/workspaces/frontend/src/app/context/WorkspaceActionsContext.tsx
@@ -12,7 +12,47 @@ import { useTypedNavigate } from '~/app/routerHelper';
 import DeleteModal from '~/shared/components/DeleteModal';
 import { WorkspaceStartActionModal } from '~/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal';
 import { WorkspaceStopActionModal } from '~/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal';
-import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { WorkspacesRedirectStep, WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { NotebookApis } from '~/shared/api/notebookApi';
+
+const resolveRedirectTargetId = (
+  redirectChain: WorkspacesRedirectStep[] | undefined,
+): string | undefined => {
+  if (!redirectChain || redirectChain.length === 0) {
+    return undefined;
+  }
+  return redirectChain[redirectChain.length - 1].target.id;
+};
+
+const updateWorkspaceWithRedirects = async (args: {
+  api: NotebookApis;
+  namespace: string;
+  workspace: WorkspacesWorkspaceListItem;
+  paused: boolean;
+}): Promise<void> => {
+  const { api, namespace, workspace, paused } = args;
+  const imageRedirectTargetId = resolveRedirectTargetId(
+    workspace.podTemplate.options.imageConfig.redirectChain,
+  );
+  const podRedirectTargetId = resolveRedirectTargetId(
+    workspace.podTemplate.options.podConfig.redirectChain,
+  );
+  const workspaceEnvelope = await api.workspaces.getWorkspace(namespace, workspace.name);
+  const currentState = workspaceEnvelope.data;
+  await api.workspaces.updateWorkspace(namespace, workspace.name, {
+    data: {
+      paused,
+      podTemplate: {
+        ...currentState.podTemplate,
+        options: {
+          imageConfig: imageRedirectTargetId ?? currentState.podTemplate.options.imageConfig,
+          podConfig: podRedirectTargetId ?? currentState.podTemplate.options.podConfig,
+        },
+      },
+      revision: currentState.revision,
+    },
+  });
+};
 
 export enum ActionType {
   ViewDetails = 'ViewDetails',
@@ -194,7 +234,12 @@ export const WorkspaceActionsContextProvider: React.FC<WorkspaceActionsContextPr
                     }
                     onActionDone={activeWsAction.onActionDone}
                     onUpdateAndStart={async () => {
-                      // TODO: implement update and stop
+                      await updateWorkspaceWithRedirects({
+                        api,
+                        namespace: selectedNamespace,
+                        workspace: activeWsAction.workspace,
+                        paused: false,
+                      });
                     }}
                   />
                 )}
@@ -214,7 +259,12 @@ export const WorkspaceActionsContextProvider: React.FC<WorkspaceActionsContextPr
                     }
                     onActionDone={activeWsAction.onActionDone}
                     onUpdateAndStop={async () => {
-                      // TODO: implement update and stop
+                      await updateWorkspaceWithRedirects({
+                        api,
+                        namespace: selectedNamespace,
+                        workspace: activeWsAction.workspace,
+                        paused: true,
+                      });
                     }}
                   />
                 )}

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -28,7 +28,9 @@ export const Workspaces: React.FunctionComponent = () => {
     },
     {
       id: 'start',
-      isVisible: (w) => w.state !== V1Beta1WorkspaceState.WorkspaceStateRunning,
+      isVisible: (w) =>
+        w.state !== V1Beta1WorkspaceState.WorkspaceStateRunning &&
+        w.state !== V1Beta1WorkspaceState.WorkspaceStateError,
       onActionDone: refreshWorkspaces,
     },
   ]);

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
 import { Icon } from '@patternfly/react-core/dist/esm/components/Icon';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
@@ -6,8 +6,8 @@ import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
-import useWorkspaceKindByName from '~/app/hooks/useWorkspaceKindByName';
-import { V1Beta1ImageConfig, V1Beta1PodConfig } from '~/generated/data-contracts';
+import { Alert } from '@patternfly/react-core/dist/esm/components/Alert';
+import { WorkspacesRedirectStep } from '~/generated/data-contracts';
 
 const getLevelIcon = (level: string | undefined) => {
   switch (level) {
@@ -39,46 +39,58 @@ const getLevelIcon = (level: string | undefined) => {
 };
 
 interface WorkspaceRedirectInformationViewProps {
-  kind: string;
+  podConfigRedirects?: WorkspacesRedirectStep[];
+  imageConfigRedirects?: WorkspacesRedirectStep[];
 }
 
+export const WorkspaceRedirectInformationViewTitle: React.FC = () => (
+  <TabTitleText>
+    There are pending redirect updates for that workspace. Are you sure you want to proceed?
+    <Alert
+      variant="info"
+      isInline
+      isPlain
+      title="Applying the pending redirect updates will delete and recreate the workspace. Any data not saved to persistent storage will be lost. "
+    />
+  </TabTitleText>
+);
+
 export const WorkspaceRedirectInformationView: React.FC<WorkspaceRedirectInformationViewProps> = ({
-  kind,
+  podConfigRedirects = [],
+  imageConfigRedirects = [],
 }) => {
   const [activeKey, setActiveKey] = useState<string | number>(0);
-  const [workspaceKind, workspaceKindLoaded] = useWorkspaceKindByName(kind);
-  const [imageConfig, setImageConfig] = useState<V1Beta1ImageConfig>();
-  const [podConfig, setPodConfig] = useState<V1Beta1PodConfig>();
+  const imageMappedRedirects = useMemo(
+    () =>
+      imageConfigRedirects.map((value) => ({
+        src: value.source,
+        dest: value.target,
+        message: value.message?.text,
+        level: value.message?.level,
+      })),
+    [imageConfigRedirects],
+  );
 
-  useEffect(() => {
-    if (!workspaceKindLoaded) {
-      return;
-    }
-    setImageConfig(workspaceKind?.podTemplate.options.imageConfig);
-    setPodConfig(workspaceKind?.podTemplate.options.podConfig);
-  }, [workspaceKindLoaded, workspaceKind]);
-
-  const imageConfigRedirects = imageConfig?.values.map((value) => ({
-    src: value.id,
-    dest: value.redirect?.to,
-    message: value.redirect?.message?.text,
-    level: value.redirect?.message?.level,
-  }));
-  const podConfigRedirects = podConfig?.values.map((value) => ({
-    src: value.id,
-    dest: value.redirect?.to,
-    message: value.redirect?.message?.text,
-    level: value.redirect?.message?.level,
-  }));
+  const podMappedRedirects = useMemo(
+    () =>
+      podConfigRedirects.map((value) => ({
+        src: value.source,
+        dest: value.target,
+        message: value.message?.text,
+        level: value.message?.level,
+      })),
+    [podConfigRedirects],
+  );
 
   const getMaxLevel = (redirects: NonNullable<typeof imageConfigRedirects>) => {
-    let maxLevel = redirects[0].level;
+    let maxLevel = redirects[0].message?.level;
     redirects.forEach((redirect) => {
       if (
-        (maxLevel === 'Info' && (redirect.level === 'Warning' || redirect.level === 'Danger')) ||
-        (maxLevel === 'Warning' && redirect.level === 'Danger')
+        (maxLevel === 'Info' &&
+          (redirect.message?.level === 'Warning' || redirect.message?.level === 'Danger')) ||
+        (maxLevel === 'Warning' && redirect.message?.level === 'Danger')
       ) {
-        maxLevel = redirect.level;
+        maxLevel = redirect.message.level;
       }
     });
     return maxLevel;
@@ -86,7 +98,7 @@ export const WorkspaceRedirectInformationView: React.FC<WorkspaceRedirectInforma
 
   return (
     <Tabs activeKey={activeKey} onSelect={(_event, eventKey) => setActiveKey(eventKey)}>
-      {imageConfigRedirects && imageConfigRedirects.length > 0 && (
+      {imageConfigRedirects.length > 0 && (
         <Tab
           eventKey={0}
           title={
@@ -95,27 +107,31 @@ export const WorkspaceRedirectInformationView: React.FC<WorkspaceRedirectInforma
             </TabTitleText>
           }
         >
-          {imageConfigRedirects.map((redirect, index) => (
+          {imageMappedRedirects.map((redirect, index) => (
             <Content style={{ display: 'flex', alignItems: 'baseline' }} key={index}>
               {getLevelIcon(redirect.level)}
-              <ExpandableSection toggleText={` ${redirect.src} -> ${redirect.dest}`}>
+              <ExpandableSection
+                toggleText={` ${redirect.src.displayName} -> ${redirect.dest.displayName}`}
+              >
                 <Content>{redirect.message}</Content>
               </ExpandableSection>
             </Content>
           ))}
         </Tab>
       )}
-      {podConfigRedirects && podConfigRedirects.length > 0 && (
+      {podConfigRedirects.length > 0 && (
         <Tab
-          eventKey={1}
+          eventKey={imageConfigRedirects.length > 0 ? 1 : 0}
           title={
             <TabTitleText>Pod config {getLevelIcon(getMaxLevel(podConfigRedirects))}</TabTitleText>
           }
         >
-          {podConfigRedirects.map((redirect, index) => (
+          {podMappedRedirects.map((redirect, index) => (
             <Content style={{ display: 'flex', alignItems: 'baseline' }} key={index}>
               {getLevelIcon(redirect.level)}
-              <ExpandableSection toggleText={` ${redirect.src} -> ${redirect.dest}`}>
+              <ExpandableSection
+                toggleText={` ${redirect.src.displayName} -> ${redirect.dest.displayName}`}
+              >
                 <Content>{redirect.message}</Content>
               </ExpandableSection>
             </Content>

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView.tsx
@@ -38,13 +38,8 @@ const getLevelIcon = (level: string | undefined) => {
   }
 };
 
-interface WorkspaceRedirectInformationViewProps {
-  podConfigRedirects?: WorkspacesRedirectStep[];
-  imageConfigRedirects?: WorkspacesRedirectStep[];
-}
-
 export const WorkspaceRedirectInformationViewTitle: React.FC = () => (
-  <TabTitleText>
+  <Content>
     There are pending redirect updates for that workspace. Are you sure you want to proceed?
     <Alert
       variant="info"
@@ -52,8 +47,13 @@ export const WorkspaceRedirectInformationViewTitle: React.FC = () => (
       isPlain
       title="Applying the pending redirect updates will delete and recreate the workspace. Any data not saved to persistent storage will be lost. "
     />
-  </TabTitleText>
+  </Content>
 );
+
+interface WorkspaceRedirectInformationViewProps {
+  podConfigRedirects?: WorkspacesRedirectStep[];
+  imageConfigRedirects?: WorkspacesRedirectStep[];
+}
 
 export const WorkspaceRedirectInformationView: React.FC<WorkspaceRedirectInformationViewProps> = ({
   podConfigRedirects = [],

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -7,9 +7,11 @@ import {
   ModalHeader,
 } from '@patternfly/react-core/dist/esm/components/Modal';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
-import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
 import { useNotification } from 'mod-arch-core';
-import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
+import {
+  WorkspaceRedirectInformationView,
+  WorkspaceRedirectInformationViewTitle,
+} from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
 import { ActionButton } from '~/shared/components/ActionButton';
 import { ErrorAlert } from '~/shared/components/ErrorAlert';
 import { extractErrorMessage } from '~/shared/api/apiUtils';
@@ -115,14 +117,14 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
             </StackItem>
           )}
           <StackItem>
-            <TabTitleText>
-              There are pending redirect updates for that workspace. Are you sure you want to
-              proceed?
-            </TabTitleText>
+            <WorkspaceRedirectInformationViewTitle />
           </StackItem>
           {workspace && (
             <StackItem>
-              <WorkspaceRedirectInformationView kind={workspace.workspaceKind.name} />
+              <WorkspaceRedirectInformationView
+                podConfigRedirects={workspace.podTemplate.options.podConfig.redirectChain}
+                imageConfigRedirects={workspace.podTemplate.options.imageConfig.redirectChain}
+              />
             </StackItem>
           )}
         </Stack>

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -7,6 +7,7 @@ import {
   ModalHeader,
 } from '@patternfly/react-core/dist/esm/components/Modal';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { useNotification } from 'mod-arch-core';
 import {
   WorkspaceRedirectInformationView,
@@ -41,6 +42,10 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
   onActionDone,
 }) => {
   const notification = useNotification();
+  const workspacePendingUpdate =
+    workspace?.pendingRestart &&
+    ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
+      (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
   const [actionOnGoing, setActionOnGoing] = useState<StartAction | null>(null);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
 
@@ -116,21 +121,21 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
               />
             </StackItem>
           )}
-          <StackItem>
-            <WorkspaceRedirectInformationViewTitle />
-          </StackItem>
-          {workspace && (
+          {workspace && workspacePendingUpdate ? (
             <StackItem>
+              <WorkspaceRedirectInformationViewTitle />
               <WorkspaceRedirectInformationView
                 podConfigRedirects={workspace.podTemplate.options.podConfig.redirectChain}
                 imageConfigRedirects={workspace.podTemplate.options.imageConfig.redirectChain}
               />
             </StackItem>
+          ) : (
+            <Content>Are you sure you want to start the workspace?</Content>
           )}
         </Stack>
       </ModalBody>
       <ModalFooter>
-        {shouldShowActionButton('updateAndStart') && (
+        {shouldShowActionButton('updateAndStart') && workspacePendingUpdate && (
           <ActionButton
             action="Update and Start"
             titleOnLoading="Starting ..."

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -133,6 +133,7 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
             action="Update and Start"
             titleOnLoading="Starting ..."
             onClick={() => handleUpdateAndStart()}
+            data-testid="update-and-start-button"
           >
             Update and Start
           </ActionButton>

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -42,7 +42,10 @@ export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
   onActionDone,
 }) => {
   const notification = useNotification();
-  const workspacePendingUpdate = workspace?.pendingRestart;
+  const workspacePendingUpdate =
+    workspace?.pendingRestart &&
+    ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
+      (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
   const [actionOnGoing, setActionOnGoing] = useState<StopAction | null>(null);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
 

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -134,6 +134,7 @@ export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
             action="Update and stop"
             titleOnLoading="Stopping ..."
             onClick={() => handleUpdateAndStop()}
+            data-testid="update-and-stop-button"
           >
             Update and stop
           </ActionButton>

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -8,9 +8,11 @@ import {
   ModalHeader,
 } from '@patternfly/react-core/dist/esm/components/Modal';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
-import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
 import { useNotification } from 'mod-arch-core';
-import { WorkspaceRedirectInformationView } from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
+import {
+  WorkspaceRedirectInformationView,
+  WorkspaceRedirectInformationViewTitle,
+} from '~/app/pages/Workspaces/workspaceActions/WorkspaceRedirectInformationView';
 import { ActionButton } from '~/shared/components/ActionButton';
 import { ErrorAlert } from '~/shared/components/ErrorAlert';
 import { extractErrorMessage } from '~/shared/api/apiUtils';
@@ -116,11 +118,11 @@ export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
           <StackItem>
             {workspacePendingUpdate ? (
               <>
-                <TabTitleText>
-                  There are pending redirect updates for that workspace. Are you sure you want to
-                  proceed?
-                </TabTitleText>
-                <WorkspaceRedirectInformationView kind={workspace.workspaceKind.name} />
+                <WorkspaceRedirectInformationViewTitle />
+                <WorkspaceRedirectInformationView
+                  podConfigRedirects={workspace.podTemplate.options.podConfig.redirectChain}
+                  imageConfigRedirects={workspace.podTemplate.options.imageConfig.redirectChain}
+                />
               </>
             ) : (
               <Content>Are you sure you want to stop the workspace?</Content>


### PR DESCRIPTION
 closes: #1149

- Replace the redirect rendering from Workspace Kind to Workspace Option
- Implement onUpdateAndStart and onUpdateAndStop workspace actions