### PR TITLE
feat: add Delete action to WorkspaceKinds page

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/workspaceKinds.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/workspaceKinds.ts
@@ -161,7 +161,10 @@ class WorkspaceKinds {
       .click();
   }
 
-  findAction(args: { action: 'view-details' | 'edit-workspace-kind'; workspaceKindName: string }) {
+  findAction(args: {
+    action: 'view-details' | 'edit-workspace-kind' | 'delete-workspace-kind';
+    workspaceKindName: string;
+  }) {
     this.openWorkspaceKindActionDropdown(args.workspaceKindName);
     return cy.findByTestId(`action-${args.action}`);
   }
@@ -250,5 +253,48 @@ class WorkspaceKindDetailsDrawer {
   }
 }
 
+class DeleteModal {
+  find() {
+    return cy.findByTestId('delete-modal');
+  }
+
+  findConfirmationInput() {
+    return this.find().findByTestId('delete-modal-input');
+  }
+
+  findSubmitButton() {
+    return this.find().findByTestId('delete-button');
+  }
+
+  findCancelButton() {
+    return this.find().findByTestId('cancel-button');
+  }
+
+  assertModalExists() {
+    this.find().should('exist');
+  }
+
+  assertModalNotExists() {
+    this.find().should('not.exist');
+  }
+
+  assertSubmitButtonDisabled() {
+    this.findSubmitButton().should('be.disabled');
+  }
+
+  assertSubmitButtonEnabled() {
+    this.findSubmitButton().should('not.be.disabled');
+  }
+
+  findErrorAlert() {
+    return this.find().findByTestId('delete-modal-error');
+  }
+
+  assertErrorAlertContainsMessage(message: string) {
+    this.find().findByTestId('delete-modal-error-message').should('have.text', message);
+  }
+}
+
 export const workspaceKinds = new WorkspaceKinds();
 export const workspaceKindDetailsDrawer = new WorkspaceKindDetailsDrawer();
