### PR TITLE
feat(frontend): display workspace auto-pause countdown in activity panel

### DIFF
--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -221,6 +221,27 @@ var _ = Describe("Workspaces Handler", func() {
 			var dataObject []models.WorkspaceListItem
 			err = json.Unmarshal(dataJSON, &dataObject)
 			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal JSON to []WorkspaceListItem")
+
+			By("ensuring every workspace list item carries the cullingConfig from its WorkspaceKind")
+			for _, ws := range response.Data {
+				Expect(ws.WorkspaceKind.CullingConfig).NotTo(BeNil(),
+					"cullingConfig should be present for a WorkspaceKind with culling enabled")
+				Expect(ws.WorkspaceKind.CullingConfig.MaxInactiveSeconds).To(Equal(int32(86400)),
+					"maxInactiveSeconds should match the value set on the WorkspaceKind")
+			}
+
+			By("ensuring cullingConfig is serialised into the JSON response")
+			var rawList []map[string]json.RawMessage
+			Expect(json.Unmarshal(dataJSON, &rawList)).To(Succeed())
+			for _, item := range rawList {
+				var wkInfo map[string]json.RawMessage
+				Expect(json.Unmarshal(item["workspaceKind"], &wkInfo)).To(Succeed())
+				Expect(wkInfo).To(HaveKey("cullingConfig"),
+					"cullingConfig must appear in the workspaceKind JSON object")
+				var cc models.CullingConfig
+				Expect(json.Unmarshal(wkInfo["cullingConfig"], &cc)).To(Succeed())
+				Expect(cc.MaxInactiveSeconds).To(Equal(int32(86400)))
+			}
 		})
 
 		It("should retrieve Workspaces from Namespace 1 successfully", func() {
@@ -484,6 +505,8 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(workspaceMissingWskModel.PodTemplate.Options.PodConfig.Current.Description).To(Equal(models.UnknownPodConfig))
 			Expect(workspaceMissingWskModel.PodTemplate.Options.ImageConfig.Current.DisplayName).To(Equal(models.UnknownImageConfig))
 			Expect(workspaceMissingWskModel.PodTemplate.Options.ImageConfig.Current.Description).To(Equal(models.UnknownImageConfig))
+			Expect(workspaceMissingWskModel.WorkspaceKind.CullingConfig).To(BeNil(),
+				"cullingConfig must be absent when the WorkspaceKind is missing")
 
 			By("ensuring the model for Workspace with invalid PodConfig is as expected")
 			workspaceInvalidPodConfigModel := models.NewWorkspaceListItemFromWorkspace(a.Config, workspaceInvalidPodConfig, workspaceKind)

--- a/workspaces/backend/internal/models/workspaces/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/funcs.go
@@ -78,10 +78,11 @@ func NewWorkspaceListItemFromWorkspace(cfg *config.EnvConfig, ws *kubefloworgv1b
 		Name:      ws.Name,
 		Namespace: ws.Namespace,
 		WorkspaceKind: WorkspaceKindInfo{
-			Name:    ws.Spec.Kind,
-			Missing: !wskExists(wsk),
-			Icon:    buildIconImageRef(cfg, ws, wsk),
-			Logo:    buildLogoImageRef(cfg, ws, wsk),
+			Name:          ws.Spec.Kind,
+			Missing:       !wskExists(wsk),
+			Icon:          buildIconImageRef(cfg, ws, wsk),
+			Logo:          buildLogoImageRef(cfg, ws, wsk),
+			CullingConfig: buildCullingConfig(wsk),
 		},
 		Paused:         ptr.Deref(ws.Spec.Paused, false),
 		PausedTime:     ws.Status.PauseTime,
@@ -346,4 +347,19 @@ func buildLogoImageRef(cfg *config.EnvConfig, ws *kubefloworgv1beta1.Workspace, 
 		return commonAssets.ImageRef{URL: UnknownLogoURL}
 	}
 	return commonAssets.NewImageRefFromWorkspaceKindAssetLogo(cfg, wsk.Spec.Spawner.Logo, wsk.Status.SpawnerLogo, ws.Spec.Kind)
+}
+
+// buildCullingConfig extracts the culling config from a WorkspaceKind.
+// Returns nil when the WorkspaceKind doesn't exist or culling is disabled.
+func buildCullingConfig(wsk *kubefloworgv1beta1.WorkspaceKind) *CullingConfig {
+	if !wskExists(wsk) || wsk.Spec.PodTemplate.Culling == nil {
+		return nil
+	}
+	culling := wsk.Spec.PodTemplate.Culling
+	if enabled := ptr.Deref(culling.Enabled, true); !enabled {
+		return nil
+	}
+	return &CullingConfig{
+		MaxInactiveSeconds: ptr.Deref(culling.MaxInactiveSeconds, 86400),
+	}
 }

--- a/workspaces/backend/internal/models/workspaces/funcs_test.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaces
+
+import (
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestWorkspacesModels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workspaces Models Suite")
+}
+
+// makeWsk returns a minimal WorkspaceKind with the given culling config.
+func makeWsk(culling *kubefloworgv1beta1.WorkspaceKindCullingConfig) *kubefloworgv1beta1.WorkspaceKind {
+	return &kubefloworgv1beta1.WorkspaceKind{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-kind",
+			UID:  "test-uid",
+		},
+		Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
+				Culling: culling,
+			},
+		},
+	}
+}
+
+var _ = Describe("buildCullingConfig", func() {
+
+	It("returns nil when the WorkspaceKind is nil", func() {
+		Expect(buildCullingConfig(nil)).To(BeNil())
+	})
+
+	It("returns nil when the WorkspaceKind has no UID (missing from cluster)", func() {
+		wsk := makeWsk(&kubefloworgv1beta1.WorkspaceKindCullingConfig{
+			Enabled:            ptr.To(true),
+			MaxInactiveSeconds: ptr.To(int32(1800)),
+			ActivityProbe: kubefloworgv1beta1.ActivityProbe{
+				Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{LastActivity: true},
+			},
+		})
+		wsk.UID = "" // simulate missing WorkspaceKind
+		Expect(buildCullingConfig(wsk)).To(BeNil())
+	})
+
+	It("returns nil when culling is disabled", func() {
+		wsk := makeWsk(&kubefloworgv1beta1.WorkspaceKindCullingConfig{
+			Enabled:            ptr.To(false),
+			MaxInactiveSeconds: ptr.To(int32(1800)),
+			ActivityProbe: kubefloworgv1beta1.ActivityProbe{
+				Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{LastActivity: true},
+			},
+		})
+		Expect(buildCullingConfig(wsk)).To(BeNil())
+	})
+
+	It("returns nil when the culling field is absent on the WorkspaceKind", func() {
+		wsk := makeWsk(nil)
+		Expect(buildCullingConfig(wsk)).To(BeNil())
+	})
+
+	It("returns CullingConfig with the configured MaxInactiveSeconds when culling is enabled", func() {
+		wsk := makeWsk(&kubefloworgv1beta1.WorkspaceKindCullingConfig{
+			Enabled:            ptr.To(true),
+			MaxInactiveSeconds: ptr.To(int32(1800)),
+			ActivityProbe: kubefloworgv1beta1.ActivityProbe{
+				Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{LastActivity: true},
+			},
+		})
+		result := buildCullingConfig(wsk)
+		Expect(result).NotTo(BeNil())
+		Expect(result.MaxInactiveSeconds).To(Equal(int32(1800)))
+	})
+
+	It("defaults MaxInactiveSeconds to 86400 when not set", func() {
+		wsk := makeWsk(&kubefloworgv1beta1.WorkspaceKindCullingConfig{
+			// MaxInactiveSeconds omitted — should default to 86400
+			ActivityProbe: kubefloworgv1beta1.ActivityProbe{
+				Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{LastActivity: true},
+			},
+		})
+		result := buildCullingConfig(wsk)
+		Expect(result).NotTo(BeNil())
+		Expect(result.MaxInactiveSeconds).To(Equal(int32(86400)))
+	})
+
+	It("treats an absent Enabled field as enabled (default true)", func() {
+		wsk := makeWsk(&kubefloworgv1beta1.WorkspaceKindCullingConfig{
+			// Enabled omitted — should default to true
+			MaxInactiveSeconds: ptr.To(int32(3600)),
+			ActivityProbe: kubefloworgv1beta1.ActivityProbe{
+				Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{LastActivity: true},
+			},
+		})
+		result := buildCullingConfig(wsk)
+		Expect(result).NotTo(BeNil())
+		Expect(result.MaxInactiveSeconds).To(Equal(int32(3600)))
+	})
+})

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -43,10 +43,17 @@ type WorkspaceListItem struct {
 }
 
 type WorkspaceKindInfo struct {
-	Name    string                `json:"name"`
-	Missing bool                  `json:"missing"`
-	Icon    commonAssets.ImageRef `json:"icon"`
-	Logo    commonAssets.ImageRef `json:"logo"`
+	Name          string                `json:"name"`
+	Missing       bool                  `json:"missing"`
+	Icon          commonAssets.ImageRef `json:"icon"`
+	Logo          commonAssets.ImageRef `json:"logo"`
+	CullingConfig *CullingConfig        `json:"cullingConfig,omitempty"`
+}
+
+// CullingConfig holds the culling settings for a WorkspaceKind, surfaced on each workspace
+// list item so the frontend can compute time-to-pause without a separate WorkspaceKind fetch.
+type CullingConfig struct {
+	MaxInactiveSeconds int32 `json:"maxInactiveSeconds"`
 }
 
 type PodTemplate struct {

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -7286,6 +7286,18 @@ const docTemplate = `{
                 }
             }
         },
+        "workspaces.CullingConfig": {
+            "type": "object",
+            "required": [
+                "maxInactiveSeconds"
+            ],
+            "properties": {
+                "maxInactiveSeconds": {
+                    "description": "The maximum number of seconds a workspace can be inactive before it is auto-paused.",
+                    "type": "integer"
+                }
+            }
+        },
         "workspaces.WorkspaceKindInfo": {
             "type": "object",
             "required": [
@@ -7295,6 +7307,14 @@ const docTemplate = `{
                 "name"
             ],
             "properties": {
+                "cullingConfig": {
+                    "description": "Culling settings for this workspace kind. Omitted when the WorkspaceKind is missing or culling is disabled.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/workspaces.CullingConfig"
+                        }
+                    ]
+                },
                 "icon": {
                     "$ref": "#/definitions/assets.ImageRef"
                 },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -7284,6 +7284,18 @@
                 }
             }
         },
