### PR TITLE
feat: add restrictions attribute to WorkspaceKind and option value responses

### DIFF
--- a/workspaces/backend/internal/models/common/funcs.go
+++ b/workspaces/backend/internal/models/common/funcs.go
@@ -115,3 +115,8 @@ func GetDescriptionFromObjectMeta(objectMeta *metav1.ObjectMeta) string {
 	}
 	return objectMeta.Annotations[AnnotationDescription]
 }
+
+// DefaultRestrictions returns the non-restrictive default action
+func DefaultRestrictions() Restrictions {
+	return Restrictions{Deny: false}
+}

--- a/workspaces/backend/internal/models/common/funcs_test.go
+++ b/workspaces/backend/internal/models/common/funcs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -146,5 +147,38 @@ var _ = Describe("UpdateObjectMetaForUpdate", func() {
 		Expect(func() {
 			UpdateObjectMetaForUpdate(nil, &user.DefaultInfo{Name: "alice"}, time.Now())
 		}).To(Panic())
+	})
+})
+
+var _ = Describe("Restrictions", func() {
+	// marshalToMap round-trips a value through JSON so we can assert on the
+	// serialized shape (in particular, which keys are present) without pinning
+	// down key ordering.
+	marshalToMap := func(v any) map[string]any {
+		data, err := json.Marshal(v)
+		Expect(err).NotTo(HaveOccurred())
+		result := map[string]any{}
+		Expect(json.Unmarshal(data, &result)).To(Succeed())
+		return result
+	}
+
+	It("omits denyMessage from the default (non-restrictive) value", func() {
+		// the optional denyMessage must be absent so the default serializes as {"deny": false}
+		Expect(marshalToMap(DefaultRestrictions())).To(BeEquivalentTo(map[string]any{
+			"deny": false,
+		}))
+	})
+
+	It("includes denyMessage when a restriction applies", func() {
+		restrictions := Restrictions{
+			Deny:        true,
+			DenyMessage: &DenyMessage{Text: "this image is no longer permitted in this namespace"},
+		}
+		Expect(marshalToMap(restrictions)).To(BeEquivalentTo(map[string]any{
+			"deny": true,
+			"denyMessage": map[string]any{
+				"text": "this image is no longer permitted in this namespace",
+			},
+		}))
 	})
 })

--- a/workspaces/backend/internal/models/common/types.go
+++ b/workspaces/backend/internal/models/common/types.go
@@ -28,3 +28,14 @@ type Audit struct {
 	UpdatedBy *string      `json:"updatedBy"`
 	DeletedAt *metav1.Time `json:"deletedAt"`
 }
+
+// Restrictions signals whether an option or Workspace Kind is denied
+type Restrictions struct {
+	Deny        bool         `json:"deny"`
+	DenyMessage *DenyMessage `json:"denyMessage,omitempty"`
+}
+
+// DenyMessage explains the reason for why a restriction applies
+type DenyMessage struct {
+	Text string `json:"text"`
+}

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common/assets"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds/podtemplate/options"
 )
@@ -72,5 +73,9 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 			},
 			Options: *podTemplateOptions,
 		},
+		//
+		// TODO: replace this with the calculation of the actual restriction!
+		//
+		Restrictions: common.DefaultRestrictions(),
 	}
 }

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 )
 
 func NewPodTemplateOptionsModelFromWorkspaceKind(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest) (*PodTemplateOptions, error) {
@@ -106,6 +107,10 @@ func buildImageConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *List
 			Hidden:         ptr.Deref(value.Spawner.Hidden, false),
 			Redirect:       buildOptionRedirect(value.Redirect),
 			ClusterMetrics: buildClusterOptionMetrics(value.Id, optionMetricsMap),
+			//
+			// TODO: replace this with the calculation of the actual restriction!
+			//
+			Restrictions: common.DefaultRestrictions(),
 		})
 	}
 
@@ -158,6 +163,10 @@ func buildPodConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListVa
 			Hidden:         ptr.Deref(value.Spawner.Hidden, false),
 			Redirect:       buildOptionRedirect(value.Redirect),
 			ClusterMetrics: buildClusterOptionMetrics(value.Id, optionMetricsMap),
+			//
+			// TODO: replace this with the calculation of the actual restriction!
+			//
+			Restrictions: common.DefaultRestrictions(),
 		})
 	}
 

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package options
 