+export const deleteModal = new DeleteModal();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -105,6 +105,11 @@ declare global {
           response: ApiWorkspaceKindEnvelope | ApiErrorEnvelope,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'DELETE /api/:apiVersion/workspacekinds/:kind',
+          options: { path: { apiVersion: string; kind: string } },
+          response: void | ApiErrorEnvelope,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'POST /api/:apiVersion/workspacekinds/:kind/podtemplate/options/listvalues',
           options: { path: { apiVersion: string; kind: string } },
           response: ApiPodTemplateOptionsEnvelope | ApiErrorEnvelope,

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/workspaceKinds.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/workspaceKinds.cy.ts
@@ -2,6 +2,7 @@ import { mockModArchResponse } from 'mod-arch-core';
 import {
   workspaceKinds,
   workspaceKindDetailsDrawer,
+  deleteModal,
 } from '~/__tests__/cypress/cypress/pages/workspaceKinds/workspaceKinds';
 import { buildMockWorkspaceKind, buildMockNamespace } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
@@ -838,6 +839,127 @@ describe('WorkspaceKinds', () => {
           .click();
 
         editWorkspaceKind.verifyPageURL(TEST_WORKSPACEKIND_NAME);
+      });
+    });
+
+    describe('Delete', () => {
+      const setupDeleteTest = (workspaceKindName: string) => {
+        setupWorkspaceKindActionTest(workspaceKindName);
+
+        cy.interceptApi(
+          'DELETE /api/:apiVersion/workspacekinds/:kind',
+          { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: workspaceKindName } },
+          undefined,
+        ).as('deleteWorkspaceKind');
+      };
+
+      it('should open delete modal from actions menu', () => {
+        setupDeleteTest(TEST_WORKSPACEKIND_NAME);
+
+        workspaceKinds
+          .findAction({
+            action: 'delete-workspace-kind',
+            workspaceKindName: TEST_WORKSPACEKIND_NAME,
+          })
+          .click();
+
+        deleteModal.assertModalExists();
+      });
+
+      it('should successfully delete a workspace kind with correct confirmation', () => {
+        setupDeleteTest(TEST_WORKSPACEKIND_NAME);
+
+        workspaceKinds
+          .findAction({
+            action: 'delete-workspace-kind',
+            workspaceKindName: TEST_WORKSPACEKIND_NAME,
+          })
+          .click();
+
+        deleteModal.findConfirmationInput().type(TEST_WORKSPACEKIND_NAME);
+        deleteModal.findSubmitButton().click();
+
+        cy.wait('@deleteWorkspaceKind').then((interception) => {
+          expect(interception.response?.statusCode).to.be.equal(200);
+        });
+
+        deleteModal.assertModalNotExists();
+      });
+
+      it('should cancel workspace kind deletion when cancel button is clicked', () => {
+        setupDeleteTest(TEST_WORKSPACEKIND_NAME);
+
+        workspaceKinds
+          .findAction({
+            action: 'delete-workspace-kind',
+            workspaceKindName: TEST_WORKSPACEKIND_NAME,
+          })
+          .click();
+
+        deleteModal.findCancelButton().click();
+        deleteModal.assertModalNotExists();
+        cy.get('@deleteWorkspaceKind.all').should('have.length', 0);
+      });
+
+      it('should disable delete button when confirmation input is incorrect', () => {
+        setupDeleteTest(TEST_WORKSPACEKIND_NAME);
+
+        workspaceKinds
+          .findAction({
+            action: 'delete-workspace-kind',
+            workspaceKindName: TEST_WORKSPACEKIND_NAME,
+          })
+          .click();
+
+        deleteModal.findConfirmationInput().type('wrong-name');
+        deleteModal.assertSubmitButtonDisabled();
+      });
+
+      it('should enable delete button after correcting confirmation input', () => {
+        setupDeleteTest(TEST_WORKSPACEKIND_NAME);
+
+        workspaceKinds
+          .findAction({
+            action: 'delete-workspace-kind',
+            workspaceKindName: TEST_WORKSPACEKIND_NAME,
+          })
+          .click();
+
+        deleteModal.findConfirmationInput().type('wrong-name');
+        deleteModal.assertSubmitButtonDisabled();
+
+        deleteModal.findConfirmationInput().clear().type(TEST_WORKSPACEKIND_NAME);
+        deleteModal.assertSubmitButtonEnabled();
+      });
+
+      it('should display error when delete fails', () => {
+        setupWorkspaceKindActionTest(TEST_WORKSPACEKIND_NAME);
+
+        cy.interceptApi(
+          'DELETE /api/:apiVersion/workspacekinds/:kind',
+          { path: { apiVersion: NOTEBOOKS_API_VERSION, kind: TEST_WORKSPACEKIND_NAME } },
+          {
+            error: {
+              code: '500',
+              message: 'Internal server error',
+            },
+          },
+        ).as('deleteWorkspaceKindError');
+
+        workspaceKinds
+          .findAction({
+            action: 'delete-workspace-kind',
+            workspaceKindName: TEST_WORKSPACEKIND_NAME,
+          })
+          .click();
+
+        deleteModal.findConfirmationInput().type(TEST_WORKSPACEKIND_NAME);
+        deleteModal.findSubmitButton().click();
+
+        cy.wait('@deleteWorkspaceKindError');
+
+        deleteModal.assertModalExists();
+        deleteModal.findErrorAlert().should('exist');
       });
     });
   });

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/WorkspaceKinds.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/WorkspaceKinds.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNotification } from 'mod-arch-core';
 import {
   Drawer,
   DrawerContent,
@@ -27,6 +28,8 @@ import {
   IActions,
 } from '@patternfly/react-table/dist/esm/components/Table';
 import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import DeleteModal from '~/shared/components/DeleteModal';
 import { useWorkspaceCountPerKind } from '~/app/hooks/useWorkspaceCountPerKind';
 import { WorkspaceKindsColumns } from '~/app/types';
 import CustomEmptyState from '~/shared/components/CustomEmptyState';
@@ -48,6 +51,7 @@ import { WorkspaceKindDetails } from './details/WorkspaceKindDetails';
 
 export enum ActionType {
   ViewDetails,
+  Delete,
 }
 
 const filterConfig = {
@@ -90,6 +94,8 @@ export const WorkspaceKinds: React.FunctionComponent = () => {
   const createWorkspaceKind = useCallback(() => {
     navigate('workspaceKindCreate');
   }, [navigate]);
+  const { api, refreshAllAPI } = useNotebookAPI();
+  const notification = useNotification();
   const [workspaceKinds, workspaceKindsLoaded, workspaceKindsError] = useWorkspaceKinds();
   const workspaceCountResult = useWorkspaceCountPerKind();
   const [selectedWorkspaceKind, setSelectedWorkspaceKind] =
@@ -216,6 +222,25 @@ export const WorkspaceKinds: React.FunctionComponent = () => {
     setActiveActionType(ActionType.ViewDetails);
   }, []);
 
+  const deleteClick = useCallback((workspaceKind: WorkspacekindsWorkspaceKindListItem) => {
+    setSelectedWorkspaceKind(workspaceKind);
+    setActiveActionType(ActionType.Delete);
+  }, []);
+
+  const closeDeleteModal = useCallback(() => {
+    setSelectedWorkspaceKind(null);
+    setActiveActionType(null);
+  }, []);
+
+  const executeDelete = useCallback(
+    async (workspaceKindName: string) => {
+      await api.workspaceKinds.deleteWorkspaceKind(workspaceKindName);
+      notification.info(`Workspace kind '${workspaceKindName}' deleted successfully`);
+      refreshAllAPI();
+    },
+    [api, notification, refreshAllAPI],
+  );
+
   const workspaceKindsDefaultActions = useCallback(
     (workspaceKind: WorkspacekindsWorkspaceKindListItem): IActions => [
       {
@@ -232,8 +257,13 @@ export const WorkspaceKinds: React.FunctionComponent = () => {
             state: { workspaceKindName: workspaceKind.name },
           }),
       },
+      {
+        id: 'delete-workspace-kind',
+        title: 'Delete',
+        onClick: () => deleteClick(workspaceKind),
+      },
     ],
-    [navigate, viewDetailsClick],
+    [navigate, viewDetailsClick, deleteClick],
   );
 
   const workspaceDetailsContent = (
@@ -453,6 +483,23 @@ export const WorkspaceKinds: React.FunctionComponent = () => {
           </PageSection>
         </DrawerContentBody>
       </DrawerContent>
+      {selectedWorkspaceKind && activeActionType === ActionType.Delete && (
+        <DeleteModal
+          isOpen
+          resourceName={selectedWorkspaceKind.name}
+          title="Delete workspace kind?"
+          errorTitle="Failed to delete workspace kind"
+          message={
+            <>
+              Deleting workspace kind <strong>{selectedWorkspaceKind.name}</strong> is a destructive
+              and cluster wide action that cannot be undone. All associated configuration will be
+              permanently removed.
+            </>
+          }
+          onClose={closeDeleteModal}
+          onDelete={executeDelete}
+        />
+      )}
     </Drawer>
   );
 };

--- a/workspaces/frontend/src/shared/components/DeleteModal.tsx
+++ b/workspaces/frontend/src/shared/components/DeleteModal.tsx
@@ -22,10 +22,12 @@ import { ApiErrorEnvelope } from '~/generated/data-contracts';
 interface DeleteModalProps {
   isOpen: boolean;
   resourceName: string;
-  namespace: string;
+  namespace?: string;
   onClose: () => void;
   onDelete: (resourceName: string) => Promise<void>;
   title: string;
+  errorTitle?: string;
+  message?: React.ReactNode;
 }
 
 const DeleteModal: React.FC<DeleteModalProps> = ({
@@ -33,6 +35,8 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
   resourceName,
   namespace,
   title,
+  errorTitle = 'Failed to delete workspace',
+  message,
   onClose,
   onDelete,
 }) => {
@@ -84,16 +88,22 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
         <Stack hasGutter={!isMUITheme}>
           {error && (
             <StackItem>
-              <ErrorAlert
-                title="Failed to delete workspace"
-                content={error}
-                testId="delete-modal-error"
-              />
+              <ErrorAlert title={errorTitle} content={error} testId="delete-modal-error" />
             </StackItem>
           )}
           <StackItem>
-            Are you sure you want to delete <strong>{resourceName}</strong> in namespace{' '}
-            <strong>{namespace}</strong>?
+            {message || (
+              <>
+                Are you sure you want to delete <strong>{resourceName}</strong>
+                {namespace && (
+                  <>
+                    {' '}
+                    in namespace <strong>{namespace}</strong>
+                  </>
+                )}
+                ?
+              </>
+            )}
           </StackItem>
           <StackItem>
             <Form


### PR DESCRIPTION
Closes: #1210
related: #480

#### DeleteModal (src/shared/components/DeleteModal.tsx)
  - Make namespace prop optional — conditionally renders "in namespace" text only when provided
  - Add optional message prop for custom body text (replaces the default confirmation message)
  - Add optional errorTitle prop (defaults to existing behavior for backward compatibility)

####  WorkspaceKinds page (src/app/pages/WorkspaceKinds/WorkspaceKinds.tsx)
  - Add Delete to the ActionType enum
  - Add "Delete" item to the kebab actions menu
  - Wire up DeleteModal with a destructive-action warning message
  - Call deleteWorkspaceKind API on confirmation, show success notification, and refresh data via refreshAllAPI()

 #### Cypress infrastructure
  - Add DELETE /api/:apiVersion/workspacekinds/:kind interceptor type to api.ts
  - Add DeleteModal page object class and 'delete-workspace-kind' action to the workspace kinds page object
  - Add 6 Cypress tests: modal open, successful delete, cancel, disabled button on wrong input, re-enable on correction, error display on API failure
  
 
<img width="620" height="416" alt="Screenshot 2026-06-22 at 3 12 11 PM" src="https://github.com/user-attachments/assets/80b23f1e-8a37-4cbd-b8cd-8214254690bb" />