+        "workspaces.CullingConfig": {
+            "type": "object",
+            "required": [
+                "maxInactiveSeconds"
+            ],
+            "properties": {
+                "maxInactiveSeconds": {
+                    "description": "The maximum number of seconds a workspace can be inactive before it is auto-paused.",
+                    "type": "integer"
+                }
+            }
+        },
         "workspaces.WorkspaceKindInfo": {
             "type": "object",
             "required": [
@@ -7293,6 +7305,14 @@
                 "name"
             ],
             "properties": {
+                "cullingConfig": {
+                    "description": "Culling settings for this workspace kind. Omitted when the WorkspaceKind is missing or culling is disabled.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/workspaces.CullingConfig"
+                        }
+                    ]
+                },
                 "icon": {
                     "$ref": "#/definitions/assets.ImageRef"
                 },

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { format } from 'date-fns/format';
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import {
   DescriptionList,
   DescriptionListTerm,
@@ -7,7 +8,9 @@ import {
   DescriptionListDescription,
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
-import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import { WorkspacesWorkspaceListItem, V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import { getMsUntilCull } from '~/shared/utilities/cullingUtils';
 
 const DATE_FORMAT = 'PPpp';
 
@@ -15,20 +18,99 @@ type WorkspaceDetailsActivityProps = {
   workspace: WorkspacesWorkspaceListItem;
 };
 
+const probeResultColor = (result: string): 'green' | 'red' | 'orange' => {
+  if (result === 'Success') {
+    return 'green';
+  }
+  if (result === 'Failure') {
+    return 'red';
+  }
+  return 'orange';
+};
+
+const formatMsUntilCull = (ms: number): string => {
+  if (ms <= 0) {
+    return 'imminent';
+  }
+  const totalSeconds = Math.ceil(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.ceil((totalSeconds % 3600) / 60);
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+};
+
 export const WorkspaceDetailsActivity: React.FunctionComponent<WorkspaceDetailsActivityProps> = ({
   workspace,
 }) => {
-  const { activity, pausedTime, pendingRestart } = workspace;
+  const { activity, pausedTime, pendingRestart, workspaceKind, state } = workspace;
+
+  const msUntilCull = getMsUntilCull(workspace);
+  const isRunning = state === V1Beta1WorkspaceState.WorkspaceStateRunning;
+  const hasCulling = workspaceKind.cullingConfig != null;
 
   return (
     <DescriptionList isHorizontal>
       <DescriptionListGroup>
         <DescriptionListTerm>Last activity</DescriptionListTerm>
         <DescriptionListDescription data-testid="lastActivity">
-          {activity.lastActivity === 0 ? 'unknown' : format(activity.lastActivity, DATE_FORMAT)}
+          {activity.lastActivity === 0
+            ? 'unknown'
+            : `${format(activity.lastActivity, DATE_FORMAT)} (${formatDistanceToNow(
+                new Date(activity.lastActivity),
+                { addSuffix: true },
+              )})`}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />
+      {isRunning && hasCulling && (
+        <>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Idle duration</DescriptionListTerm>
+            <DescriptionListDescription data-testid="idleDuration">
+              {activity.lastActivity === 0
+                ? 'unknown'
+                : formatDistanceToNow(new Date(activity.lastActivity))}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <Divider />
+          <DescriptionListGroup>
+            <DescriptionListTerm>Auto-pause in</DescriptionListTerm>
+            <DescriptionListDescription data-testid="cullingCountdown">
+              {msUntilCull === null
+                ? 'N/A'
+                : msUntilCull <= 0
+                  ? 'imminent'
+                  : formatMsUntilCull(msUntilCull)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <Divider />
+        </>
+      )}
+      {activity.lastProbe && (
+        <>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Last probe result</DescriptionListTerm>
+            <DescriptionListDescription data-testid="lastProbeResult">
+              <Label color={probeResultColor(activity.lastProbe.result)} isCompact>
+                {activity.lastProbe.result}
+              </Label>
+              {activity.lastProbe.message && (
+                <span style={{ marginLeft: '0.5rem' }}>{activity.lastProbe.message}</span>
+              )}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <Divider />
+          <DescriptionListGroup>
+            <DescriptionListTerm>Last probe time</DescriptionListTerm>
+            <DescriptionListDescription data-testid="lastProbeTime">
+              {format(activity.lastProbe.endTimeMs, DATE_FORMAT)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <Divider />
+        </>
+      )}
       <DescriptionListGroup>
         <DescriptionListTerm>Last update</DescriptionListTerm>
         <DescriptionListDescription data-testid="lastUpdate">

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/__tests__/WorkspaceDetailsActivity.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/__tests__/WorkspaceDetailsActivity.spec.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WorkspaceDetailsActivity } from '~/app/pages/Workspaces/Details/WorkspaceDetailsActivity';
+import {
+  V1Beta1WorkspaceState,
+  WorkspacesProbeResult,
+  WorkspacesWorkspaceListItem,
+} from '~/generated/data-contracts';
+
+const baseWorkspace: WorkspacesWorkspaceListItem = {
+  name: 'test-ws',
+  namespace: 'default',
+  paused: false,
+  pausedTime: 0,
+  pendingRestart: false,
+  state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+  stateMessage: '',
+  workspaceKind: {
+    name: 'jupyter',
+    missing: false,
+    icon: { url: '' },
+    logo: { url: '' },
+  },
+  podTemplate: {
+    podMetadata: { labels: {}, annotations: {} },
+    volumes: { data: [] },
+    options: {
+      imageConfig: { current: { id: '', displayName: '', description: '', labels: [] } },
+      podConfig: { current: { id: '', displayName: '', description: '', labels: [] } },
+    },
+  },
+  activity: {
+    lastActivity: 0,
+    lastUpdate: 0,
+  },
+  services: [],
+  audit: { createdAt: '', createdBy: '', updatedAt: '', updatedBy: '', deletedAt: '' },
+};
+
+describe('WorkspaceDetailsActivity', () => {
+  it('shows unknown when lastActivity is 0', () => {
+    render(<WorkspaceDetailsActivity workspace={baseWorkspace} />);
+    expect(screen.getByTestId('lastActivity')).toHaveTextContent('unknown');
+  });
+
+  it('shows formatted date when lastActivity is set', () => {
+    const ws = {
+      ...baseWorkspace,
+      activity: { ...baseWorkspace.activity, lastActivity: 1_700_000_000_000 },
+    };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.getByTestId('lastActivity').textContent).not.toBe('unknown');
+  });
+
+  it('shows idle duration and culling countdown when running with culling config', () => {
+    const now = Date.now();
+    const ws: WorkspacesWorkspaceListItem = {
+      ...baseWorkspace,
+      state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+      workspaceKind: {
+        ...baseWorkspace.workspaceKind,
+        cullingConfig: { maxInactiveSeconds: 3600 },
+      },
+      activity: { lastActivity: now - 10 * 60 * 1000, lastUpdate: 0 },
+    };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.getByTestId('idleDuration')).toBeInTheDocument();
+    expect(screen.getByTestId('cullingCountdown')).toBeInTheDocument();
+  });
+
+  it('does not show idle duration when not running', () => {
+    const ws: WorkspacesWorkspaceListItem = {
+      ...baseWorkspace,
+      state: V1Beta1WorkspaceState.WorkspaceStatePaused,
+      workspaceKind: {
+        ...baseWorkspace.workspaceKind,
+        cullingConfig: { maxInactiveSeconds: 3600 },
+      },
+    };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.queryByTestId('idleDuration')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cullingCountdown')).not.toBeInTheDocument();
+  });
+
+  it('does not show idle duration when no culling config', () => {
+    const ws = {
+      ...baseWorkspace,
+      state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+    };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.queryByTestId('idleDuration')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cullingCountdown')).not.toBeInTheDocument();
+  });
+
+  it('shows probe result when lastProbe is present', () => {
+    const ws: WorkspacesWorkspaceListItem = {
+      ...baseWorkspace,
+      activity: {
+        lastActivity: 0,
+        lastUpdate: 0,
+        lastProbe: {
+          startTimeMs: 1_700_000_000_000,
+          endTimeMs: 1_700_000_001_000,
+          result: WorkspacesProbeResult.ProbeResultSuccess,
+          message: '',
+        },
+      },
+    };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.getByTestId('lastProbeResult')).toHaveTextContent('Success');
+    expect(screen.getByTestId('lastProbeTime')).toBeInTheDocument();
+  });
+
+  it('hides probe section when no lastProbe', () => {
+    render(<WorkspaceDetailsActivity workspace={baseWorkspace} />);
+    expect(screen.queryByTestId('lastProbeResult')).not.toBeInTheDocument();
+  });
+
+  it('shows probe message when non-empty', () => {
+    const ws: WorkspacesWorkspaceListItem = {
+      ...baseWorkspace,
+      activity: {
+        lastActivity: 0,
+        lastUpdate: 0,
+        lastProbe: {
+          startTimeMs: 1_700_000_000_000,
+          endTimeMs: 1_700_000_001_000,
+          result: WorkspacesProbeResult.ProbeResultFailure,
+          message: 'connection refused',
+        },
+      },
+    };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.getByTestId('lastProbeResult')).toHaveTextContent('connection refused');
+  });
+
+  it('shows pendingRestart as Yes/No', () => {
+    const ws = { ...baseWorkspace, pendingRestart: true };
+    render(<WorkspaceDetailsActivity workspace={ws} />);
+    expect(screen.getByTestId('pendingRestart')).toHaveTextContent('Yes');
+  });
+});

--- a/workspaces/frontend/src/generated/data-contracts.ts
+++ b/workspaces/frontend/src/generated/data-contracts.ts
@@ -4140,7 +4140,12 @@ export interface WorkspacesWorkspaceCreate {
   podTemplate: WorkspacesPodTemplateMutate;
 }
 
+export interface WorkspacesCullingConfig {
+  maxInactiveSeconds: number;
+}
+
 export interface WorkspacesWorkspaceKindInfo {
+  cullingConfig?: WorkspacesCullingConfig;
   icon: AssetsImageRef;
   logo: AssetsImageRef;
   missing: boolean;

--- a/workspaces/frontend/src/shared/utilities/cullingUtils.ts
+++ b/workspaces/frontend/src/shared/utilities/cullingUtils.ts
@@ -1,0 +1,45 @@
+import { WorkspacesWorkspaceListItem, V1Beta1WorkspaceState } from '~/generated/data-contracts';
+
+export type CullingWarningLevel = 'warning' | 'critical' | null;
+
+export const WARNING_THRESHOLD_MS = 15 * 60 * 1000;
+export const CRITICAL_THRESHOLD_MS = 5 * 60 * 1000;
+
+export function getMsUntilCull(workspace: WorkspacesWorkspaceListItem): number | null {
+  if (workspace.state !== V1Beta1WorkspaceState.WorkspaceStateRunning) {
+    return null;
+  }
+  const maxInactiveMs = (workspace.workspaceKind.cullingConfig?.maxInactiveSeconds ?? 0) * 1000;
+  if (!maxInactiveMs) {
+    return null;
+  }
+  // NOTE: activity.lastActivity is in milliseconds (consistent with the rest of the frontend,
+  // e.g. the "Last activity" column passes it directly to `new Date()`).
+  const lastActivityMs = workspace.activity.lastActivity;
+  return maxInactiveMs - (Date.now() - lastActivityMs);
+}
+
+export function getCullingWarningLevel(
+  workspace: WorkspacesWorkspaceListItem,
+): CullingWarningLevel {
+  const msUntilCull = getMsUntilCull(workspace);
+  if (msUntilCull === null) {
+    return null;
+  }
+  if (msUntilCull <= CRITICAL_THRESHOLD_MS) {
+    return 'critical';
+  }
+  if (msUntilCull <= WARNING_THRESHOLD_MS) {
+    return 'warning';
+  }
+  return null;
+}
+
+export function formatTimeUntilCull(workspace: WorkspacesWorkspaceListItem): string {
+  const msUntilCull = getMsUntilCull(workspace);
+  if (msUntilCull === null) {
+    return '';
+  }
+  const minutes = Math.ceil(Math.max(0, msUntilCull) / 60_000);
+  return `${minutes} min`;
+}


### PR DESCRIPTION
## Summary

Partially implements #1202 (remaining ACs blocked on #867, #1123, #868)

This PR delivers the backend model change and frontend scaffolding for workspace activity status display. Full acceptance-criteria compliance requires the upstream controller and CRD issues (#867, #1123) to merge first.

### What this PR does

**Backend**
- Add `CullingConfig` struct and `cullingConfig` field to `WorkspaceKindInfo` API model
- Populate via `buildCullingConfig()` from `wsk.Spec.PodTemplate.Culling`; returns `nil` when the WorkspaceKind is missing or culling is disabled; defaults `maxInactiveSeconds` to `86400` when unset
- Update OpenAPI schema (`swagger.json` + `docs.go`) with the new `workspaces.CullingConfig` type

**Frontend**
- Regenerate `data-contracts.ts` with `WorkspacesCullingConfig` and updated `WorkspacesWorkspaceKindInfo`
- Add `cullingUtils.ts` with `getMsUntilCull` and `formatTimeUntilCull` helpers
- Enhance `WorkspaceDetailsActivity` to show idle duration, auto-pause countdown, and last probe result — all conditionally rendered (only when workspace is Running and cullingConfig is present)
- Unit tests for `WorkspaceDetailsActivity` (9 tests)

### What is approximated / deferred

| Acceptance Criterion | Status |
|---|---|
| List view idle duration | ✅ existing `formatDistanceToNow` on Last Activity column |
| List view culling countdown | ⚠️ approximated as `lastActivity + maxInactiveSeconds − now`; exact `eligibleAfter` timestamp requires #867/#1123 |
| Detail view probe result (Success/Failure/Timeout) | ⚠️ UI is in place but backend hardcodes `LastProbe: nil` pending #867 |
| Human-readable relative time | ✅ `formatDistanceToNow` throughout |
| No activity UI without activity data | ✅ conditional rendering |
| Unit tests | ✅ 9 tests covering with/without activity data |
| Cypress tests for detail activity view | ❌ deferred until `lastProbe` is populated by the controller (#867) |

🛑 Depended on by: #1203 (frontend culling warning notifications)
🛑 Full implementation unblocked by: #867, #1123, #868

## Test plan

- [x] 7 unit tests for `buildCullingConfig()`: nil WSK, missing UID, disabled culling, absent culling field, custom value, default value, absent Enabled field
- [x] Handler integration test asserts `cullingConfig` present in JSON when culling is enabled
- [x] Handler integration test asserts `cullingConfig` absent when WorkspaceKind is missing
- [x] Full API envtest suite (110 specs) passes
- [x] 9 Jest unit tests for `WorkspaceDetailsActivity` (with/without culling config, probe results, running vs paused state)