### PR TITLE
chore: WorkspaceKind Edit UI improvements

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/components/toastNotification.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/components/toastNotification.ts
@@ -1,10 +1,10 @@
 class ToastNotification {
   find() {
-    return cy.get('.pf-v6-c-alert-group[aria-live="polite"]');
+    return cy.findByTestId('toast-notification-group');
   }
 
   findAlert(variant: 'success' | 'danger' | 'warning' | 'info') {
-    return this.find().find(`.pf-v6-c-alert.pf-m-${variant}`);
+    return this.find().findByTestId(`toast-notification-${variant}`);
   }
 
   findErrorAlert() {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/createWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/createWorkspaceKind.ts
@@ -35,7 +35,7 @@ class CreateWorkspaceKind {
   }
 
   findErrorToast() {
-    return cy.get('.pf-v6-c-alert-group[aria-live="polite"]').find('.pf-v6-c-alert.pf-m-danger');
+    return cy.findByTestId('toast-notification-group').findByTestId('toast-notification-danger');
   }
 
   assertErrorAlertContainsMessage(message: string) {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/createWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/createWorkspaceKind.ts
@@ -34,12 +34,12 @@ class CreateWorkspaceKind {
     return cy.findByTestId('cancel-button');
   }
 
-  findErrorAlert() {
-    return cy.findByTestId('workspace-kind-form-error');
+  findErrorToast() {
+    return cy.get('.pf-v6-c-alert-group[aria-live="polite"]').find('.pf-v6-c-alert.pf-m-danger');
   }
 
   assertErrorAlertContainsMessage(message: string) {
-    cy.findByTestId('workspace-kind-form-error-message').should('have.text', message);
+    this.findErrorToast().should('contain.text', message);
   }
 
   findFormPropertiesSection() {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -68,11 +68,11 @@ class EditWorkspaceKind {
   }
 
   findIconUrlInput() {
-    return cy.findByTestId('workspace-kind-icon-input');
+    return cy.findByTestId('workspace-kind-icon-url-input');
   }
 
   findLogoUrlInput() {
-    return cy.findByTestId('workspace-kind-logo-input');
+    return cy.findByTestId('workspace-kind-logo-url-input');
   }
 
   findHiddenSwitch() {
@@ -1123,8 +1123,10 @@ class EditWorkspaceKind {
     this.findSubmitButton().should('have.text', text);
   }
 
-  assertErrorAlertVisible() {
-    cy.findByTestId('workspace-kind-form-error').should('be.visible');
+  assertErrorToastVisible() {
+    cy.get('.pf-v6-c-alert-group[aria-live="polite"]')
+      .find('.pf-v6-c-alert.pf-m-danger')
+      .should('exist');
   }
 
   // View mode tabs (Form / YAML)

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaceKinds/editWorkspaceKind.ts
@@ -1124,8 +1124,8 @@ class EditWorkspaceKind {
   }
 
   assertErrorToastVisible() {
-    cy.get('.pf-v6-c-alert-group[aria-live="polite"]')
-      .find('.pf-v6-c-alert.pf-m-danger')
+    cy.findByTestId('toast-notification-group')
+      .findByTestId('toast-notification-danger')
       .should('exist');
   }
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/createWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/createWorkspaceKind.cy.ts
@@ -127,7 +127,7 @@ describe('Create workspace kind', () => {
       createWorkspaceKind.clickSubmit();
       cy.wait('@createWorkspaceKindServerError');
 
-      createWorkspaceKind.assertErrorAlertContainsMessage('Error: Internal server error');
+      createWorkspaceKind.assertErrorAlertContainsMessage('Internal server error');
 
       createWorkspaceKind.verifyPageURL();
     });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaceKinds/editWorkspaceKind.cy.ts
@@ -1346,7 +1346,7 @@ describe('Edit workspace kind', () => {
 
       cy.wait('@updateWorkspaceKindError');
 
-      editWorkspaceKind.assertErrorAlertVisible();
+      editWorkspaceKind.assertErrorToastVisible();
       editWorkspaceKind.verifyPageURL(mockWorkspaceKind.name);
     });
   });

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -21,7 +21,12 @@ import { useTypedNavigate, useTypedParams } from '~/app/routerHelper';
 import { useCurrentRouteKey } from '~/app/hooks/useCurrentRouteKey';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { ImagePullPolicy, WorkspaceKindFormData } from '~/app/types';
-import { extractErrorMessage, safeApiCall } from '~/shared/api/apiUtils';
+import {
+  extractErrorMessage,
+  formatConflictErrorMessages,
+  formatValidationErrorMessages,
+  safeApiCall,
+} from '~/shared/api/apiUtils';
 import { CONTENT_TYPE_KEY, WORKSPACE_KIND_EXAMPLES_URL } from '~/shared/utilities/const';
 import { ContentType } from '~/shared/utilities/types';
 import { LoadError } from '~/app/components/LoadError';
@@ -296,7 +301,16 @@ export const WorkspaceKindForm: React.FC = () => {
       navigate('workspaceKinds');
     } catch (err) {
       const extracted = extractErrorMessage(err);
-      const message = typeof extracted === 'string' ? extracted : extracted.error.message;
+      let message: string;
+      if (typeof extracted === 'string') {
+        message = extracted;
+      } else {
+        const details = [
+          ...formatValidationErrorMessages(extracted),
+          ...formatConflictErrorMessages(extracted),
+        ];
+        message = details.length > 0 ? details.join('; ') : extracted.error.message;
+      }
       notification.error(
         `Failed to ${mode === 'edit' ? 'edit' : 'create'} workspace kind`,
         message,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -83,8 +83,8 @@ const convertToFormData = (
       deprecated: spawner.deprecated ?? false,
       deprecationMessage: spawner.deprecationMessage ?? '',
       hidden: spawner.hidden ?? false,
-      icon: { url: spawner.icon.url ?? '' },
-      logo: { url: spawner.logo.url ?? '' },
+      icon: spawner.icon,
+      logo: spawner.logo,
     },
     imageConfig: {
       default: podTemplate.options.imageConfig.spawner.default,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -22,12 +22,10 @@ import { useCurrentRouteKey } from '~/app/hooks/useCurrentRouteKey';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
 import { ImagePullPolicy, WorkspaceKindFormData } from '~/app/types';
 import { extractErrorMessage, safeApiCall } from '~/shared/api/apiUtils';
-import { ErrorAlert } from '~/shared/components/ErrorAlert';
 import { CONTENT_TYPE_KEY, WORKSPACE_KIND_EXAMPLES_URL } from '~/shared/utilities/const';
 import { ContentType } from '~/shared/utilities/types';
 import { LoadError } from '~/app/components/LoadError';
 import {
-  ApiErrorEnvelope,
   OptionsOptionRedirect,
   OptionsRedirectMessageLevel,
   V1Beta1OptionRedirect,
@@ -168,8 +166,6 @@ export const WorkspaceKindForm: React.FC = () => {
   const [validated, setValidated] = useState<ValidationStatus>(
     mode === 'edit' ? 'success' : 'default',
   );
-  const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
-
   const routeParams = useTypedParams<'workspaceKindEdit' | 'workspaceKindCreate'>();
   const [initialFormData, initialFormDataLoaded, initialFormDataError] = useWorkspaceKindByName(
     routeParams?.kind,
@@ -237,7 +233,6 @@ export const WorkspaceKindForm: React.FC = () => {
       setOriginalYaml(yamlStr);
       setEditYamlValue(yamlStr);
       setYamlParseError(null);
-      setError(null);
     }
   }, [initialFormData, replaceData]);
 
@@ -253,7 +248,6 @@ export const WorkspaceKindForm: React.FC = () => {
 
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
-    setError(null);
     // TODO: Complete handleCreate with API call to create a new WS kind
     try {
       if (mode === 'create') {
@@ -301,7 +295,12 @@ export const WorkspaceKindForm: React.FC = () => {
       }
       navigate('workspaceKinds');
     } catch (err) {
-      setError(extractErrorMessage(err));
+      const extracted = extractErrorMessage(err);
+      const message = typeof extracted === 'string' ? extracted : extracted.error.message;
+      notification.error(
+        `Failed to ${mode === 'edit' ? 'edit' : 'create'} workspace kind`,
+        message,
+      );
       if (mode === 'create') {
         setValidated('error');
       }
@@ -379,15 +378,6 @@ export const WorkspaceKindForm: React.FC = () => {
       </PageGroup>
       <PageSection isFilled>
         <Stack hasGutter>
-          {error && (
-            <StackItem>
-              <ErrorAlert
-                title={`Failed to ${mode === 'edit' ? 'edit' : 'create'} workspace kind`}
-                content={error}
-                testId="workspace-kind-form-error"
-              />
-            </StackItem>
-          )}
           {mode === 'create' && (
             <StackItem style={{ height: '100%' }}>
               <WorkspaceKindFileUpload
@@ -396,9 +386,8 @@ export const WorkspaceKindForm: React.FC = () => {
                 setValue={setYamlValue}
                 validated={validated}
                 setValidated={setValidated}
-                onClear={() => {
-                  setError(null);
-                }}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                onClear={() => {}}
               />
             </StackItem>
           )}

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/__tests__/WorkspaceKindAssetField.spec.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/__tests__/WorkspaceKindAssetField.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { userEvent } from '@testing-library/user-event';
+import { WorkspaceKindAssetField } from '~/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindAssetField';
+import {
+  V1Beta1WorkspaceKindAsset,
+  V1Beta1WorkspaceKindAssetMediaType,
+} from '~/generated/data-contracts';
+
+const renderAssetField = (asset: V1Beta1WorkspaceKindAsset, onChange = jest.fn()) =>
+  render(
+    <WorkspaceKindAssetField
+      label="Icon"
+      fieldIdPrefix="test-icon"
+      asset={asset}
+      onChange={onChange}
+    />,
+  );
+
+describe('WorkspaceKindAssetField', () => {
+  it('should show URL fields when asset has url', () => {
+    renderAssetField({ url: 'https://example.com/icon.png' });
+
+    expect(screen.getByTestId('test-icon-url-input')).toBeInTheDocument();
+    expect(screen.getByTestId('test-icon-url-input')).toHaveValue('https://example.com/icon.png');
+    expect(screen.queryByTestId('test-icon-config-map-name-input')).not.toBeInTheDocument();
+  });
+
+  it('should show ConfigMap fields when asset has configMap', () => {
+    renderAssetField({
+      configMap: {
+        name: 'my-icons',
+        namespace: 'kubeflow',
+        key: 'icon.svg',
+        mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+      },
+    });
+
+    expect(screen.queryByTestId('test-icon-url-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('test-icon-config-map-name-input')).toHaveValue('my-icons');
+    expect(screen.getByTestId('test-icon-config-map-namespace-input')).toHaveValue('kubeflow');
+    expect(screen.getByTestId('test-icon-config-map-key-input')).toHaveValue('icon.svg');
+  });
+
+  it('should switch to ConfigMap fields when asset prop changes from url to configMap', () => {
+    const { rerender } = render(
+      <WorkspaceKindAssetField
+        label="Icon"
+        fieldIdPrefix="test-icon"
+        asset={{ url: '' }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('test-icon-url-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('test-icon-config-map-name-input')).not.toBeInTheDocument();
+
+    rerender(
+      <WorkspaceKindAssetField
+        label="Icon"
+        fieldIdPrefix="test-icon"
+        asset={{
+          configMap: {
+            name: 'my-icons',
+            namespace: 'kubeflow',
+            key: 'icon.svg',
+            mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+          },
+        }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('test-icon-url-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('test-icon-config-map-name-input')).toHaveValue('my-icons');
+  });
+
+  it('should call onChange with url shape when URL radio is clicked', async () => {
+    const onChange = jest.fn();
+    renderAssetField(
+      {
+        configMap: {
+          name: 'my-icons',
+          namespace: 'kubeflow',
+          key: 'icon.svg',
+          mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+        },
+      },
+      onChange,
+    );
+
+    await userEvent.click(screen.getByTestId('test-icon-source-url'));
+    expect(onChange).toHaveBeenCalledWith({ url: '' });
+  });
+
+  it('should call onChange with configMap shape when ConfigMap radio is clicked', async () => {
+    const onChange = jest.fn();
+    renderAssetField({ url: 'https://example.com/icon.png' }, onChange);
+
+    await userEvent.click(screen.getByTestId('test-icon-source-config-map'));
+    expect(onChange).toHaveBeenCalledWith({
+      configMap: {
+        name: '',
+        namespace: '',
+        key: '',
+        mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+      },
+    });
+  });
+
+  it('should default to URL mode when asset is empty', () => {
+    renderAssetField({});
+
+    expect(screen.getByTestId('test-icon-url-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('test-icon-config-map-name-input')).not.toBeInTheDocument();
+  });
+});

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/__tests__/helpers.spec.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/__tests__/helpers.spec.ts
@@ -3,6 +3,7 @@ import { mockPodConfig } from '~/__mocks__/mockResources';
 import { WorkspaceKindFormData, WorkspaceKindPodConfigValue, ImagePullPolicy } from '~/app/types';
 import {
   WorkspacekindsWorkspaceKindUpdate,
+  V1Beta1WorkspaceKindAssetMediaType,
   V1PullPolicy,
   V1ResourceList,
 } from '~/generated/data-contracts';
@@ -81,7 +82,7 @@ const buildMockApiUpdate = (
   ...overrides,
 });
 
-const buildMockFormData = (): WorkspaceKindFormData => ({
+const buildMockFormData = (overrides?: Partial<WorkspaceKindFormData>): WorkspaceKindFormData => ({
   properties: {
     displayName: 'Test WK',
     description: 'A test workspace kind',
@@ -137,6 +138,7 @@ const buildMockFormData = (): WorkspaceKindFormData => ({
       },
     },
   },
+  ...overrides,
 });
 
 describe('getResources', () => {
@@ -171,7 +173,7 @@ describe('getResources', () => {
     expect(gpu?.id).toMatch(/nvidia\.com\/gpu-/);
   });
 
-  it(' handle empty or missing resources and return default CPU and memory entries', () => {
+  it('should handle empty or missing resources and return default CPU and memory entries', () => {
     const emptyConfig: WorkspaceKindPodConfigValue = {
       id: 'test-config',
       displayName: 'Test Config',
@@ -328,5 +330,84 @@ describe('convertFormDataToUpdate', () => {
     expect(result.spawner.deprecationMessage).toBeUndefined();
     expect(result.spawner.icon).toEqual({ url: undefined });
     expect(result.spawner.logo).toEqual({ url: undefined });
+  });
+
+  it('should use configMap-based icon when configMap is set', () => {
+    const formData = buildMockFormData({
+      properties: {
+        displayName: 'Test WK',
+        description: 'A test workspace kind',
+        deprecated: false,
+        deprecationMessage: '',
+        hidden: false,
+        icon: {
+          configMap: {
+            name: 'my-icons',
+            namespace: 'default',
+            key: 'icon.svg',
+            mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+          },
+        },
+        logo: { url: 'https://example.com/logo.png' },
+      },
+    });
+    const original = buildMockApiUpdate();
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.spawner.icon).toEqual({
+      configMap: {
+        name: 'my-icons',
+        namespace: 'default',
+        key: 'icon.svg',
+        mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+      },
+    });
+    expect(result.spawner.logo).toEqual({ url: 'https://example.com/logo.png' });
+  });
+
+  it('should use configMap-based logo when configMap is set', () => {
+    const formData = buildMockFormData({
+      properties: {
+        displayName: 'Test WK',
+        description: 'A test workspace kind',
+        deprecated: false,
+        deprecationMessage: '',
+        hidden: false,
+        icon: { url: 'https://example.com/icon.png' },
+        logo: {
+          configMap: {
+            name: 'my-logos',
+            namespace: 'kubeflow',
+            key: 'logo.svg',
+            mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+          },
+        },
+      },
+    });
+    const original = buildMockApiUpdate();
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.spawner.icon).toEqual({ url: 'https://example.com/icon.png' });
+    expect(result.spawner.logo).toEqual({
+      configMap: {
+        name: 'my-logos',
+        namespace: 'kubeflow',
+        key: 'logo.svg',
+        mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+      },
+    });
+  });
+
+  it('should preserve the original volumeMounts.home (immutable field)', () => {
+    const formData = buildMockFormData({
+      podTemplate: {
+        podMetadata: { labels: {}, annotations: {} },
+        volumeMounts: { home: '/home/changed-by-user' },
+      },
+    });
+    const original = buildMockApiUpdate();
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.podTemplate.volumeMounts).toEqual({ home: '/home/jovyan' });
   });
 });

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -249,9 +249,7 @@ export const convertFormDataToUpdate = (
       labels: formData.podTemplate.podMetadata.labels,
       annotations: formData.podTemplate.podMetadata.annotations,
     },
-    volumeMounts: {
-      home: formData.podTemplate.volumeMounts.home,
-    },
+    volumeMounts: original.podTemplate.volumeMounts,
     culling: formData.podTemplate.culling
       ? {
           enabled: formData.podTemplate.culling.enabled,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/helpers.ts
@@ -236,8 +236,12 @@ export const convertFormDataToUpdate = (
     deprecated: formData.properties.deprecated,
     deprecationMessage: formData.properties.deprecationMessage || undefined,
     hidden: formData.properties.hidden,
-    icon: { url: formData.properties.icon.url || undefined },
-    logo: { url: formData.properties.logo.url || undefined },
+    icon: formData.properties.icon.configMap
+      ? { configMap: formData.properties.icon.configMap }
+      : { url: formData.properties.icon.url || undefined },
+    logo: formData.properties.logo.configMap
+      ? { configMap: formData.properties.logo.configMap }
+      : { url: formData.properties.logo.url || undefined },
   },
   podTemplate: {
     ...original.podTemplate,

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
@@ -8,9 +8,11 @@ import {
 import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
 import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
 import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { WorkspaceKindPodTemplateData, WorkspacesPodVolumeMountValue } from '~/app/types';
 import { EditableRowsTable } from '~/app/pages/WorkspaceKinds/Form/EditableRowsTable';
 import { ResourceInputWrapper } from '~/shared/components/ResourceInputWrapper';
+import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
 import { WorkspaceFormPropertiesVolumes } from '~/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes';
 
 interface WorkspaceKindFormPodTemplateProps {
@@ -171,6 +173,40 @@ export const WorkspaceKindFormPodTemplate: React.FC<WorkspaceKindFormPodTemplate
             </FormGroup>
           </FormFieldGroup>
         )}
+        <FormFieldGroup
+          aria-label="Volume Mounts"
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'Volume Mounts',
+                id: 'workspace-kind-volume-mounts',
+              }}
+              titleDescription={
+                <HelperText>Configure volume mount paths for workspaces.</HelperText>
+              }
+            />
+          }
+        >
+          <ThemeAwareFormGroupWrapper
+            label="Home Volume Path"
+            isRequired
+            fieldId="workspace-kind-volume-mounts-home"
+          >
+            <TextInput
+              isRequired
+              type="text"
+              value={podTemplate.volumeMounts.home}
+              onChange={(_, value) =>
+                updatePodTemplate({
+                  ...podTemplate,
+                  volumeMounts: { ...podTemplate.volumeMounts, home: value },
+                })
+              }
+              id="workspace-kind-volume-mounts-home"
+              data-testid="workspace-kind-volume-mounts-home-input"
+            />
+          </ThemeAwareFormGroupWrapper>
+        </FormFieldGroup>
         <FormFieldGroup
           aria-label="Additional Volumes"
           header={

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/podTemplate/WorkspaceKindFormPodTemplate.tsx
@@ -8,11 +8,9 @@ import {
 import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
 import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
 import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
-import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { WorkspaceKindPodTemplateData, WorkspacesPodVolumeMountValue } from '~/app/types';
 import { EditableRowsTable } from '~/app/pages/WorkspaceKinds/Form/EditableRowsTable';
 import { ResourceInputWrapper } from '~/shared/components/ResourceInputWrapper';
-import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
 import { WorkspaceFormPropertiesVolumes } from '~/app/pages/Workspaces/Form/properties/WorkspaceFormPropertiesVolumes';
 
 interface WorkspaceKindFormPodTemplateProps {
@@ -186,27 +184,7 @@ export const WorkspaceKindFormPodTemplate: React.FC<WorkspaceKindFormPodTemplate
               }
             />
           }
-        >
-          <ThemeAwareFormGroupWrapper
-            label="Home Volume Path"
-            isRequired
-            fieldId="workspace-kind-volume-mounts-home"
-          >
-            <TextInput
-              isRequired
-              type="text"
-              value={podTemplate.volumeMounts.home}
-              onChange={(_, value) =>
-                updatePodTemplate({
-                  ...podTemplate,
-                  volumeMounts: { ...podTemplate.volumeMounts, home: value },
-                })
-              }
-              id="workspace-kind-volume-mounts-home"
-              data-testid="workspace-kind-volume-mounts-home-input"
-            />
-          </ThemeAwareFormGroupWrapper>
-        </FormFieldGroup>
+        />
         <FormFieldGroup
           aria-label="Additional Volumes"
           header={

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindAssetField.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindAssetField.tsx
@@ -1,0 +1,195 @@
+import React, { useState } from 'react';
+import {
+  FormFieldGroup,
+  FormFieldGroupHeader,
+} from '@patternfly/react-core/dist/esm/components/Form';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/esm/components/HelperText';
+import { Radio } from '@patternfly/react-core/dist/esm/components/Radio';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import {
+  V1Beta1WorkspaceKindAsset,
+  V1Beta1WorkspaceKindAssetMediaType,
+} from '~/generated/data-contracts';
+import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
+
+type AssetMode = 'url' | 'configMap';
+
+interface WorkspaceKindAssetFieldProps {
+  label: string;
+  fieldIdPrefix: string;
+  asset: V1Beta1WorkspaceKindAsset;
+  onChange: (asset: V1Beta1WorkspaceKindAsset) => void;
+}
+
+export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = ({
+  label,
+  fieldIdPrefix,
+  asset,
+  onChange,
+}) => {
+  const [mode, setMode] = useState<AssetMode>('url');
+
+  return (
+    <FormFieldGroup
+      aria-label={`${label} Asset`}
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: label,
+            id: `${fieldIdPrefix}-group`,
+          }}
+        />
+      }
+    >
+      <ThemeAwareFormGroupWrapper
+        label="Source"
+        fieldId={`${fieldIdPrefix}-source-type`}
+        role="radiogroup"
+        skipFieldset
+      >
+        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <Radio
+              id={`${fieldIdPrefix}-source-url`}
+              data-testid={`${fieldIdPrefix}-source-url`}
+              name={`${fieldIdPrefix}-source-type`}
+              label="URL"
+              isChecked={mode === 'url'}
+              onChange={() => {
+                setMode('url');
+                onChange({ url: '' });
+              }}
+            />
+          </FlexItem>
+          <FlexItem>
+            <Radio
+              id={`${fieldIdPrefix}-source-config-map`}
+              data-testid={`${fieldIdPrefix}-source-config-map`}
+              name={`${fieldIdPrefix}-source-type`}
+              label="ConfigMap"
+              isChecked={mode === 'configMap'}
+              onChange={() => {
+                setMode('configMap');
+                onChange({
+                  configMap: {
+                    name: '',
+                    namespace: '',
+                    key: '',
+                    mediaType: V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG,
+                  },
+                });
+              }}
+            />
+          </FlexItem>
+        </Flex>
+      </ThemeAwareFormGroupWrapper>
+
+      {mode === 'url' && (
+        <ThemeAwareFormGroupWrapper
+          label={`${label} URL`}
+          isRequired
+          fieldId={`${fieldIdPrefix}-url`}
+          helperTextNode={
+            <HelperText>
+              <HelperTextItem icon={<InfoCircleIcon />}>
+                Value must be a valid URL to an image
+              </HelperTextItem>
+            </HelperText>
+          }
+        >
+          <TextInput
+            isRequired
+            type="text"
+            value={asset.url ?? ''}
+            onChange={(_, value) => onChange({ url: value })}
+            id={`${fieldIdPrefix}-url`}
+            data-testid={`${fieldIdPrefix}-url-input`}
+          />
+        </ThemeAwareFormGroupWrapper>
+      )}
+
+      {mode === 'configMap' && (
+        <>
+          <ThemeAwareFormGroupWrapper
+            label="Name"
+            isRequired
+            fieldId={`${fieldIdPrefix}-config-map-name`}
+          >
+            <TextInput
+              isRequired
+              type="text"
+              value={asset.configMap?.name ?? ''}
+              onChange={(_, value) =>
+                onChange({
+                  configMap: { ...asset.configMap!, name: value },
+                })
+              }
+              id={`${fieldIdPrefix}-config-map-name`}
+              data-testid={`${fieldIdPrefix}-config-map-name-input`}
+            />
+          </ThemeAwareFormGroupWrapper>
+          <ThemeAwareFormGroupWrapper
+            label="Namespace"
+            isRequired
+            fieldId={`${fieldIdPrefix}-config-map-namespace`}
+          >
+            <TextInput
+              isRequired
+              type="text"
+              value={asset.configMap?.namespace ?? ''}
+              onChange={(_, value) =>
+                onChange({
+                  configMap: { ...asset.configMap!, namespace: value },
+                })
+              }
+              id={`${fieldIdPrefix}-config-map-namespace`}
+              data-testid={`${fieldIdPrefix}-config-map-namespace-input`}
+            />
+          </ThemeAwareFormGroupWrapper>
+          <ThemeAwareFormGroupWrapper
+            label="Key"
+            isRequired
+            fieldId={`${fieldIdPrefix}-config-map-key`}
+            helperTextNode={
+              <HelperText>
+                <HelperTextItem icon={<InfoCircleIcon />}>
+                  Only letters, digits, hyphens, dots, or underscores
+                </HelperTextItem>
+              </HelperText>
+            }
+          >
+            <TextInput
+              isRequired
+              type="text"
+              value={asset.configMap?.key ?? ''}
+              onChange={(_, value) =>
+                onChange({
+                  configMap: { ...asset.configMap!, key: value },
+                })
+              }
+              id={`${fieldIdPrefix}-config-map-key`}
+              data-testid={`${fieldIdPrefix}-config-map-key-input`}
+            />
+          </ThemeAwareFormGroupWrapper>
+          <ThemeAwareFormGroupWrapper
+            label="Media Type"
+            fieldId={`${fieldIdPrefix}-config-map-media-type`}
+          >
+            <TextInput
+              type="text"
+              value={
+                asset.configMap?.mediaType ??
+                V1Beta1WorkspaceKindAssetMediaType.WorkspaceKindAssetMediaTypeSVG
+              }
+              isDisabled
+              id={`${fieldIdPrefix}-config-map-media-type`}
+              data-testid={`${fieldIdPrefix}-config-map-media-type-input`}
+            />
+          </ThemeAwareFormGroupWrapper>
+        </>
+      )}
+    </FormFieldGroup>
+  );
+};

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindAssetField.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindAssetField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   FormFieldGroup,
   FormFieldGroupHeader,
@@ -29,7 +29,7 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
   asset,
   onChange,
 }) => {
-  const [mode, setMode] = useState<AssetMode>('url');
+  const mode: AssetMode = asset.configMap ? 'configMap' : 'url';
 
   return (
     <FormFieldGroup
@@ -58,7 +58,6 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
               label="URL"
               isChecked={mode === 'url'}
               onChange={() => {
-                setMode('url');
                 onChange({ url: '' });
               }}
             />
@@ -71,7 +70,6 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
               label="ConfigMap"
               isChecked={mode === 'configMap'}
               onChange={() => {
-                setMode('configMap');
                 onChange({
                   configMap: {
                     name: '',
@@ -116,6 +114,13 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
             label="Name"
             isRequired
             fieldId={`${fieldIdPrefix}-config-map-name`}
+            helperTextNode={
+              <HelperText>
+                <HelperTextItem icon={<InfoCircleIcon />}>
+                  Name of the ConfigMap containing the asset data
+                </HelperTextItem>
+              </HelperText>
+            }
           >
             <TextInput
               isRequired
@@ -134,6 +139,13 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
             label="Namespace"
             isRequired
             fieldId={`${fieldIdPrefix}-config-map-namespace`}
+            helperTextNode={
+              <HelperText>
+                <HelperTextItem icon={<InfoCircleIcon />}>
+                  Namespace where the ConfigMap is located
+                </HelperTextItem>
+              </HelperText>
+            }
           >
             <TextInput
               isRequired
@@ -149,16 +161,9 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
             />
           </ThemeAwareFormGroupWrapper>
           <ThemeAwareFormGroupWrapper
-            label="Key"
+            label="ConfigMap Key"
             isRequired
             fieldId={`${fieldIdPrefix}-config-map-key`}
-            helperTextNode={
-              <HelperText>
-                <HelperTextItem icon={<InfoCircleIcon />}>
-                  Only letters, digits, hyphens, dots, or underscores
-                </HelperTextItem>
-              </HelperText>
-            }
           >
             <TextInput
               isRequired
@@ -176,6 +181,13 @@ export const WorkspaceKindAssetField: React.FC<WorkspaceKindAssetFieldProps> = (
           <ThemeAwareFormGroupWrapper
             label="Media Type"
             fieldId={`${fieldIdPrefix}-config-map-media-type`}
+            helperTextNode={
+              <HelperText>
+                <HelperTextItem icon={<InfoCircleIcon />}>
+                  Only SVG media type is currently supported
+                </HelperTextItem>
+              </HelperText>
+            }
           >
             <TextInput
               type="text"

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindFormProperties.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/properties/WorkspaceKindFormProperties.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@patternfly/react-core/dist/esm/components/Switch';
 import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
 import { WorkspaceKindProperties } from '~/app/types';
 import ThemeAwareFormGroupWrapper from '~/shared/components/ThemeAwareFormGroupWrapper';
+import { WorkspaceKindAssetField } from './WorkspaceKindAssetField';
 
 interface WorkspaceKindFormPropertiesProps {
   mode: string;
@@ -113,26 +114,18 @@ export const WorkspaceKindFormProperties: React.FC<WorkspaceKindFormPropertiesPr
               />
             </FormGroup>
           )}
-          <ThemeAwareFormGroupWrapper label="Icon URL" isRequired fieldId="workspace-kind-icon">
-            <TextInput
-              isRequired
-              type="text"
-              value={properties.icon.url}
-              onChange={(_, value) => updateField({ ...properties, icon: { url: value } })}
-              id="workspace-kind-icon"
-              data-testid="workspace-kind-icon-input"
-            />
-          </ThemeAwareFormGroupWrapper>
-          <ThemeAwareFormGroupWrapper label="Logo URL" isRequired fieldId="workspace-kind-logo">
-            <TextInput
-              isRequired
-              type="text"
-              value={properties.logo.url}
-              onChange={(_, value) => updateField({ ...properties, logo: { url: value } })}
-              id="workspace-kind-logo"
-              data-testid="workspace-kind-logo-input"
-            />
-          </ThemeAwareFormGroupWrapper>
+          <WorkspaceKindAssetField
+            label="Icon"
+            fieldIdPrefix="workspace-kind-icon"
+            asset={properties.icon}
+            onChange={(icon) => updateField({ ...properties, icon })}
+          />
+          <WorkspaceKindAssetField
+            label="Logo"
+            fieldIdPrefix="workspace-kind-logo"
+            asset={properties.logo}
+            onChange={(logo) => updateField({ ...properties, logo })}
+          />
         </Form>
       </ExpandableSection>
     </Content>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx
@@ -47,7 +47,7 @@ export const WorkspaceKindDetailsOverview: React.FunctionComponent<
     </DescriptionListGroup>
     <Divider />
     <DescriptionListGroup>
-      <DescriptionListTerm style={{ alignSelf: 'center' }}>Icon</DescriptionListTerm>
+      <DescriptionListTerm style={{ alignSelf: 'center' }}>Icon Source</DescriptionListTerm>
       <DescriptionListDescription>
         <WorkspaceKindImage
           imageSrc={workspaceKind.icon.url}
@@ -65,7 +65,7 @@ export const WorkspaceKindDetailsOverview: React.FunctionComponent<
           {(validSrc) => <img src={validSrc} alt={workspaceKind.name} style={{ width: '40px' }} />}
         </WorkspaceKindImage>
       </DescriptionListDescription>
-      <DescriptionListTerm style={{ alignSelf: 'center' }}>Icon URL</DescriptionListTerm>
+      <DescriptionListTerm style={{ alignSelf: 'center' }}>Source Type</DescriptionListTerm>
       <DescriptionListDescription>
         <a href={workspaceKind.icon.url} target="_blank" rel="noreferrer">
           {workspaceKind.icon.url}
@@ -74,7 +74,7 @@ export const WorkspaceKindDetailsOverview: React.FunctionComponent<
     </DescriptionListGroup>
     <Divider />
     <DescriptionListGroup>
-      <DescriptionListTerm style={{ alignSelf: 'center' }}>Logo</DescriptionListTerm>
+      <DescriptionListTerm style={{ alignSelf: 'center' }}>Logo Source</DescriptionListTerm>
       <DescriptionListDescription>
         <WorkspaceKindImage
           imageSrc={workspaceKind.logo.url}
@@ -92,7 +92,7 @@ export const WorkspaceKindDetailsOverview: React.FunctionComponent<
           {(validSrc) => <img src={validSrc} alt={workspaceKind.name} style={{ width: '40px' }} />}
         </WorkspaceKindImage>
       </DescriptionListDescription>
-      <DescriptionListTerm style={{ alignSelf: 'center' }}>Logo URL</DescriptionListTerm>
+      <DescriptionListTerm style={{ alignSelf: 'center' }}>Source Type</DescriptionListTerm>
       <DescriptionListDescription>
         <a href={workspaceKind.logo.url} target="_blank" rel="noreferrer">
           {workspaceKind.logo.url}

--- a/workspaces/frontend/src/app/standalone/ToastNotifications.tsx
+++ b/workspaces/frontend/src/app/standalone/ToastNotifications.tsx
@@ -7,7 +7,7 @@ const ToastNotifications: React.FC = () => {
   const { notifications } = useContext(NotificationContext);
 
   return (
-    <AlertGroup isToast isLiveRegion>
+    <AlertGroup isToast isLiveRegion data-testid="toast-notification-group">
       {notifications.map((notification) => (
         <ToastNotification notification={notification} key={notification.id} />
       ))}

--- a/workspaces/frontend/src/app/types.ts
+++ b/workspaces/frontend/src/app/types.ts
@@ -1,7 +1,7 @@
 import {
   OptionsImageConfigValue,
   OptionsPodConfigValue,
-  AssetsImageRef,
+  V1Beta1WorkspaceKindAsset,
   WorkspacekindsPodMetadata,
   WorkspacekindsPodVolumeMounts,
   WorkspacekindsWorkspaceKindListItem,
@@ -60,8 +60,8 @@ export interface WorkspaceKindProperties {
   deprecated: boolean;
   deprecationMessage: string;
   hidden: boolean;
-  icon: AssetsImageRef;
-  logo: AssetsImageRef;
+  icon: V1Beta1WorkspaceKindAsset;
+  logo: V1Beta1WorkspaceKindAsset;
 }
 
 export interface WorkspaceKindImageConfigValue extends OptionsImageConfigValue {


### PR DESCRIPTION
 closes: #1232
UI Improvements for WorkspaceKind Form (Edit Mode) component:

#### Better Error Display
Convert from an inline alert to toast alert for better visibility. Users will not have to scroll up to see error messages any longer
<img width="1467" height="858" alt="Screenshot 2026-07-09 at 2 27 01 PM" src="https://github.com/user-attachments/assets/0c61bf33-0f19-44fc-95eb-c29dccae1fae" />

#### Support ConfigMap for Logos and icons
Add ConfigMap support for WorkspaceKind icon and logo fields (it was just URL before)
<img width="1225" height="486" alt="Screenshot 2026-07-09 at 2 28 21 PM" src="https://github.com/user-attachments/assets/f9b1d15e-a8da-4897-96e1-e77ed3df76ce" />

#### Implement Home Volume Path Input in Pod Template Form Section
<img width="480" height="174" alt="Screenshot 2026-07-09 at 2 29 28 PM" src="https://github.com/user-attachments/assets/82fb4566-30ca-46b7-805b-5c549d4e0d59" />


