### PR TITLE
fix: prevent duplicate volumes when same PVC is mounted to multiple paths

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -57,6 +57,7 @@ def post_pvc(namespace):
         api.create_pvc(pvc, namespace, dry_run=True)
 
     # create the new PVCs and set the Notebook volumes and mounts
+    added_volumes = set()
     for api_volume in api_volumes:
         pvc = volumes.get_new_pvc(api_volume)
         if pvc is not None:
@@ -66,7 +67,10 @@ def post_pvc(namespace):
         v1_volume = volumes.get_pod_volume(api_volume, pvc)
         mount = volumes.get_container_mount(api_volume, v1_volume["name"])
 
-        notebook = volumes.add_notebook_volume(notebook, v1_volume)
+        if v1_volume["name"] not in added_volumes:
+            notebook = volumes.add_notebook_volume(notebook, v1_volume)
+            added_volumes.add(v1_volume["name"])
+
         notebook = volumes.add_notebook_container_mount(notebook, mount)
 
     log.info("Creating Notebook: %s", notebook)

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post_test.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest import mock
+
+from flask import Flask
+
+from apps.default.routes import post
+
+
+FORM_SETTERS = (
+    "set_notebook_image",
+    "set_notebook_image_pull_policy",
+    "set_server_type",
+    "set_notebook_cpu",
+    "set_notebook_memory",
+    "set_notebook_gpus",
+    "set_notebook_tolerations",
+    "set_notebook_affinity",
+    "set_notebook_configurations",
+    "set_notebook_shm",
+)
+
+
+class TestPostPVC(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_same_pvc_mounted_at_multiple_paths_adds_one_volume(self):
+        api_volumes = [
+            {
+                "mount": "/data",
+                "existingSource": {
+                    "persistentVolumeClaim": {
+                        "claimName": "shared-pvc",
+                    },
+                },
+            },
+            {
+                "mount": "/backup",
+                "existingSource": {
+                    "persistentVolumeClaim": {
+                        "claimName": "shared-pvc",
+                    },
+                },
+            },
+        ]
+        notebook = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [{}],
+                    },
+                },
+            },
+        }
+
+        with self.app.test_request_context(
+            "/api/namespaces/test-namespace/notebooks",
+            method="POST",
+            json={"name": "test-notebook"},
+        ):
+            with (
+                mock.patch.object(
+                    post.helpers,
+                    "load_param_yaml",
+                    return_value=notebook,
+                ),
+                mock.patch.object(
+                    post.utils,
+                    "load_spawner_ui_config",
+                    return_value={},
+                ),
+                mock.patch.object(
+                    post.form,
+                    "get_form_value",
+                    side_effect=[api_volumes, None],
+                ),
+                mock.patch.object(
+                    post.authn,
+                    "get_username",
+                    return_value="user@example.com",
+                ),
+                mock.patch.object(
+                    post.api,
+                    "create_notebook",
+                ) as create_notebook,
+                mock.patch.multiple(
+                    post.form,
+                    **{name: mock.DEFAULT for name in FORM_SETTERS},
+                ),
+            ):
+                post.post_pvc("test-namespace")
+
+        created_notebook = create_notebook.call_args.args[0]
+        pod_spec = created_notebook["spec"]["template"]["spec"]
+
+        self.assertEqual(
+            [volume["name"] for volume in pod_spec["volumes"]],
+            ["shared-pvc"],
+        )
+        self.assertEqual(
+            [
+                mount["mountPath"]
+                for mount in pod_spec["containers"][0]["volumeMounts"]
+            ],
+            ["/data", "/backup"],
+        )
+        self.assertEqual(
+            {
+                mount["name"]
+                for mount in pod_spec["containers"][0]["volumeMounts"]
+            },
+            {"shared-pvc"},
+        )


### PR DESCRIPTION
When the same PVC is mounted to multiple paths via the Jupyter Web App UI, `add_notebook_volume` appends a `V1Volume` with the same name for each mount. This causes a Kubernetes validation error (duplicate volume names in `spec.volumes`) and the Pod fails to start.

**Fix:** Track already-added volume names in the volume creation loop (`post.py`) to skip duplicate `add_notebook_volume` calls. `add_notebook_container_mount` is unchanged since multiple `volumeMounts` referencing the same volume is valid in Kubernetes.

**How to test:**
1. Create a new notebook with the same PVC mounted to two different paths (e.g. `/data` and `/backup`)
2. Verify the Pod starts successfully with one volume entry and two volume mounts

<sub>Re-opening #1023, which was auto-closed by the stale bot due to inactivity. No changes from the original.</sub>
