### PR TITLE
chore: add roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Key features of Kubeflow Notebooks:
 ## Documentation
 
 The official documentation for Kubeflow Notebooks can be found [here](https://www.kubeflow.org/docs/components/notebooks/).
-The current roadmap and release planning references are tracked in [`ROADMAP.md`](ROADMAP.md).
+The current roadmap is tracked in the issues in this project as described in [`ROADMAP.md`](ROADMAP.md).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Key features of Kubeflow Notebooks:
 ## Documentation
 
 The official documentation for Kubeflow Notebooks can be found [here](https://www.kubeflow.org/docs/components/notebooks/).
+The current roadmap and release planning references are tracked in [`ROADMAP.md`](ROADMAP.md).
 
 ## Community
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,57 @@
+# Kubeflow Notebooks Roadmap
+
+Kubeflow Notebooks runs interactive development environments for AI, ML, and data workloads on Kubernetes.
+
+## Current Release Lines
+
+This repository currently maintains two major development lines:
+
+- `notebooks-v1`: the stable Kubeflow Notebooks v1 codebase used by current Kubeflow platform releases.
+- `notebooks-v2`: the Kubeflow Notebooks v2 codebase, also described as Kubeflow Workspaces, under active development with alpha release tags.
+
+Kubeflow Notebooks v1 releases are tracked through semver tags such as [`v1.11.0`](https://github.com/kubeflow/notebooks/releases/tag/v1.11.0). Kubeflow Notebooks v2 alpha releases are tracked through semver tags such as [`v2.0.0-alpha.3`](https://github.com/kubeflow/notebooks/releases/tag/v2.0.0-alpha.3).
+
+## Notebooks 2.0 / Workspaces
+
+The primary forward-looking roadmap for Kubeflow Notebooks is [Kubeflow Notebooks 2.0 / Kubeflow Workspaces](https://github.com/kubeflow/notebooks/issues/85). Notebooks 2.0 is intended to make running IDEs on Kubernetes better for both end users and cluster admins by introducing higher-level workspace abstractions instead of exposing users directly to raw pod specs.
+
+The roadmap is organized around three new components in the [`notebooks-v2`](https://github.com/kubeflow/notebooks/tree/notebooks-v2) branch:
+
+- [Workspace Controller](https://github.com/kubeflow/notebooks/tree/notebooks-v2/workspaces/controller): reconciles `Workspace` and `WorkspaceKind` resources and provides validation webhooks.
+- [Workspace Backend API](https://github.com/kubeflow/notebooks/tree/notebooks-v2/workspaces/backend): provides the backend-for-frontend REST API between the UI and Kubernetes.
+- [Workspace Frontend](https://github.com/kubeflow/notebooks/tree/notebooks-v2/workspaces/frontend): lets users create, edit, connect to, and manage Workspaces.
+
+The key API direction is to split the existing Notebook model into:
+
+- `Workspace`: a namespaced resource created by users through the UI or `kubectl`.
+- `WorkspaceKind`: a cluster resource defined by admins to describe templates such as JupyterLab, VS Code, or RStudio, including approved images and pod configurations.
+
+## Roadmap Themes
+
+Near-term work is focused on:
+
+- Maintaining the stable Notebooks v1 experience for current Kubeflow platform users.
+- Developing and validating Notebooks v2 / Workspaces through alpha releases.
+- Providing admin-defined `WorkspaceKind` templates so users can choose IDE, image, pod configuration, and volumes without understanding all Kubernetes pod details.
+- Supporting safer workspace updates, including image and pod-configuration changes managed by admins.
+- Improving support for resource-sensitive environments, including GPU-oriented pod configurations and future lifecycle controls such as culling or maximum runtime policies.
+- Preserving a path for users to opt into Workspaces before it becomes the default Notebooks experience.
+
+## Open Readiness Questions
+
+The Notebooks Working Group is still using issue and release artifacts to refine readiness criteria for making Workspaces the default experience. Open questions called out in the Notebooks 2.0 discussion include:
+
+- Whether Workspaces has feature parity with the current Notebooks web app.
+- Which lifecycle controls, such as culling, are required before default adoption.
+- How admins should define and evolve common pod labels, annotations, resource profiles, and runtime policies through `WorkspaceKind`.
+- Which future activity probes or usage signals should be supported beyond the initial release.
+
+## Planning References
+
+- [Kubeflow Notebooks 2.0 / Workspaces proposal and tracking issue](https://github.com/kubeflow/notebooks/issues/85)
+- [Kubeflow 1.11.0 Notebooks WG tracking issue](https://github.com/kubeflow/notebooks/issues/707)
+- [Kubeflow Notebooks v1 branch](https://github.com/kubeflow/notebooks/tree/notebooks-v1)
+- [Kubeflow Notebooks v2 branch](https://github.com/kubeflow/notebooks/tree/notebooks-v2)
+- [Kubeflow Notebooks releases](https://github.com/kubeflow/notebooks/releases)
+- [Kubeflow Notebooks planning issues](https://github.com/kubeflow/notebooks/issues?q=is%3Aissue%20label%3Akind%2Fplanning)
+- [Notebooks Working Group](https://github.com/kubeflow/community/tree/master/wg-notebooks)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,5 +44,5 @@ For detailed epics and tracking, see the [Kubeflow Notebooks project board](http
 - [Kubeflow Notebooks v1 branch](https://github.com/kubeflow/notebooks/tree/notebooks-v1)
 - [Kubeflow Notebooks v2 branch](https://github.com/kubeflow/notebooks/tree/notebooks-v2)
 - [Kubeflow Notebooks releases](https://github.com/kubeflow/notebooks/releases)
-- [Kubeflow Notebooks planning issues](https://github.com/kubeflow/notebooks/issues?q=is%3Aissue%20label%3Akind%2Fplanning)
+- [Kubeflow Notebooks planning board](https://github.com/orgs/kubeflow/projects/62)
 - [Notebooks Working Group](https://github.com/kubeflow/community/tree/master/wg-notebooks)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,16 +2,14 @@
 
 Kubeflow Notebooks runs interactive development environments for AI, ML, and data workloads on Kubernetes.
 
-## Current Release Lines
+## Current Releases
 
-This repository currently maintains two major development lines:
+This repository maintains two development branches and follows [semver](https://semver.org/) for versioning:
 
 - `notebooks-v1`: the stable Kubeflow Notebooks v1 codebase used by current Kubeflow platform releases.
 - `notebooks-v2`: the Kubeflow Notebooks v2 codebase, also described as Kubeflow Workspaces, under active development with alpha release tags.
 
-Kubeflow Notebooks v1 releases are tracked through semver tags such as [`v1.11.0`](https://github.com/kubeflow/notebooks/releases/tag/v1.11.0). Kubeflow Notebooks v2 alpha releases are tracked through semver tags such as [`v2.0.0-alpha.3`](https://github.com/kubeflow/notebooks/releases/tag/v2.0.0-alpha.3).
-
-## Notebooks 2.0 / Workspaces
+## Notebooks 2.0 / Kubeflow Workspaces
 
 The primary forward-looking roadmap for Kubeflow Notebooks is [Kubeflow Notebooks 2.0 / Kubeflow Workspaces](https://github.com/kubeflow/notebooks/issues/85). Notebooks 2.0 is intended to make running IDEs on Kubernetes better for both end users and cluster admins by introducing higher-level workspace abstractions instead of exposing users directly to raw pod specs.
 
@@ -37,14 +35,7 @@ Near-term work is focused on:
 - Improving support for resource-sensitive environments, including GPU-oriented pod configurations and future lifecycle controls such as culling or maximum runtime policies.
 - Preserving a path for users to opt into Workspaces before it becomes the default Notebooks experience.
 
-## Open Readiness Questions
-
-The Notebooks Working Group is still using issue and release artifacts to refine readiness criteria for making Workspaces the default experience. Open questions called out in the Notebooks 2.0 discussion include:
-
-- Whether Workspaces has feature parity with the current Notebooks web app.
-- Which lifecycle controls, such as culling, are required before default adoption.
-- How admins should define and evolve common pod labels, annotations, resource profiles, and runtime policies through `WorkspaceKind`.
-- Which future activity probes or usage signals should be supported beyond the initial release.
+For detailed epics and tracking, see the [Kubeflow Notebooks project board](https://github.com/orgs/kubeflow/projects/62).
 
 ## Planning References
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,6 @@ For detailed epics and tracking, see the [Kubeflow Notebooks project board](http
 ## Planning References
 
 - [Kubeflow Notebooks 2.0 / Workspaces proposal and tracking issue](https://github.com/kubeflow/notebooks/issues/85)
-- [Kubeflow 1.11.0 Notebooks WG tracking issue](https://github.com/kubeflow/notebooks/issues/707)
 - [Kubeflow Notebooks v1 branch](https://github.com/kubeflow/notebooks/tree/notebooks-v1)
 - [Kubeflow Notebooks v2 branch](https://github.com/kubeflow/notebooks/tree/notebooks-v2)
 - [Kubeflow Notebooks releases](https://github.com/kubeflow/notebooks/releases)


### PR DESCRIPTION
Ref: kubeflow/community#988

Adds a root `ROADMAP.md` for Kubeflow Notebooks so CNCF graduation reviewers have a durable roadmap reference for the Notebooks subproject.

The roadmap is based on the existing Notebooks 2.0 / Kubeflow Workspaces tracking issue and current repo structure:

- points to the `notebooks-v1` and `notebooks-v2` development branches
- notes the project follows semver for versioning
- describes Notebooks 2.0 / Kubeflow Workspaces using kubeflow/notebooks#85
- lists the Workspace Controller, Backend API, and Frontend components
- summarizes the `Workspace` / `WorkspaceKind` API direction
- links to the [Kubeflow Notebooks project board](https://github.com/orgs/kubeflow/projects/62) for detailed epics and tracking
- links releases, planning issues, and the Notebooks Working Group

Also links the new roadmap from the README.