### PR TITLE
chore: use server-side apply for CRDs in tilt and makefile

### DIFF
--- a/developing/.gitignore
+++ b/developing/.gitignore
@@ -5,3 +5,6 @@
 *.so
 *.dylib
 bin/*
+
+# Tilt-generated scratch files
+.tilt-tmp/

--- a/developing/Tiltfile
+++ b/developing/Tiltfile
@@ -51,9 +51,32 @@ else:
     controller_kustomize_path = os.path.join(controller_dir, "manifests/kustomize/overlays/istio")
 manifests = kustomize(controller_kustomize_path, kustomize_bin=kustomize_bin)
 
-# Apply manifests
+# Split CRDs from controller manifests for server-side apply.
+# The WorkspaceKinds CRD (~316K) exceeds the 262KB last-applied-configuration
+# annotation limit for client-side apply, so CRDs must use server-side apply.
+controller_objects = decode_yaml_stream(manifests)
+controller_crds = [o for o in controller_objects if o.get("kind") == "CustomResourceDefinition"]
+controller_non_crds = [o for o in controller_objects if o.get("kind") != "CustomResourceDefinition"]
+
+# Write CRDs to a scratch file for kubectl to apply.
+# This file is regenerated each time the Tiltfile re-evaluates (triggered by
+# kustomize() watching the manifests directory for changes).
+if controller_crds:
+    local("mkdir -p .tilt-tmp", quiet=True)
+    local("cat > .tilt-tmp/crds.yaml", stdin=encode_yaml_stream(controller_crds), quiet=True)
+
+# Apply CRDs via server-side apply and wait for establishment.
+local_resource(
+    "apply-crds",
+    cmd="kubectl apply --server-side --force-conflicts -f .tilt-tmp/crds.yaml"
+        + " && kubectl wait --for=condition=Established crd --all --timeout=60s",
+    deps=[".tilt-tmp/crds.yaml"],
+    labels=["controller"],
+)
+
+# Apply non-CRD controller resources via standard k8s_yaml
 # NOTE: allow_duplicates=True because namespace may be defined by multiple overlays
-k8s_yaml(manifests, allow_duplicates=True)
+k8s_yaml(encode_yaml_stream(controller_non_crds), allow_duplicates=True)
 
 # Manage k8s_yaml resources
 # - Apply Tilt-specific grouping/labels
@@ -64,6 +87,7 @@ k8s_resource(
       "8080:8080", # healthz
       "8081:8081", # metrics
     ],
+    resource_deps=["apply-crds"],
     labels=["controller"],
 )
 

--- a/workspaces/controller/Makefile
+++ b/workspaces/controller/Makefile
@@ -140,7 +140,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build manifests/kustomize/base/crd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build manifests/kustomize/base/crd | $(KUBECTL) apply --server-side --force-conflicts -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -154,7 +154,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	@cp -r manifests/kustomize/* manifests/kustomize/.output/
 	# Match both short name and registry-prefixed name (base kustomization may transform either)
 	@cd manifests/kustomize/.output/overlays/istio && $(KUSTOMIZE) edit set image $(NAME)=${IMG} $(REGISTRY)/$(NAME)=${IMG}
-	@$(KUBECTL) apply -k manifests/kustomize/.output/overlays/istio
+	@$(KUSTOMIZE) build manifests/kustomize/.output/overlays/istio | $(KUBECTL) apply --server-side --force-conflicts -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_

---

The WorkspaceKinds CRD (~316K) exceeds the 262KB
last-applied-configuration annotation limit for client-side kubectl apply. This hasn't caused failures yet because Tilt's k8s_yaml applies resources through its own mechanism, but the CRD will continue to grow and the controller Makefile's install and deploy targets use kubectl apply directly.

Adopt the pattern used by external-secrets-operator: split CRDs from non-CRD resources at the Tiltfile level and apply them separately with server-side apply.

## Development environment (developing/)

- Update Tiltfile to decode the rendered kustomize output and separate CRDs from non-CRD resources using decode_yaml_stream. CRDs are written to a scratch file in .tilt-tmp/ and applied via a local_resource using kubectl apply --server-side --force-conflicts, followed by kubectl wait --for=condition=Established to block until CRDs are registered. Non-CRD resources continue through standard k8s_yaml.

- Add apply-crds as a resource dependency on workspaces-controller, ensuring the controller deployment does not start until CRDs are fully established. This eliminates transient errors on cold starts where webhooks or RBAC referencing CRD types could be applied before the CRDs existed.

- Add .tilt-tmp/ directory to .gitignore for scratch files generated during Tiltfile evaluation.

## Controller Makefile (workspaces/controller/)

- Update make install to use --server-side --force-conflicts when applying CRDs from base/crd, preventing annotation size limit failures when installing CRDs standalone.

- Update make deploy to pipe kustomize build output through kubectl apply --server-side --force-conflicts instead of using kubectl apply -k (which uses client-side apply). This is functionally equivalent but avoids the annotation size limit for all resources in the overlay.