### PR TITLE
chore: Update the `notebooks-v1` OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,7 @@
 labels:
   - area/v1
 approvers:
-  - kimwnasptd
+  - andyatmiami
   - thesuperzapper
+emeritus_approvers:
+  - kimwnasptd

--- a/components/crud-web-apps/OWNERS
+++ b/components/crud-web-apps/OWNERS
@@ -2,8 +2,8 @@ labels:
   - area/frontend
   - area/backend
 approvers:
-  - kimwnasptd
   - thesuperzapper
 emeritus_approvers:
   - elikatsis
+  - kimwnasptd
   - StefanoFioravanzo

--- a/components/crud-web-apps/common/frontend/OWNERS
+++ b/components/crud-web-apps/common/frontend/OWNERS
@@ -1,5 +1,4 @@
-approvers:
+emeritus_approvers:
   - elenzio9
   - orfeas-k
-emeritus_approvers:
   - tasos-ale

--- a/components/crud-web-apps/jupyter/frontend/OWNERS
+++ b/components/crud-web-apps/jupyter/frontend/OWNERS
@@ -1,5 +1,5 @@
-approvers:
+emeritus_approvers:
   - elenzio9
   - orfeas-k
-emeritus_approvers:
   - tasos-ale
+

--- a/components/crud-web-apps/jupyter/frontend/i18n/fr/OWNERS
+++ b/components/crud-web-apps/jupyter/frontend/i18n/fr/OWNERS
@@ -1,4 +1,3 @@
-approvers:
+emeritus_approvers:
   - Jose-Matsuda
   - wg102
-reviewers:

--- a/components/crud-web-apps/tensorboards/frontend/OWNERS
+++ b/components/crud-web-apps/tensorboards/frontend/OWNERS
@@ -1,5 +1,4 @@
-approvers:
+emeritus_approvers:
   - elenzio9
   - orfeas-k
-emeritus_approvers:
   - tasos-ale

--- a/components/crud-web-apps/tensorboards/frontend/i18n/fr/OWNERS
+++ b/components/crud-web-apps/tensorboards/frontend/i18n/fr/OWNERS
@@ -1,4 +1,3 @@
-approvers:
+emeritus_approvers:
   - Jose-Matsuda
   - wg102
-reviewers:

--- a/components/crud-web-apps/volumes/frontend/OWNERS
+++ b/components/crud-web-apps/volumes/frontend/OWNERS
@@ -1,5 +1,4 @@
-approvers:
+emeritus_approvers:
   - elenzio9
   - orfeas-k
-emeritus_approvers:
   - tasos-ale

--- a/components/crud-web-apps/volumes/frontend/i18n/fr/OWNERS
+++ b/components/crud-web-apps/volumes/frontend/i18n/fr/OWNERS
@@ -1,4 +1,3 @@
-approvers:
+emeritus_approvers:
   - Jose-Matsuda
   - wg102
-reviewers:

--- a/components/example-notebook-servers/OWNERS
+++ b/components/example-notebook-servers/OWNERS
@@ -1,9 +1,9 @@
 labels:
   - area/server-images
 approvers:
-  - kimwnasptd
   - thesuperzapper
 emeritus_approvers:
   - DavidSpek
   - elikatsis
+  - kimwnasptd
   - StefanoFioravanzo

--- a/components/notebook-controller/OWNERS
+++ b/components/notebook-controller/OWNERS
@@ -1,9 +1,9 @@
 labels:
   - area/controller
 approvers:
-  - kimwnasptd
   - thesuperzapper
 emeritus_approvers:
   - elikatsis
+  - kimwnasptd
   - StefanoFioravanzo
   - yanniszark

--- a/components/pvcviewer-controller/OWNERS
+++ b/components/pvcviewer-controller/OWNERS
@@ -1,6 +1,6 @@
 labels:
   - area/controller
-approvers:
+emeritus_approvers:
   - apo-ger
   - kimwnasptd
   - TobiasGoerke


### PR DESCRIPTION
This removes Kimonas as approver and adds Andy in accordance
to the governance changes in the Notebooks WG.

Related-to: https://github.com/kubeflow/community/pull/983
