### PR TITLE
fix: discard controller-runtime logger in the backend

### DIFF
--- a/workspaces/backend/cmd/main.go
+++ b/workspaces/backend/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	application "github.com/kubeflow/notebooks/workspaces/backend/api"
@@ -126,6 +127,13 @@ func main() {
 
 	// Initialize the logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Discard controller-runtime's global logger. We only use the manager as a
+	// lifecycle host for the Kubernetes client, not as an actual controller, so
+	// its internal logs are noise. Without this, controller-runtime emits a
+	// "log.SetLogger(...) was never called" warning the first time it tries to
+	// log (e.g. during shutdown).
+	ctrl.SetLogger(logr.Discard())
 
 	// Build the Kubernetes client configuration
 	kubeconfig, err := ctrl.GetConfig()

--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -5,6 +5,7 @@ go 1.24.13
 replace github.com/kubeflow/notebooks/workspaces/controller => ../controller
 
 require (
+	github.com/go-logr/logr v1.4.2
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kubeflow/notebooks/workspaces/controller v0.0.0
 	github.com/onsi/ginkgo/v2 v2.19.0
@@ -33,7 +34,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect


### PR DESCRIPTION
## What

The backend creates a controller-runtime `Manager` purely as a lifecycle host for the Kubernetes client (metrics/health/leader-election all disabled) — it is not an actual controller. However, `ctrl.SetLogger(...)` was never called, so controller-runtime printed:

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  ...
        >  sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func3()
```

along with a goroutine stack trace, the first time controller-runtime tried to log (e.g. from the manager's stop procedure on shutdown/reload).

## Change

Set the global controller-runtime logger to `logr.Discard()` in `cmd/main.go`, before the manager is created. Since we don't use the manager as a real controller, its internal logs are noise and are simply discarded. The backend's own `slog` logger is unaffected.

`github.com/go-logr/logr` is promoted from an indirect to a direct dependency in `go.mod` (no version change; it was already in the module graph).

## Testing

- `make build` ✅
- `make lint` ✅ (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)