### PR TITLE
feat: integrate metrics-server in tilt

### DIFF
--- a/developing/DEVELOPMENT_GUIDE.md
+++ b/developing/DEVELOPMENT_GUIDE.md
@@ -113,6 +113,9 @@ make tilt-up
 
 # OPTION 2: run with prometheus metrics enabled
 ENABLE_PROMETHEUS=true make tilt-up
+
+# OPTION 3: run with metrics-server enabled (kubectl top verification)
+ENABLE_METRICS_SERVER=true make tilt-up
 ```
 
 What this does:
@@ -143,6 +146,10 @@ What this does:
 > ```bash
 > ENABLE_FRONTEND=false make tilt-up
 > ```
+
+> [!TIP]
+>
+> `ENABLE_METRICS_SERVER=true` installs [metrics-server](https://github.com/kubernetes-sigs/metrics-server), registering the `metrics.k8s.io` API so `kubectl top nodes` / `kubectl top pods` work against the cluster.
 
 Wait until all resources show green/healthy status. 
 The frontend may take a couple of minutes on first start as webpack compiles the bundle.

--- a/developing/Makefile
+++ b/developing/Makefile
@@ -54,9 +54,15 @@ setup-prometheus:
 	@echo "Setting up Prometheus..."
 	@export PATH="$(LOCALBIN):$$PATH" && ./scripts/setup-prometheus.sh
 
+# Install metrics-server for `kubectl top` verification (optional, gated by ENABLE_METRICS_SERVER)
+.PHONY: setup-metrics-server
+setup-metrics-server:
+	@echo "Setting up metrics-server..."
+	@export PATH="$(LOCALBIN):$$PATH" && ./scripts/setup-metrics-server.sh
+
 # Run tilt up with kind cluster, cert-manager, and Istio setup
 .PHONY: tilt-up
-tilt-up: kustomize check-tilt setup-kind setup-istio setup-prometheus
+tilt-up: kustomize check-tilt setup-kind setup-istio setup-prometheus setup-metrics-server
 	@echo "Starting Tilt..."
 	@tilt up
 

--- a/developing/manifests/metrics-server/kustomization.yaml
+++ b/developing/manifests/metrics-server/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.1/components.yaml
+
+patches:
+# Kind's kubelets serve metrics over TLS certificates that aren't valid for
+# the address metrics-server connects to, so verification must be disabled.
+# This is only safe for local development, never for production.
+- target:
+    kind: Deployment
+    name: metrics-server
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --kubelet-insecure-tls

--- a/developing/manifests/metrics-server/kustomization.yaml
+++ b/developing/manifests/metrics-server/kustomization.yaml
@@ -8,10 +8,30 @@ patches:
 # Kind's kubelets serve metrics over TLS certificates that aren't valid for
 # the address metrics-server connects to, so verification must be disabled.
 # This is only safe for local development, never for production.
+#
+# Selects the container by name (rather than by array index) so the patch
+# doesn't break if upstream reorders or adds containers to the Deployment.
+#
+# Args are modified from upstream deployment, those might require updates when
+# the metrics-server component is being updated
+# https://github.com/kubernetes-sigs/metrics-server/blob/9ce65a47f9262e19e482c259ace815f01135a898/manifests/base/deployment.yaml#L20-L33
 - target:
     kind: Deployment
     name: metrics-server
   patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --kubelet-insecure-tls
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: metrics-server
+    spec:
+      template:
+        spec:
+          containers:
+          - name: metrics-server
+            args:
+              - --cert-dir=/tmp
+              - --secure-port=10250
+              - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+              - --kubelet-use-node-status-port
+              - --metric-resolution=15s
+              - --kubelet-insecure-tls

--- a/developing/scripts/setup-metrics-server.sh
+++ b/developing/scripts/setup-metrics-server.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Setup script for metrics-server
+# This script checks if metrics-server is installed and installs it if needed.
+# It lets developers verify `kubectl top` and the metrics.k8s.io APIService
+# work end-to-end.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVELOPING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Do nothing if ENABLE_METRICS_SERVER is not set to true
+if [[ "${ENABLE_METRICS_SERVER:-false}" != "true" ]]; then
+  echo ""
+  echo ""
+  echo "INFO: metrics-server setup is disabled. Set ENABLE_METRICS_SERVER=true to enable."
+  echo ""
+  echo ""
+  exit 0
+fi
+
+if kubectl get deployment metrics-server -n kube-system >/dev/null 2>&1; then
+  echo "metrics-server is already installed"
+else
+  echo "Installing metrics-server..."
+  kubectl apply -k "${DEVELOPING_DIR}/manifests/metrics-server"
+fi
+
+echo "Waiting for metrics-server to be ready..."
+kubectl wait --for=condition=available deployment/metrics-server \
+  --namespace=kube-system \
+  --timeout=120s
+
+echo "Waiting for the metrics.k8s.io APIService to become available..."
+kubectl wait --for=condition=available apiservice/v1beta1.metrics.k8s.io --timeout=60s
+
+echo "metrics-server setup complete"

--- a/developing/scripts/setup-metrics-server.sh
+++ b/developing/scripts/setup-metrics-server.sh
@@ -31,6 +31,10 @@ echo "Waiting for metrics-server to be ready..."
 kubectl wait --for=condition=available deployment/metrics-server \
   --namespace=kube-system \
   --timeout=120s
+kubectl wait --for=condition=ready pod \
+  -l k8s-app=metrics-server \
+  --namespace=kube-system \
+  --timeout=120s
 
 echo "Waiting for the metrics.k8s.io APIService to become available..."
 kubectl wait --for=condition=available apiservice/v1beta1.metrics.k8s.io --timeout=60s


### PR DESCRIPTION
Add opt-in metrics-server support to the Kind/Tilt development
environment, gated by the `ENABLE_METRICS_SERVER` env var, so that the
metrics.k8s.io APIService can be verified end-to-end.

Add `setup-metrics-server.sh` tries to follow the same pattern as
`setup-prometheus.sh` and by adding a kustomize overlay that patches the
upstream `components.yaml` with `--kubelet-insecure-tls` (required since
Kind's kubelet serving certs aren't valid for metrics-server to verify).

Related to https://github.com/kubeflow/notebooks/issues/1222 (cc @richabanker)

---

Verified via:
```
$ kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes" | jq ".items[].usage"
{
  "cpu": "87224497n",
  "memory": "1757708Ki"
}
{
  "cpu": "144742938n",
  "memory": "4121184Ki"
}

$ kubectl top pod
NAME                              CPU(cores)   MEMORY(bytes)
ws-jupyterlab-workspace-v5nr9-0   0m           138Mi
ws-test123-sd4ff-0                0m           145Mi
```

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
