### PR TITLE
refactor: Enable 'modernize' linter

### DIFF
--- a/workspaces/backend/.golangci.yml
+++ b/workspaces/backend/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - modernize
     - nakedret
     - nolintlint
     - prealloc

--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"strings"
@@ -44,9 +45,7 @@ func (a *App) WriteJSON(w http.ResponseWriter, status int, data any, headers htt
 		return err
 	}
 
-	for key, value := range headers {
-		w.Header()[key] = value
-	}
+	maps.Copy(w.Header(), headers)
 
 	w.Header().Set("Content-Type", constants.MediaTypeJson)
 	w.WriteHeader(status)
@@ -60,9 +59,7 @@ func (a *App) WriteJSON(w http.ResponseWriter, status int, data any, headers htt
 
 // WriteSVG writes an SVG response with the given status code, content, and headers.
 func (a *App) WriteSVG(w http.ResponseWriter, status int, content []byte, headers http.Header) error {
-	for key, value := range headers {
-		w.Header()[key] = value
-	}
+	maps.Copy(w.Header(), headers)
 
 	w.Header().Set("Content-Type", constants.MediaTypeSVG)
 	w.WriteHeader(status)

--- a/workspaces/backend/api/workspace_actions_handler_test.go
+++ b/workspaces/backend/api/workspace_actions_handler_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 
 		It("should return 422 when request body is missing data field", func() {
 			By("creating the request body without data field")
-			requestBody := map[string]interface{}{}
+			requestBody := map[string]any{}
 			bodyBytes, err := json.Marshal(requestBody)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -446,8 +446,8 @@ var _ = Describe("Workspace Actions Handler", func() {
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 
 			By("creating the request body with empty data object")
-			requestBody := map[string]interface{}{
-				"data": map[string]interface{}{},
+			requestBody := map[string]any{
+				"data": map[string]any{},
 			}
 			bodyBytes, err := json.Marshal(requestBody)
 			Expect(err).NotTo(HaveOccurred())

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -342,6 +342,7 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 		var validYAML []byte
 
 		BeforeEach(func() {
+			//nolint:modernize
 			validYAML = []byte(fmt.Sprintf(`
 apiVersion: kubeflow.org/v1beta1
 kind: WorkspaceKind

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package workspacekinds
 
 import (
+	"maps"
+
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 	"k8s.io/utils/ptr"
 
@@ -33,12 +35,8 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 	podAnnotations := make(map[string]string)
 	if wsk.Spec.PodTemplate.PodMetadata != nil {
 		// NOTE: we copy the maps to avoid creating a reference to the original maps.
-		for k, v := range wsk.Spec.PodTemplate.PodMetadata.Labels {
-			podLabels[k] = v
-		}
-		for k, v := range wsk.Spec.PodTemplate.PodMetadata.Annotations {
-			podAnnotations[k] = v
-		}
+		maps.Copy(podLabels, wsk.Spec.PodTemplate.PodMetadata.Labels)
+		maps.Copy(podAnnotations, wsk.Spec.PodTemplate.PodMetadata.Annotations)
 	}
 
 	//

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
@@ -220,12 +220,12 @@ func buildOptionRedirect(redirect *kubefloworgv1beta1.OptionRedirect) *OptionRed
 	}
 }
 
-func buildClusterOptionMetrics(optionId string, optionMetricsMap map[string]int32) ClusterOptionMetrics {
+func buildClusterOptionMetrics(optionId string, optionMetricsMap map[string]int32) *ClusterOptionMetrics {
 	optionMetrics := ClusterOptionMetrics{}
 
 	if workspacesCount, ok := optionMetricsMap[optionId]; ok {
 		optionMetrics.Workspaces = workspacesCount
 	}
 
-	return optionMetrics
+	return &optionMetrics
 }

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types.go
@@ -35,14 +35,14 @@ type ImageConfig struct {
 }
 
 type ImageConfigValue struct {
-	Id             string               `json:"id"`
-	DisplayName    string               `json:"displayName"`
-	Description    string               `json:"description"`
-	Labels         []OptionLabel        `json:"labels,omitempty"`
-	Hidden         bool                 `json:"hidden"`
-	Redirect       *OptionRedirect      `json:"redirect,omitempty"`
-	ClusterMetrics ClusterOptionMetrics `json:"clusterMetrics,omitempty"`
-	Restrictions   common.Restrictions  `json:"restrictions"`
+	Id             string                `json:"id"`
+	DisplayName    string                `json:"displayName"`
+	Description    string                `json:"description"`
+	Labels         []OptionLabel         `json:"labels,omitempty"`
+	Hidden         bool                  `json:"hidden"`
+	Redirect       *OptionRedirect       `json:"redirect,omitempty"`
+	ClusterMetrics *ClusterOptionMetrics `json:"clusterMetrics,omitempty"`
+	Restrictions   common.Restrictions   `json:"restrictions"`
 }
 
 type PodConfig struct {
@@ -51,14 +51,14 @@ type PodConfig struct {
 }
 
 type PodConfigValue struct {
-	Id             string               `json:"id"`
-	DisplayName    string               `json:"displayName"`
-	Description    string               `json:"description"`
-	Labels         []OptionLabel        `json:"labels,omitempty"`
-	Hidden         bool                 `json:"hidden"`
-	Redirect       *OptionRedirect      `json:"redirect,omitempty"`
-	ClusterMetrics ClusterOptionMetrics `json:"clusterMetrics,omitempty"`
-	Restrictions   common.Restrictions  `json:"restrictions"`
+	Id             string                `json:"id"`
+	DisplayName    string                `json:"displayName"`
+	Description    string                `json:"description"`
+	Labels         []OptionLabel         `json:"labels,omitempty"`
+	Hidden         bool                  `json:"hidden"`
+	Redirect       *OptionRedirect       `json:"redirect,omitempty"`
+	ClusterMetrics *ClusterOptionMetrics `json:"clusterMetrics,omitempty"`
+	Restrictions   common.Restrictions   `json:"restrictions"`
 }
 
 type OptionLabel struct {

--- a/workspaces/backend/internal/models/workspaces/common/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/common/funcs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package common
 
 import (
+	"maps"
+
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 	"k8s.io/utils/ptr"
 )
@@ -31,12 +33,8 @@ func ExtractPodMetadata(ws *kubefloworgv1beta1.Workspace) PodMetadata {
 	podLabels := make(map[string]string)
 	podAnnotations := make(map[string]string)
 	if ws.Spec.PodTemplate.PodMetadata != nil {
-		for k, v := range ws.Spec.PodTemplate.PodMetadata.Labels {
-			podLabels[k] = v
-		}
-		for k, v := range ws.Spec.PodTemplate.PodMetadata.Annotations {
-			podAnnotations[k] = v
-		}
+		maps.Copy(podLabels, ws.Spec.PodTemplate.PodMetadata.Labels)
+		maps.Copy(podAnnotations, ws.Spec.PodTemplate.PodMetadata.Annotations)
 	}
 	return PodMetadata{
 		Labels:      podLabels,

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -224,9 +224,9 @@ func (r *WorkspaceRepository) DeleteWorkspace(ctx context.Context, namespace, wo
 
 // WorkspacePatchOperation represents a single JSONPatch operation
 type WorkspacePatchOperation struct {
-	Op    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
 }
 
 // HandlePauseAction handles pause/start operations for a workspace

--- a/workspaces/controller/.golangci.yml
+++ b/workspaces/controller/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - modernize
     - nakedret
     - nolintlint
     - prealloc

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -648,7 +649,7 @@ func generateNamePrefix(workspaceName string, maxLength int) string {
 }
 
 // generateStatefulSet generates a StatefulSet for a Workspace
-func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind *kubefloworgv1beta1.WorkspaceKind, imageConfigSpec kubefloworgv1beta1.ImageConfigSpec, podConfigSpec kubefloworgv1beta1.PodConfigSpec) (*appsv1.StatefulSet, error) { //nolint:gocyclo
+func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind *kubefloworgv1beta1.WorkspaceKind, imageConfigSpec kubefloworgv1beta1.ImageConfigSpec, podConfigSpec kubefloworgv1beta1.PodConfigSpec) (*appsv1.StatefulSet, error) {
 	// generate name prefix
 	namePrefix := generateNamePrefix(workspace.Name, maxStatefulSetNameLength)
 
@@ -663,20 +664,12 @@ func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind 
 	podAnnotations := make(map[string]string)
 	podLabels := make(map[string]string)
 	if workspaceKind.Spec.PodTemplate.PodMetadata != nil {
-		for k, v := range workspaceKind.Spec.PodTemplate.PodMetadata.Annotations {
-			podAnnotations[k] = v
-		}
-		for k, v := range workspaceKind.Spec.PodTemplate.PodMetadata.Labels {
-			podLabels[k] = v
-		}
+		maps.Copy(podAnnotations, workspaceKind.Spec.PodTemplate.PodMetadata.Annotations)
+		maps.Copy(podLabels, workspaceKind.Spec.PodTemplate.PodMetadata.Labels)
 	}
 	if workspace.Spec.PodTemplate.PodMetadata != nil {
-		for k, v := range workspace.Spec.PodTemplate.PodMetadata.Annotations {
-			podAnnotations[k] = v
-		}
-		for k, v := range workspace.Spec.PodTemplate.PodMetadata.Labels {
-			podLabels[k] = v
-		}
+		maps.Copy(podAnnotations, workspace.Spec.PodTemplate.PodMetadata.Annotations)
+		maps.Copy(podLabels, workspace.Spec.PodTemplate.PodMetadata.Labels)
 	}
 
 	// generate container imagePullPolicy

--- a/workspaces/controller/test/utils/common.go
+++ b/workspaces/controller/test/utils/common.go
@@ -53,8 +53,8 @@ func Run(cmd *exec.Cmd) (string, error) {
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {
 	var res []string
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
+	elements := strings.SplitSeq(output, "\n")
+	for element := range elements {
 		if element != "" {
 			res = append(res, element)
 		}

--- a/workspaces/controller/test/utils/istio.go
+++ b/workspaces/controller/test/utils/istio.go
@@ -94,7 +94,7 @@ func IsIstioCRDsInstalled() bool {
 }
 
 // verifyIstioVersionOutput validates a single version slice has exactly one element
-func verifyIstioVersionOutput(versionSlice []interface{}, fieldName string) error {
+func verifyIstioVersionOutput(versionSlice []any, fieldName string) error {
 	if versionSlice == nil || len(versionSlice) != 1 {
 		return fmt.Errorf("istioctl version '%s' array must have exactly one element, got %d",
 			fieldName,
@@ -139,9 +139,9 @@ func WaitIstioAvailable() error {
 	// Note: this is not a comprehensive validation of the version output, but a basic validation to ensure the output
 	// matches expectations of e2e tests.
 	type IstioVersionInfo struct {
-		ClientVersion    map[string]interface{} `json:"clientVersion"`
-		MeshVersion      []interface{}          `json:"meshVersion"`
-		DataPlaneVersion []interface{}          `json:"dataPlaneVersion"`
+		ClientVersion    map[string]any `json:"clientVersion"`
+		MeshVersion      []any          `json:"meshVersion"`
+		DataPlaneVersion []any          `json:"dataPlaneVersion"`
 	}
 
 	// Try to parse output as JSON - if it fails, stderr was likely included in combined output from Run command


### PR DESCRIPTION
Detailed descriptions are in each commit:

- **refactor: Enable the 'modernize' linter in `golangci-lint`**
- **refactor: Utilize `maps.Copy()` instead of `for`**
- **refactor: Replace `interface{}` with `any`**
- **refactor: Convert `ClusterOptionMetrics` to pointer**
- **refactor: Use the more efficient `strings.SplitSeq()`**
- **chore: Suppress `fmt.Appendf()` lint in test**

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
