### PR TITLE
feat: remove pod labels from WorkspaceKind summary panel

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel.tsx
@@ -341,10 +341,8 @@ export const WorkspaceFormSummaryPanel: React.FC<WorkspaceFormSummaryPanelProps>
         title: 'Workspace Kind',
         displayName: selectedKind?.displayName || selectedKind?.name,
         description: selectedKind?.description,
-        labels: selectedKind?.podTemplate.podMetadata.labels,
         originalDisplayName: originalKind?.displayName || originalKind?.name,
         originalDescription: originalKind?.description,
-        originalLabels: originalKind?.podTemplate.podMetadata.labels,
         disabledTooltip: isEditMode
           ? 'Workspace kind cannot be changed after creation.'
           : undefined,


### PR DESCRIPTION
## Changes
Removes pod labels from the WorkspaceKind summary card in the workspace
create/edit flow. Pod labels are internal Kubernetes metadata that are
not useful to end users and add visual clutter.
## Testing
- [x] `npm run test:type-check` — no errors
- [x] `npm run test:lint` — no warnings  
- [x] `npm run test:unit` — 350 tests pass
- [x] Manually verified WorkspaceKind summary card no longer shows pod labels
- [x] Image and Pod Config labels still visible (unaffected)
Fixes #1143