### PR TITLE
chore: Add RELEASE.md to the main branch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+# Kubeflow Notebooks Release Process
+
+Extensive documentation on the release process for the projects in the
+`kubeflow/notebooks` repository can be found in each version-specific branch in
+the `README.md` of the `releasing/` folder:
+
+- **notebooks-v1**: [releasing/README.md](https://github.com/kubeflow/notebooks/tree/notebooks-v1/releasing)
+- **notebooks-v2**: [releasing/README.md](https://github.com/kubeflow/notebooks/tree/notebooks-v2/releasing)


### PR DESCRIPTION
The release process itself already was docuemented but not yet easily discoverable for the CNCF reviewers and therefore most likely for anyone. Fix this by linking the branch-specific documents from the `main` branch.

Fixes https://github.com/kubeflow/community/issues/990
