### PR TITLE
feat: Stub `ruleEffects` on workspacekinds list API

### DIFF
--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -147,6 +147,11 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2),
 			))
 
+			By("ensuring ruleEffects is present with a stubbed uiHide of false on every WorkspaceKind")
+			for _, item := range response.Data {
+				Expect(item.RuleEffects.UiHide).To(BeFalse())
+			}
+
 			By("ensuring the wrapped data can be marshaled to JSON and back to []WorkspaceKind")
 			dataJSON, err := json.Marshal(response.Data)
 			Expect(err).NotTo(HaveOccurred(), "failed to marshal data to JSON")
@@ -242,6 +247,11 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1),
 				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2),
 			))
+
+			By("ensuring ruleEffects is present with a stubbed uiHide of false even when namespaceFilter is provided")
+			for _, item := range response.Data {
+				Expect(item.RuleEffects.UiHide).To(BeFalse())
+			}
 		})
 
 		It("should return 422 for an invalid namespaceFilter query parameter", func() {

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -58,6 +58,11 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 		Hidden:             ptr.Deref(wsk.Spec.Spawner.Hidden, false),
 		Icon:               assets.NewImageRefFromWorkspaceKindAssetIcon(cfg, wsk.Spec.Spawner.Icon, wsk.Status.SpawnerIcon, wsk.Name),
 		Logo:               assets.NewImageRefFromWorkspaceKindAssetLogo(cfg, wsk.Spec.Spawner.Logo, wsk.Status.SpawnerLogo, wsk.Name),
+		// TODO: stub for compatibility selectors (https://github.com/kubeflow/notebooks/issues/682)
+		//       uiHide is hard-coded to false until WorkspaceKind filterRules evaluation is implemented
+		RuleEffects: RuleEffects{
+			UiHide: false,
+		},
 		// TODO: in the future will need to support including exactly one of clusterMetrics or namespaceMetrics based on request context
 		ClusterMetrics: ClusterKindMetrics{
 			Workspaces: wsk.Status.Workspaces,

--- a/workspaces/backend/internal/models/workspacekinds/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspacekinds
+
+import (
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
+)
+
+func TestWorkspaceKinds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "WorkspaceKinds Models Suite")
+}
+
+var _ = Describe("NewWorkspaceKindModelFromWorkspaceKind", func() {
+
+	It("should include a stubbed ruleEffects with uiHide set to false", func() {
+		By("building the model from a minimal WorkspaceKind")
+		wsk := &kubefloworgv1beta1.WorkspaceKind{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-wsk",
+			},
+		}
+		model := NewWorkspaceKindModelFromWorkspaceKind((*config.EnvConfig)(nil), wsk)
+
+		By("ensuring the compatibility selectors stub is present and hard-coded to false")
+		// TODO: update this expectation once WorkspaceKind filterRules evaluation is
+		//       implemented (https://github.com/kubeflow/notebooks/issues/682).
+		Expect(model.RuleEffects).To(Equal(RuleEffects{UiHide: false}))
+	})
+})

--- a/workspaces/backend/internal/models/workspacekinds/types.go
+++ b/workspaces/backend/internal/models/workspacekinds/types.go
@@ -30,8 +30,21 @@ type WorkspaceKindListItem struct {
 	Hidden             bool               `json:"hidden"`
 	Icon               assets.ImageRef    `json:"icon"`
 	Logo               assets.ImageRef    `json:"logo"`
+	RuleEffects        RuleEffects        `json:"ruleEffects"`
 	ClusterMetrics     ClusterKindMetrics `json:"clusterMetrics"`
 	PodTemplate        PodTemplate        `json:"podTemplate"`
+}
+
+// RuleEffects communicates the outcome of evaluating a WorkspaceKind's compatibility
+// selector filter rules for the current request context.
+//
+// TODO: this is currently a stub for the compatibility selectors feature
+//
+//	(https://github.com/kubeflow/notebooks/issues/682). Once WorkspaceKind
+//	filterRules evaluation is implemented, UiHide will reflect the merged
+//	result of the matching rules' `ui.hide` effects.
+type RuleEffects struct {
+	UiHide bool `json:"uiHide"`
 }
 
 type ClusterKindMetrics struct {

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -6736,6 +6736,17 @@ const docTemplate = `{
                 }
             }
         },
+        "workspacekinds.RuleEffects": {
+            "type": "object",
+            "required": [
+                "uiHide"
+            ],
+            "properties": {
+                "uiHide": {
+                    "type": "boolean"
+                }
+            }
+        },
         "workspacekinds.WorkspaceKindCreate": {
             "type": "object",
             "required": [
@@ -6767,7 +6778,8 @@ const docTemplate = `{
                 "icon",
                 "logo",
                 "name",
-                "podTemplate"
+                "podTemplate",
+                "ruleEffects"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -6799,6 +6811,9 @@ const docTemplate = `{
                 },
                 "podTemplate": {
                     "$ref": "#/definitions/workspacekinds.PodTemplate"
+                },
+                "ruleEffects": {
+                    "$ref": "#/definitions/workspacekinds.RuleEffects"
                 }
             }
         },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -6734,6 +6734,17 @@
                 }
             }
         },
+        "workspacekinds.RuleEffects": {
+            "type": "object",
+            "required": [
+                "uiHide"
+            ],
+            "properties": {
+                "uiHide": {
+                    "type": "boolean"
+                }
+            }
+        },
         "workspacekinds.WorkspaceKindCreate": {
             "type": "object",
             "required": [
@@ -6765,7 +6776,8 @@
                 "icon",
                 "logo",
                 "name",
-                "podTemplate"
+                "podTemplate",
+                "ruleEffects"
             ],
             "properties": {
                 "clusterMetrics": {
@@ -6797,6 +6809,9 @@
                 },
                 "podTemplate": {
                     "$ref": "#/definitions/workspacekinds.PodTemplate"
+                },
+                "ruleEffects": {
+                    "$ref": "#/definitions/workspacekinds.RuleEffects"
                 }
             }
         },


### PR DESCRIPTION
Add a hard-coded `ruleEffects: {"uiHide": false}` attribute to each item
of the `GET /api/v1/workspacekinds` list response. This is a stub for
the Compatibility Selectors feature that establishes the response schema
the frontend can code against, without implementing the WorkspaceKind
filterRules evaluation itself.

`uiHide` is always false and is included regardless of whether the
`namespaceFilter` query parameter is provided.

---

Closes https://github.com/kubeflow/notebooks/issues/838
Related https://github.com/kubeflow/notebooks/pull/1043 https://github.com/kubeflow/notebooks/pull/1033

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
