### PR TITLE
feat: add `ENABLE_KCD_COMPONENTS` option to tiltfile

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -123,6 +123,17 @@ What this does:
 > ENABLE_FRONTEND=false make tilt-up
 > ```
 
+> [!TIP]
+>
+> To deploy with Kubeflow Community Distribution (KCD) components — dex, oauth2-proxy, and the Kubeflow Central Dashboard — set `ENABLE_KCD_COMPONENTS=true`:
+>
+> ```bash
+> ENABLE_KCD_COMPONENTS=true make tilt-up
+> ```
+>
+> This mirrors the upstream community distribution setup and lets you test authentication and dashboard integration locally.
+> See [Tilt - Community Distribution Setup](#tilt---community-distribution-setup) for details.
+
 Wait until all resources show green/healthy status. 
 The frontend may take a couple of minutes on first start as webpack compiles the bundle.
 
@@ -170,6 +181,33 @@ kubectl auth can-i --list --as=user -n default | grep -E '^Resources|^\S'
 >
 > You can switch between users from the **Debug** page in the frontend UI.
 > The default user is `admin`. Switch to `user` to test non-admin behavior (e.g., namespace-scoped permissions, 403 responses on admin-only pages).
+
+### Tilt - Community Distribution Setup
+
+Setting `ENABLE_KCD_COMPONENTS=true` installs the following components from the [Kubeflow Community Distribution](https://github.com/kubeflow/community-distribution) (release `26.03.1`) into the Kind cluster before Tilt starts:
+
+| Component | Namespace | Purpose |
+|-----------|-----------|---------|
+| [dex](https://github.com/dexidp/dex) | `auth` | OIDC identity provider |
+| [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) | `oauth2-proxy` | Authentication proxy in front of the Istio gateway |
+| [Kubeflow Central Dashboard](https://github.com/kubeflow/dashboard) | `kubeflow` | Top-level Kubeflow UI, accessible at `https://localhost:8443/` |
+
+These components are installed once by `make setup-kcd` and are **not** hot-reloaded by Tilt.
+
+**Login credentials** (KCD static password defaults):
+
+| Field | Value |
+|-------|-------|
+| Email | `user@example.com` |
+| Password | `12341234` |
+
+After a successful login, the Kubeflow Central Dashboard is available at `https://localhost:8443/`.
+The Workspaces UI remains at `https://localhost:8443/workspaces/` (if the frontend is enabled).
+
+> [!NOTE]
+>
+> With KCD enabled, **all** traffic through the Istio gateway requires authentication via dex/oauth2-proxy.
+> The "Debug" menu in the Workspaces frontend (used in non-KCD mode for setting `kubeflow-userid` manually) is superseded by the real OIDC login flow.
 
 ### Tilt - Access Logging
 

--- a/developing/Makefile
+++ b/developing/Makefile
@@ -48,9 +48,19 @@ setup-istio: setup-cert-manager
 	@echo "Setting up Istio..."
 	@./scripts/setup-istio.sh
 
+# Install Kubeflow Community Distribution components: dex, oauth2-proxy, and central dashboard.
+# Only invoked when ENABLE_KCD_COMPONENTS=true.
+.PHONY: setup-kcd
+setup-kcd: setup-istio kustomize
+	@echo "Setting up Kubeflow Community Distribution (KCD) components..."
+	@./scripts/setup-kcd.sh
+
 # Run tilt up with kind cluster, cert-manager, and Istio setup
 .PHONY: tilt-up
 tilt-up: check-tilt setup-istio kustomize
+ifeq ($(ENABLE_KCD_COMPONENTS),true)
+	@$(MAKE) setup-kcd
+endif
 	@echo "Starting Tilt..."
 	@tilt up
 

--- a/developing/Tiltfile
+++ b/developing/Tiltfile
@@ -13,6 +13,10 @@ allow_k8s_contexts('kind-tilt')
 # Allow skipping frontend via environment variable
 enable_frontend = os.getenv("ENABLE_FRONTEND", "true").lower() == "true"
 
