### PR TITLE
fix: bump kubectl to v1.35.6 to patch Go stdlib CVEs

### DIFF
--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -39,7 +39,7 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS 2
 # args - software versions
 # https://kubernetes.io/releases/
 # https://github.com/just-containers/s6-overlay/releases
-ARG KUBECTL_VERSION=v1.35.5
+ARG KUBECTL_VERSION=v1.35.6
 ARG S6_VERSION=v3.2.3.0
 
 # set shell to bash


### PR DESCRIPTION
## What this PR does

Bumps the `kubectl` binary in the notebook-server **base** image from `v1.35.5` to `v1.35.6`.

## Why

`kubectl v1.35.5` is compiled with `go1.25.9`, whose standard library carries 8 HIGH-severity CVEs. `kubectl v1.35.6` is compiled with `go1.25.11`, which fixes all of them. Because every example notebook-server image (`jupyter`, `jupyter-pytorch`, `rstudio`, …) inherits from `base`, this clears the findings across the whole image family.

Resolved Go stdlib CVEs:

- CVE-2026-33811
- CVE-2026-33814
- CVE-2026-39820
- CVE-2026-39823
- CVE-2026-39825
- CVE-2026-39836
- CVE-2026-42499
- CVE-2026-42504

## Validation

Built `base` + `jupyter` locally before and after the change and scanned with Trivy 0.71.2 (`--severity CRITICAL,HIGH`):

| `usr/local/bin/kubectl` (gobinary) | Before (`v1.35.5`) | After (`v1.35.6`) |
| --- | --- | --- |
| Go stdlib HIGH CVEs | 8 | **0** |

Embedded Go toolchain confirmed: `v1.35.5 → go1.25.9` (vulnerable), `v1.35.6 → go1.25.11` (patched). This is a same-minor patch bump, so no behavioral change to `kubectl` is expected.
