### PR TITLE
chore: improved owner declarations and root file responsibilities

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,6 +1,6 @@
 labels:
   - area/ci
 approvers:
-  - andyatmiami
+  - ci-approvers
 reviewers:
-  - christian-heusel
+  - ci-reviewers

--- a/OWNERS
+++ b/OWNERS
@@ -3,3 +3,7 @@ labels:
 approvers:
   - kimwnasptd
   - thesuperzapper
+filters:
+  ".*\\.md$":
+    approvers:
+      - ci-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,19 @@
+aliases:
+  frontend-approvers:
+    - ederign
+    - paulovmr
+  frontend-reviewers:
+    - thaorell
+    - caponetto
+  backend-approvers:
+    - andyatmiami
+  backend-reviewers: []
+  controller-approvers:
+    - andyatmiami
+  controller-reviewers: []
+  ci-approvers:
+    - andyatmiami
+  ci-reviewers:
+    - christian-heusel
+  release-approvers: []
+  release-reviewers: []

--- a/developing/OWNERS
+++ b/developing/OWNERS
@@ -2,6 +2,6 @@ labels:
   - area/ci
   - area/v2
 approvers:
-  - andyatmiami
+  - ci-approvers
 reviewers:
-  - christian-heusel
+  - ci-reviewers

--- a/releasing/OWNERS
+++ b/releasing/OWNERS
@@ -1,2 +1,6 @@
 labels:
   - area/release
+approvers:
+  - release-approvers
+reviewers:
+  - release-reviewers

--- a/testing/OWNERS
+++ b/testing/OWNERS
@@ -2,6 +2,6 @@ labels:
   - area/ci
   - area/v2
 approvers:
-  - andyatmiami
+  - ci-approvers
 reviewers:
-  - christian-heusel
+  - ci-reviewers

--- a/workspaces/backend/OWNERS
+++ b/workspaces/backend/OWNERS
@@ -1,4 +1,4 @@
 labels:
   - area/backend
 approvers:
-  - andyatmiami
+  - backend-approvers

--- a/workspaces/controller/OWNERS
+++ b/workspaces/controller/OWNERS
@@ -1,4 +1,4 @@
 labels:
   - area/controller
 approvers:
-  - andyatmiami
+  - controller-approvers

--- a/workspaces/frontend/OWNERS
+++ b/workspaces/frontend/OWNERS
@@ -1,8 +1,6 @@
 labels:
   - area/frontend
 approvers:
-  - ederign
-  - paulovmr
+  - frontend-approvers
 reviewers:
-  - thaorell
-  - caponetto
+  - frontend-reviewers


### PR DESCRIPTION
Introduce OWNERS_ALIASES to centralize team membership definitions and update all OWNERS files to reference alias groups instead of hardcoded usernames. This provides a single place to manage team membership changes without touching multiple OWNERS files across the repo.

Alias groups defined for all areas:
- frontend-approvers/reviewers
- backend-approvers/reviewers
- controller-approvers/reviewers
- ci-approvers/reviewers
- release-approvers/reviewers

Additionally, add a `filters` section to the root OWNERS file so that root-level markdown files (e.g. DEVELOPMENT_GUIDE.md) can be approved by ci-approvers without requiring a core maintainer. This resolves a gap where PRs touching both subproject files and root-level docs were blocked on maintainer approval even when all functional code changes were already covered by the relevant area approvers.
