### PR TITLE
fix: set restricted PSS sample context

### DIFF
--- a/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml
@@ -51,12 +51,16 @@ spec:
           medium: "Memory"
     securityContext:
       fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     options:
       imageConfig:
         spawner:

--- a/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml
@@ -226,6 +226,8 @@ spec:
     ##
     securityContext:
       fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
 
     ## container SecurityContext for Workspace Pods (MUTABLE)
     ##  - spec for SecurityContext:
@@ -237,6 +239,8 @@ spec:
         drop:
           - ALL
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 
     ## ==============================================================
     ## WORKSPACE OPTIONS

--- a/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml
@@ -54,12 +54,16 @@ spec:
           medium: "Memory"
     securityContext:
       fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     options:
       imageConfig:
         spawner:


### PR DESCRIPTION
## Summary

This PR updates the JupyterLab `WorkspaceKind` sample so generated workspace pods are compatible with Kubernetes restricted Pod Security Standards.

The change is limited to `workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml` and adds:

- pod `seccompProfile.type: RuntimeDefault`
- container `seccompProfile.type: RuntimeDefault`

Existing `fsGroup: 100`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, and `runAsNonRoot: true` are preserved.

No CRD defaults, controller reconciliation logic, codeserver, or rstudio samples are changed.

## Validation

- branch based on `kubeflow/notebooks:notebooks-v2`
- `kustomize build workspaces/controller/manifests/kustomize/samples`
- source and rendered YAML assertions for the JupyterLab `WorkspaceKind`
- `git diff --check`

## Related

Related to kubeflow/manifests#3487.
