### PR TITLE
feat: UI improvements for WorkspaceForm and WorkspaceTable

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/volumesManagement.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/volumesManagement.ts
@@ -254,16 +254,17 @@ class VolumesCreateModal {
   }
 
   // Access Mode
-  findAccessModeRadio(mode: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId(`access-mode-${mode}`);
+  findAccessModeSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('access-mode-select');
   }
 
-  selectAccessMode(mode: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findAccessModeRadio(mode).click({ force: true });
+  selectAccessMode(mode: string): void {
+    this.findAccessModeSelect().click();
+    cy.findByTestId(`access-mode-option-${mode}`).click();
   }
 
-  assertAccessModeChecked(mode: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findAccessModeRadio(mode).should('be.checked');
+  assertAccessModeSelected(mode: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findAccessModeSelect().should('contain.text', mode);
   }
 
   // Read-only Switch
@@ -273,6 +274,14 @@ class VolumesCreateModal {
 
   toggleReadOnly(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findReadOnlySwitch().click({ force: true });
+  }
+
+  assertReadOnlySwitchExists(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findReadOnlySwitch().should('exist');
+  }
+
+  assertReadOnlySwitchNotExists(): void {
+    cy.findByTestId('read-only-switch').should('not.exist');
   }
 
   // Error Alert

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/volumesManagement.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/volumesManagement.ts
@@ -79,9 +79,25 @@ class VolumesManagementPage {
     return this.findCreateVolumeButton().click();
   }
 
+  // Home Volume Table
+  findHomeVolumesTable(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findAllByTestId('volumes-table').filter(':visible').first();
+  }
+
+  findHomeVolumeRow(mountPath: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findHomeVolumesTable().contains('tr', mountPath) as unknown as Cypress.Chainable<
+      JQuery<HTMLElement>
+    >;
+  }
+
+  clickHomeVolumeEditAction(mountPath: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    this.findHomeVolumesTable().findByTestId(`volume-kebab-${mountPath}`).click();
+    return cy.findByTestId(`edit-volume-${mountPath}`).click();
+  }
+
   // Row Actions
   openRowKebabMenu(pvcName: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findVolumeRow(pvcName).find('[aria-label="plain kebab"]').click();
+    return this.findVolumeRow(pvcName).findByTestId(`volume-kebab-${pvcName}`).click();
   }
 
   clickDetachAction(pvcName: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
@@ -261,7 +261,7 @@ describe('Volumes Management - Attach and Create', () => {
       volumesManagement.clickCreateVolume();
       volumesCreateModal.assertModalVisible();
 
-      volumesCreateModal.assertAccessModeChecked('ReadWriteOnce');
+      volumesCreateModal.assertAccessModeSelected('ReadWriteOnce (RWO)');
     });
 
     it('should create a volume and display it in the table', () => {
@@ -328,7 +328,7 @@ describe('Volumes Management - Attach and Create', () => {
       volumesCreateModal.assertModalVisible();
 
       volumesCreateModal.selectAccessMode('ReadWriteMany');
-      volumesCreateModal.assertAccessModeChecked('ReadWriteMany');
+      volumesCreateModal.assertAccessModeSelected('ReadWriteMany (RWX)');
     });
 
     it('should allow selecting a different storage class', () => {
@@ -419,6 +419,28 @@ describe('Volumes Management - Attach and Create', () => {
 
       volumesCreateModal.assertModalNotExists();
       volumesManagement.assertVolumeReadOnly('data-pvc', false);
+    });
+  });
+
+  describe('Read-only toggle visibility', () => {
+    it('should show read-only toggle when creating a data volume', () => {
+      volumesManagement.clickCreateVolume();
+      volumesCreateModal.assertModalVisible();
+
+      volumesCreateModal.assertReadOnlySwitchExists();
+      volumesCreateModal.clickCancel();
+    });
+
+    it('should hide read-only toggle when editing a home volume', () => {
+      // The Home Volume section is always expanded above the Data Volumes section.
+      // The mock workspace update returns the mount path as the home PVC identifier,
+      // which the form reconstructs as pvcName.
+      cy.findAllByTestId('volumes-table').first().find('[aria-label="plain kebab"]').click();
+      cy.findByTestId('edit-volume-/home').click();
+      volumesCreateModal.assertModalVisible();
+
+      volumesCreateModal.assertReadOnlySwitchNotExists();
+      volumesCreateModal.clickCancel();
     });
   });
 });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
@@ -432,11 +432,7 @@ describe('Volumes Management - Attach and Create', () => {
     });
 
     it('should hide read-only toggle when editing a home volume', () => {
-      // The Home Volume section is always expanded above the Data Volumes section.
-      // The mock workspace update returns the mount path as the home PVC identifier,
-      // which the form reconstructs as pvcName.
-      cy.findAllByTestId('volumes-table').first().find('[aria-label="plain kebab"]').click();
-      cy.findByTestId('edit-volume-/home').click();
+      volumesManagement.clickHomeVolumeEditAction('/home');
       volumesCreateModal.assertModalVisible();
 
       volumesCreateModal.assertReadOnlySwitchNotExists();

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -474,9 +474,11 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               {columnKey === 'namespace' && workspace.namespace}
                               {columnKey === 'state' && (
                                 <div className="pf-v6-u-display-inline-block">
-                                  <Label color={extractWorkspaceStateColor(workspace.state)}>
-                                    {workspace.state}
-                                  </Label>
+                                  <Tooltip content={workspace.stateMessage}>
+                                    <Label color={extractWorkspaceStateColor(workspace.state)}>
+                                      {workspace.state}
+                                    </Label>
+                                  </Tooltip>
                                 </div>
                               )}
                               {columnKey === 'gpu' && formatResourceFromWorkspace(workspace, 'gpu')}

--- a/workspaces/frontend/src/app/hooks/useVolumesFormState.ts
+++ b/workspaces/frontend/src/app/hooks/useVolumesFormState.ts
@@ -76,6 +76,8 @@ interface UseVolumesFormStateResult {
   isMountPathEditing: boolean;
   isStorageClassOpen: boolean;
   setIsStorageClassOpen: Dispatch<SetStateAction<boolean>>;
+  isAccessModeOpen: boolean;
+  setIsAccessModeOpen: Dispatch<SetStateAction<boolean>>;
   isSubmitting: boolean;
   error: string | ApiErrorEnvelope | null;
   setError: Dispatch<SetStateAction<string | ApiErrorEnvelope | null>>;
@@ -117,6 +119,7 @@ const useVolumesFormState = ({
   const [readOnly, setReadOnly] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isStorageClassOpen, setIsStorageClassOpen] = useState(false);
+  const [isAccessModeOpen, setIsAccessModeOpen] = useState(false);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
 
   useEffect(() => {
@@ -137,6 +140,7 @@ const useVolumesFormState = ({
       setIsMountPathEditing(false);
       setIsSubmitting(false);
       setIsStorageClassOpen(false);
+      setIsAccessModeOpen(false);
       setError(storageClassLoadError);
     }
   }, [isOpen, fixedMountPath, isEditMode, volumeToEdit, storageClasses, storageClassLoadError]);
@@ -249,6 +253,8 @@ const useVolumesFormState = ({
     isMountPathEditing,
     isStorageClassOpen,
     setIsStorageClassOpen,
+    isAccessModeOpen,
+    setIsAccessModeOpen,
     isSubmitting,
     error,
     setError,

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes.tsx
@@ -382,6 +382,7 @@ export const WorkspaceFormPropertiesVolumes: React.FC<WorkspaceFormPropertiesVol
                             onClick={() => setDropdownOpen(dropdownOpen === index ? null : index)}
                             variant="plain"
                             aria-label="plain kebab"
+                            data-testid={`volume-kebab-${volume.pvcName}`}
                           >
                             <EllipsisVIcon />
                           </MenuToggle>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/volumes/VolumesAttachModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/volumes/VolumesAttachModal.tsx
@@ -234,28 +234,30 @@ export const VolumesAttachModal: React.FC<VolumesAttachModalProps> = ({
                   isFixed={!!fixedMountPath}
                   fieldId="pvc-mount-path"
                 />
-                <ThemeAwareFormGroupWrapper
-                  label="Read-only Access"
-                  fieldId="pvc-read-only"
-                  skipFieldset
-                  labelHelp={
-                    <Popover
-                      headerContent="Read-only access"
-                      bodyContent="Mount the volume as read-only when this workspace only needs to read data. This prevents accidental or unintended writes to shared volumes."
-                    >
-                      <OutlinedQuestionCircleIcon />
-                    </Popover>
-                  }
-                >
-                  <Switch
-                    id="pvc-read-only-switch"
-                    data-testid="pvc-read-only-switch"
-                    label="Enabled"
-                    hasCheckIcon
-                    isChecked={readOnly}
-                    onChange={(_ev, checked) => setReadOnly(checked)}
-                  />
-                </ThemeAwareFormGroupWrapper>
+                {!fixedMountPath && (
+                  <ThemeAwareFormGroupWrapper
+                    label="Read-only Access"
+                    fieldId="pvc-read-only"
+                    skipFieldset
+                    labelHelp={
+                      <Popover
+                        headerContent="Read-only access"
+                        bodyContent="Mount the volume as read-only when this workspace only needs to read data. This prevents accidental or unintended writes to shared volumes."
+                      >
+                        <OutlinedQuestionCircleIcon />
+                      </Popover>
+                    }
+                  >
+                    <Switch
+                      id="pvc-read-only-switch"
+                      data-testid="pvc-read-only-switch"
+                      label="Enabled"
+                      hasCheckIcon
+                      isChecked={readOnly}
+                      onChange={(_ev, checked) => setReadOnly(checked)}
+                    />
+                  </ThemeAwareFormGroupWrapper>
+                )}
               </Form>
             </StackItem>
           </Stack>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/properties/volumes/VolumesCreateModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/properties/volumes/VolumesCreateModal.tsx
@@ -20,10 +20,9 @@ import {
   ModalHeader,
   ModalVariant,
 } from '@patternfly/react-core/dist/esm/components/Modal';
-import { Radio } from '@patternfly/react-core/dist/esm/components/Radio';
+
 import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
 import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
-import { List, ListItem } from '@patternfly/react-core/dist/esm/components/List';
 import { Popover } from '@patternfly/react-core/dist/esm/components/Popover';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
@@ -38,10 +37,26 @@ import { ResourceInputWrapper } from '~/shared/components/ResourceInputWrapper';
 import { MountPathField } from '~/app/pages/Workspaces/Form/MountPathField';
 
 const ACCESS_MODES = [
-  { label: 'ReadWriteOnce (RWO)', value: V1PersistentVolumeAccessMode.ReadWriteOnce },
-  { label: 'ReadWriteMany (RWX)', value: V1PersistentVolumeAccessMode.ReadWriteMany },
-  { label: 'ReadOnlyMany (ROX)', value: V1PersistentVolumeAccessMode.ReadOnlyMany },
-  { label: 'ReadWriteOncePod (RWOP)', value: V1PersistentVolumeAccessMode.ReadWriteOncePod },
+  {
+    label: 'ReadWriteOnce (RWO)',
+    value: V1PersistentVolumeAccessMode.ReadWriteOnce,
+    description: 'The volume can be attached to a single workspace at a given time',
+  },
+  {
+    label: 'ReadWriteMany (RWX)',
+    value: V1PersistentVolumeAccessMode.ReadWriteMany,
+    description: 'The volume can be attached to many workspaces simultaneously',
+  },
+  {
+    label: 'ReadOnlyMany (ROX)',
+    value: V1PersistentVolumeAccessMode.ReadOnlyMany,
+    description: 'The volume can be attached to many workspaces as read-only',
+  },
+  {
+    label: 'ReadWriteOncePod (RWOP)',
+    value: V1PersistentVolumeAccessMode.ReadWriteOncePod,
+    description: 'The volume can be attached to a single pod on a single node as read-write',
+  },
 ] as const;
 
 export interface VolumesCreateModalProps {
@@ -91,6 +106,8 @@ export const VolumesCreateModal: React.FC<VolumesCreateModalProps> = ({
     isMountPathEditing,
     isStorageClassOpen,
     setIsStorageClassOpen,
+    isAccessModeOpen,
+    setIsAccessModeOpen,
     isSubmitting,
     error,
     setError,
@@ -130,28 +147,30 @@ export const VolumesCreateModal: React.FC<VolumesCreateModalProps> = ({
         isFixed={!!fixedMountPath}
         fieldId="create-volume-mount-path"
       />
-      <ThemeAwareFormGroupWrapper
-        label="Read-only Access"
-        fieldId="read-only"
-        skipFieldset
-        labelHelp={
-          <Popover
-            headerContent="Read-only access"
-            bodyContent="Mount the volume as read-only when this workspace only needs to read data. This prevents accidental or unintended writes to shared volumes."
-          >
-            <OutlinedQuestionCircleIcon />
-          </Popover>
-        }
-      >
-        <Switch
-          id="read-only-switch"
-          data-testid="read-only-switch"
-          label="Enabled"
-          hasCheckIcon
-          isChecked={readOnly}
-          onChange={(_ev, checked) => setReadOnly(checked)}
-        />
-      </ThemeAwareFormGroupWrapper>
+      {!fixedMountPath && (
+        <ThemeAwareFormGroupWrapper
+          label="Read-only Access"
+          fieldId="read-only"
+          skipFieldset
+          labelHelp={
+            <Popover
+              headerContent="Read-only access"
+              bodyContent="Mount the volume as read-only when this workspace only needs to read data. This prevents accidental or unintended writes to shared volumes."
+            >
+              <OutlinedQuestionCircleIcon />
+            </Popover>
+          }
+        >
+          <Switch
+            id="read-only-switch"
+            data-testid="read-only-switch"
+            label="Enabled"
+            hasCheckIcon
+            isChecked={readOnly}
+            onChange={(_ev, checked) => setReadOnly(checked)}
+          />
+        </ThemeAwareFormGroupWrapper>
+      )}
     </>
   );
 
@@ -275,61 +294,50 @@ export const VolumesCreateModal: React.FC<VolumesCreateModalProps> = ({
                 label="Access Mode"
                 isRequired
                 fieldId="access-mode"
-                role="radiogroup"
-                skipFieldset
-                isInline
-                labelHelp={
-                  <Popover
-                    headerContent="Access mode"
-                    bodyContent={
-                      <>
-                        Access mode is a Kubernetes concept that determines how nodes can interact
-                        with the volume
-                        <List className="pf-v6-u-mt-sm">
-                          <ListItem>
-                            <strong>ReadWriteMany (RWX)</strong> means that the volume can be
-                            attached to many workspaces simultaneously
-                          </ListItem>
-                          <ListItem>
-                            <strong>ReadOnlyMany (ROX)</strong> means that the volume can be
-                            attached to many workspaces as read-only
-                          </ListItem>
-                          <ListItem>
-                            <strong>ReadWriteOnce (RWO)</strong> means that the volume can be
-                            attached to a single workspace at a given time
-                          </ListItem>
-                          <ListItem>
-                            <strong>ReadWriteOncePod (RWOP)</strong> means that the volume can be
-                            attached to a single pod on a single node as read-write
-                          </ListItem>
-                        </List>
-                      </>
-                    }
-                  >
-                    <OutlinedQuestionCircleIcon />
-                  </Popover>
-                }
                 helperTextNode={
                   <HelperText>
                     <HelperTextItem>
                       <InfoCircleIcon className="pf-v6-u-mr-xs" />
-                      Access mode cannot be changed after creation
+                      Access mode is a Kubernetes concept that determines how nodes can interact
+                      with the volume. It cannot be changed after creation
                     </HelperTextItem>
                   </HelperText>
                 }
               >
-                {ACCESS_MODES.map(({ label, value }) => (
-                  <Radio
-                    key={value}
-                    id={`access-mode-${value}`}
-                    data-testid={`access-mode-${value}`}
-                    name="access-mode"
-                    label={label}
-                    value={value}
-                    isChecked={accessMode === value}
-                    onChange={() => setAccessMode(value)}
-                  />
-                ))}
+                <Select
+                  id="access-mode"
+                  isOpen={isAccessModeOpen}
+                  selected={accessMode}
+                  onSelect={(_ev, value) => {
+                    setAccessMode(value as V1PersistentVolumeAccessMode);
+                    setIsAccessModeOpen(false);
+                  }}
+                  onOpenChange={setIsAccessModeOpen}
+                  toggle={(toggleRef) => (
+                    <MenuToggle
+                      ref={toggleRef}
+                      onClick={() => setIsAccessModeOpen((prev) => !prev)}
+                      isExpanded={isAccessModeOpen}
+                      isFullWidth
+                      data-testid="access-mode-select"
+                    >
+                      {ACCESS_MODES.find((m) => m.value === accessMode)?.label ?? accessMode}
+                    </MenuToggle>
+                  )}
+                >
+                  <SelectList>
+                    {ACCESS_MODES.map(({ label, value, description }) => (
+                      <SelectOption
+                        key={value}
+                        value={value}
+                        description={description}
+                        data-testid={`access-mode-option-${value}`}
+                      >
+                        {label}
+                      </SelectOption>
+                    ))}
+                  </SelectList>
+                </Select>
               </ThemeAwareFormGroupWrapper>
               <ThemeAwareFormGroupWrapper
                 label="Volume Size"


### PR DESCRIPTION
 closes: #989

Descriptions
This PR targets a few UI improvements that were discussed in the working group meeting
* Hide Read Only Access from Home Volume Modals
* Convert Access Mode Select from Radio to DropDown
<img width="879" height="368" alt="Screenshot 2026-06-25 at 6 11 30 PM" src="https://github.com/user-attachments/assets/199fb20f-061a-4219-a627-344348839b4e" />

* Wrap the state with a tooltip to display state message on WS table
<img width="237" height="119" alt="Screenshot 2026-06-25 at 6 10 58 PM" src="https://github.com/user-attachments/assets/42f92f2c-312f-4a37-94a0-b2b970d1e17c" />