+# Allow enabling Kubeflow Community Distribution components (dex, oauth2-proxy, dashboard)
+# via environment variable. These are installed by the Makefile before Tilt starts.
+enable_kcd = os.getenv("ENABLE_KCD_COMPONENTS", "false").lower() == "true"
+
 # Get paths relative to Tiltfile location
 # Tilt evaluates paths relative to the Tiltfile directory
 tilt_root = os.path.dirname(os.path.abspath(__file__))
@@ -323,6 +327,8 @@ k8s_resource(
 gateway_links = [link("https://localhost:8443/workspaces/api/v1/swagger/index.html", "API (Backend)")]
 if enable_frontend:
     gateway_links.insert(0, link("https://localhost:8443/workspaces/", "Dashboard (Frontend)"))
+if enable_kcd:
+    gateway_links.insert(0, link("https://localhost:8443/", "Kubeflow Dashboard (KCD)"))
 
 
 local_resource(
@@ -332,3 +338,31 @@ local_resource(
     links=gateway_links,
     labels=["istio"],
 )
+
+
+# ============================================================================
+# Kubeflow Community Distribution (optional)
+# ============================================================================
+# KCD components (dex, oauth2-proxy, central dashboard) are installed by the
+# Makefile via scripts/setup-kcd.sh before Tilt starts — they are not built
+# or hot-reloaded by Tilt. This section only adds Tilt UI visibility.
+#
+# Login credentials (KCD static password defaults):
+#   Email:    user@example.com
+#   Password: 12341234
+
+if enable_kcd:
+    # KCD components are installed by setup-kcd.sh before Tilt starts and are not
+    # managed by Tilt. This resource waits until the auth layer is healthy so that
+    # the link in the Tilt UI is only shown as ready once login actually works.
+    local_resource(
+        "kcd-ready",
+        # TODO(chris): This does not yet seem right
+        cmd=" && ".join([
+            "kubectl wait --for=condition=available deployment/dex -n auth --timeout=180s",
+            "kubectl wait --for=condition=available deployment/oauth2-proxy -n oauth2-proxy --timeout=180s",
+            "kubectl wait --for=condition=available deployment/dashboard -n kubeflow --timeout=180s",
+        ]),
+        links=[link("https://localhost:8443/", "Kubeflow Dashboard (KCD) — user@example.com / 12341234")],
+        labels=["kcd"],
+    )

--- a/developing/manifests/kcd/kustomization.yaml
+++ b/developing/manifests/kcd/kustomization.yaml
@@ -1,0 +1,54 @@
+# Kubeflow Community Distribution (KCD) components for local development.
+# All resources are pinned to release 26.03.1 of kubeflow/community-distribution.
+# https://github.com/kubeflow/community-distribution/releases/tag/26.03.1
+#
+# NOTE: kubeflow-istio-resources is intentionally omitted — it defines an HTTP-only
+# kubeflow-gateway that conflicts with the HTTPS gateway managed by Tilt.
+# The gateway itself is provided by developing/manifests/istio-gateway/.
+# The kubeflow-istio-resources cluster roles are not required for the basic dev experience.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Ensure CRDs are applied before CRs.
+sortOptions:
+  order: legacy
+  legacySortOptions:
+    orderFirst:
+    - Namespace
+    - ResourceQuota
+    - StorageClass
+    - CustomResourceDefinition
+    - MutatingWebhookConfiguration
+    - ServiceAccount
+    - PodSecurityPolicy
+    - NetworkPolicy
+    - Role
+    - ClusterRole
+    - RoleBinding
+    - ClusterRoleBinding
+    - ConfigMap
+    - Secret
+    - Endpoints
+    - Service
+    - LimitRange
+    - PriorityClass
+    - PersistentVolume
+    - PersistentVolumeClaim
+    - Deployment
+    - StatefulSet
+    - CronJob
+    - PodDisruptionBudget
+    orderLast:
+    - ValidatingWebhookConfiguration
+
+resources:
+# kubeflow and kubeflow-system namespaces
+- github.com/kubeflow/community-distribution/common/kubeflow-namespace/base?ref=26.03.1
+# Kubeflow aggregate ClusterRoles (admin, edit, view)
+- github.com/kubeflow/community-distribution/common/kubeflow-roles/base?ref=26.03.1
+# Dex OIDC provider (auth namespace, configured for oauth2-proxy)
+- github.com/kubeflow/community-distribution/common/dex/overlays/oauth2-proxy?ref=26.03.1
+# oauth2-proxy with KinD M2M token support (allows Kubernetes SA JWTs at the gateway)
+- github.com/kubeflow/community-distribution/common/oauth2-proxy/overlays/m2m-dex-and-kind?ref=26.03.1
+# Central Dashboard with profile-controller and poddefaults-webhooks
+- github.com/kubeflow/community-distribution/applications/dashboard/overlays/istio?ref=26.03.1

--- a/developing/scripts/setup-kcd.sh
+++ b/developing/scripts/setup-kcd.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Setup script for Kubeflow Community Distribution (KCD) components.
+#
+# Installs dex, oauth2-proxy, and the Kubeflow Central Dashboard into the
+# local Kind cluster, mirroring the upstream community distribution layout.
+# Pinned to release 26.03.1 of github.com/kubeflow/community-distribution.
+#
+# Default login credentials (from KCD static password config):
+#   Email:    user@example.com
+#   Password: 12341234
+#
+# This script is idempotent: re-running it on an existing cluster is safe.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVELOPING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCALBIN="${DEVELOPING_DIR}/bin"
+KUSTOMIZE="${LOCALBIN}/kustomize"
+
+KCD_VERSION="26.03.1"
+
+if [[ ! -f "${KUSTOMIZE}" ]]; then
+  echo "ERROR: kustomize not found at ${KUSTOMIZE}. Run 'make kustomize' first."
+  exit 1
+fi
+
+echo "INFO: Installing KCD ${KCD_VERSION} components (dex, oauth2-proxy, dashboard)..."
+echo "INFO: Downloading and applying manifests (this may take a moment on first run)..."
+
+# Apply the main KCD components.
+# NOTE: server-side apply avoids field ownership conflicts when kustomize-managed
+# resources also appear in Tilt's resource list (e.g. the kubeflow namespace).
+"${KUSTOMIZE}" build "${DEVELOPING_DIR}/manifests/kcd" \
+  | kubectl apply --server-side -f -
+
+# Wait for the auth layer to be ready.
+echo "INFO: Waiting for dex to be ready..."
+kubectl wait --for=condition=available deployment/dex \
+  --namespace=auth --timeout=180s
+
+echo "INFO: Waiting for oauth2-proxy to be ready..."
+kubectl wait --for=condition=available deployment/oauth2-proxy \
+  --namespace=oauth2-proxy --timeout=180s
+
+# Wait for dashboard components.
+echo "INFO: Waiting for profile-controller to be ready..."
+kubectl wait --for=condition=available deployment/profiles-deployment \
+  --namespace=kubeflow --timeout=180s
+
+echo "INFO: Waiting for centraldashboard to be ready..."
+kubectl wait --for=condition=available deployment/dashboard \
+  --namespace=kubeflow --timeout=180s
+
+# Create the default user profile.
+# This is applied after the profile-controller is ready to ensure the
+# profiles.kubeflow.org CRD is established before creating the Profile CR.
+echo "INFO: Creating default user profile (user@example.com)..."
+kubectl apply --server-side -f - <<EOF
+apiVersion: kubeflow.org/v1beta1
+kind: Profile
+metadata:
+  name: kubeflow-user-example-com
+spec:
+  owner:
+    kind: User
+    name: user@example.com
+EOF
+
+echo ""
+echo "INFO: Kubeflow Community Distribution tilt setup complete."
+echo ""
+echo "  Login at: https://localhost:8443/"
+echo "  Email:    user@example.com"
+echo "  Password: 12341234"
+echo ""


### PR DESCRIPTION
Adds an optional `ENABLE_KCD_COMPONENTS=true` flag to `make tilt-up` that
installs Kubeflow Community Distribution components (dex, oauth2-proxy,
central dashboard) from a pinned release before Tilt starts.

This lets developers develop and reproduce bugs against the upstream
community distributions auth and dashboard setup without losing the
nice DevX around the Tilt workflow.

Related to #1205 

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