+import (
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
+)
+
 type PodTemplateOptions struct {
 	ImageConfig ImageConfig `json:"imageConfig"`
 	PodConfig   PodConfig   `json:"podConfig"`
@@ -38,6 +42,7 @@ type ImageConfigValue struct {
 	Hidden         bool                 `json:"hidden"`
 	Redirect       *OptionRedirect      `json:"redirect,omitempty"`
 	ClusterMetrics ClusterOptionMetrics `json:"clusterMetrics,omitempty"`
+	Restrictions   common.Restrictions  `json:"restrictions"`
 }
 
 type PodConfig struct {
@@ -53,6 +58,7 @@ type PodConfigValue struct {
 	Hidden         bool                 `json:"hidden"`
 	Redirect       *OptionRedirect      `json:"redirect,omitempty"`
 	ClusterMetrics ClusterOptionMetrics `json:"clusterMetrics,omitempty"`
+	Restrictions   common.Restrictions  `json:"restrictions"`
 }
 
 type OptionLabel struct {

--- a/workspaces/backend/internal/models/workspacekinds/types.go
+++ b/workspaces/backend/internal/models/workspacekinds/types.go
@@ -17,21 +17,23 @@ limitations under the License.
 package workspacekinds
 
 import (
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common/assets"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds/podtemplate/options"
 )
 
 type WorkspaceKindListItem struct {
-	Name               string             `json:"name"`
-	DisplayName        string             `json:"displayName"`
-	Description        string             `json:"description"`
-	Deprecated         bool               `json:"deprecated"`
-	DeprecationMessage string             `json:"deprecationMessage"`
-	Hidden             bool               `json:"hidden"`
-	Icon               assets.ImageRef    `json:"icon"`
-	Logo               assets.ImageRef    `json:"logo"`
-	ClusterMetrics     ClusterKindMetrics `json:"clusterMetrics"`
-	PodTemplate        PodTemplate        `json:"podTemplate"`
+	Name               string              `json:"name"`
+	DisplayName        string              `json:"displayName"`
+	Description        string              `json:"description"`
+	Deprecated         bool                `json:"deprecated"`
+	DeprecationMessage string              `json:"deprecationMessage"`
+	Hidden             bool                `json:"hidden"`
+	Icon               assets.ImageRef     `json:"icon"`
+	Logo               assets.ImageRef     `json:"logo"`
+	ClusterMetrics     ClusterKindMetrics  `json:"clusterMetrics"`
+	PodTemplate        PodTemplate         `json:"podTemplate"`
+	Restrictions       common.Restrictions `json:"restrictions"`
 }
 
 type ClusterKindMetrics struct {

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -2298,6 +2298,17 @@ const docTemplate = `{
                 }
             }
         },
+        "common.DenyMessage": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
         "common.PodMetadata": {
             "type": "object",
             "required": [
@@ -2353,6 +2364,20 @@ const docTemplate = `{
                 },
                 "readOnly": {
                     "type": "boolean"
+                }
+            }
+        },
+        "common.Restrictions": {
+            "type": "object",
+            "required": [
+                "deny"
+            ],
+            "properties": {
+                "deny": {
+                    "type": "boolean"
+                },
+                "denyMessage": {
+                    "$ref": "#/definitions/common.DenyMessage"
                 }
             }
         },
@@ -2616,7 +2641,8 @@ const docTemplate = `{
                 "description",
                 "displayName",
                 "hidden",
-                "id"
+                "id",
+                "restrictions"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -2642,6 +2668,9 @@ const docTemplate = `{
                 },
                 "redirect": {
                     "$ref": "#/definitions/options.OptionRedirect"
+                },
+                "restrictions": {
+                    "$ref": "#/definitions/common.Restrictions"
                 }
             }
         },
@@ -2722,7 +2751,8 @@ const docTemplate = `{
                 "description",
                 "displayName",
                 "hidden",
-                "id"
+                "id",
+                "restrictions"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -2748,6 +2778,9 @@ const docTemplate = `{
                 },
                 "redirect": {
                     "$ref": "#/definitions/options.OptionRedirect"
+                },
+                "restrictions": {
+                    "$ref": "#/definitions/common.Restrictions"
                 }
             }
         },
@@ -6984,7 +7017,8 @@ const docTemplate = `{
                 "icon",
                 "logo",
                 "name",
-                "podTemplate"
+                "podTemplate",
+                "restrictions"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -7016,6 +7050,9 @@ const docTemplate = `{
                 },
                 "podTemplate": {
                     "$ref": "#/definitions/workspacekinds.PodTemplate"
+                },
+                "restrictions": {
+                    "$ref": "#/definitions/common.Restrictions"
                 }
             }
         },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -2296,6 +2296,17 @@
                 }
             }
         },
+        "common.DenyMessage": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
         "common.PodMetadata": {
             "type": "object",
             "required": [
@@ -2351,6 +2362,20 @@
                 },
                 "readOnly": {
                     "type": "boolean"
+                }
+            }
+        },
+        "common.Restrictions": {
+            "type": "object",
+            "required": [
+                "deny"
+            ],
+            "properties": {
+                "deny": {
+                    "type": "boolean"
+                },
+                "denyMessage": {
+                    "$ref": "#/definitions/common.DenyMessage"
                 }
             }
         },
@@ -2614,7 +2639,8 @@
                 "description",
                 "displayName",
                 "hidden",
-                "id"
+                "id",
+                "restrictions"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -2640,6 +2666,9 @@
                 },
                 "redirect": {
                     "$ref": "#/definitions/options.OptionRedirect"
+                },
+                "restrictions": {
+                    "$ref": "#/definitions/common.Restrictions"
                 }
             }
         },
@@ -2720,7 +2749,8 @@
                 "description",
                 "displayName",
                 "hidden",
-                "id"
+                "id",
+                "restrictions"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -2746,6 +2776,9 @@
                 },
                 "redirect": {
                     "$ref": "#/definitions/options.OptionRedirect"
+                },
+                "restrictions": {
+                    "$ref": "#/definitions/common.Restrictions"
                 }
             }
         },
@@ -6982,7 +7015,8 @@
                 "icon",
                 "logo",
                 "name",
-                "podTemplate"
+                "podTemplate",
+                "restrictions"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -7014,6 +7048,9 @@
                 },
                 "podTemplate": {
                     "$ref": "#/definitions/workspacekinds.PodTemplate"
+                },
+                "restrictions": {
+                    "$ref": "#/definitions/common.Restrictions"
                 }
             }
         },


### PR DESCRIPTION
Add a `restrictions` object (with a nested optional `denyMessage`) to the
WorkspaceKind list response items and to the imageConfig/podConfig values
returned by the podtemplate options listvalues endpoint.

Closes https://github.com/kubeflow/notebooks/issues/1207

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
