### PR TITLE
fix: add origin and conflict_cause to revision mismatch 409 responses

### DIFF
--- a/workspaces/backend/api/response_errors.go
+++ b/workspaces/backend/api/response_errors.go
@@ -231,6 +231,28 @@ func (a *App) conflictResponse(w http.ResponseWriter, r *http.Request, err error
 	a.errorResponse(w, r, httpError)
 }
 
+// HTTP: 409
+// internalConflictResponse is for conflicts detected by internal application logic,
+// as opposed to conflicts reported by the Kubernetes API server (use conflictResponse for those).
+func (a *App) internalConflictResponse(w http.ResponseWriter, r *http.Request, err error) {
+	httpError := &HTTPError{
+		StatusCode: http.StatusConflict,
+		ErrorResponse: ErrorResponse{
+			Code:    strconv.Itoa(http.StatusConflict),
+			Message: err.Error(),
+			Cause: &ErrorCause{
+				ConflictCauses: []ConflictError{
+					{
+						Origin:  OriginInternal,
+						Message: err.Error(),
+					},
+				},
+			},
+		},
+	}
+	a.errorResponse(w, r, httpError)
+}
+
 // HTTP:413
 func (a *App) requestEntityTooLargeResponse(w http.ResponseWriter, r *http.Request, err error) {
 	httpError := &HTTPError{

--- a/workspaces/backend/api/response_errors_test.go
+++ b/workspaces/backend/api/response_errors_test.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -145,6 +146,39 @@ var _ = Describe("Error Response Functions", func() {
 				Expect(envelope.Error.ErrorResponse).To(Equal(expectedErrorResponse))
 			})
 		}
+	})
+
+	Describe("internalConflictResponse", func() {
+		const testRevisionConflictMsg = "current workspace revision does not match request"
+
+		var httpStatusCodeConflictStr = strconv.Itoa(http.StatusConflict)
+
+		It("should return 409 with an internal conflict cause", func() {
+			err := errors.New(testRevisionConflictMsg)
+
+			app.internalConflictResponse(w, r, err)
+
+			Expect(w.Code).To(Equal(http.StatusConflict))
+
+			var envelope ErrorEnvelope
+			unmarshalErr := json.Unmarshal(w.Body.Bytes(), &envelope)
+			Expect(unmarshalErr).NotTo(HaveOccurred())
+			Expect(envelope.Error).NotTo(BeNil())
+
+			expectedErrorResponse := ErrorResponse{
+				Code:    httpStatusCodeConflictStr,
+				Message: testRevisionConflictMsg,
+				Cause: &ErrorCause{
+					ConflictCauses: []ConflictError{
+						{
+							Origin:  OriginInternal,
+							Message: testRevisionConflictMsg,
+						},
+					},
+				},
+			}
+			Expect(envelope.Error.ErrorResponse).To(Equal(expectedErrorResponse))
+		})
 	})
 
 	Describe("failedValidationResponse", func() {

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -392,8 +392,7 @@ func (a *App) UpdateWorkspaceKindHandler(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		if errors.Is(err, repository.ErrWorkspaceKindRevisionConflict) {
-			causes := helper.StatusCausesFromAPIStatus(err)
-			a.conflictResponse(w, r, err, causes)
+			a.internalConflictResponse(w, r, err)
 			return
 		}
 		if apierrors.IsInvalid(err) {

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -1222,6 +1222,15 @@ metadata:
 
 			By("verifying the HTTP response status code")
 			Expect(rs.StatusCode).To(Equal(http.StatusConflict), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("verifying the error response includes an internal conflict cause")
+			var errorEnvelope ErrorEnvelope
+			Expect(json.Unmarshal(rr.Body.Bytes(), &errorEnvelope)).To(Succeed())
+			Expect(errorEnvelope.Error).NotTo(BeNil())
+			Expect(errorEnvelope.Error.Cause).NotTo(BeNil())
+			Expect(errorEnvelope.Error.Cause.ConflictCauses).To(HaveLen(1))
+			Expect(errorEnvelope.Error.Cause.ConflictCauses[0].Origin).To(Equal(OriginInternal))
+			Expect(errorEnvelope.Error.Cause.ConflictCauses[0].Message).NotTo(BeEmpty())
 		})
 
 		It("should return 415 for wrong Content-Type", func() {

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -370,8 +370,7 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 			return
 		}
 		if errors.Is(err, repository.ErrWorkspaceRevisionConflict) {
-			causes := helper.StatusCausesFromAPIStatus(err)
-			a.conflictResponse(w, r, err, causes)
+			a.internalConflictResponse(w, r, err)
 			return
 		}
 		if apierrors.IsInvalid(err) {

--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -1494,6 +1494,15 @@ var _ = Describe("Workspaces Handler", func() {
 			By("verifying the HTTP response status code is 409")
 			Expect(rs.StatusCode).To(Equal(http.StatusConflict), descUnexpectedHTTPStatus, rr.Body.String())
 
+			By("verifying the error response includes an internal conflict cause")
+			var errorEnvelope ErrorEnvelope
+			Expect(json.Unmarshal(rr.Body.Bytes(), &errorEnvelope)).To(Succeed())
+			Expect(errorEnvelope.Error).NotTo(BeNil())
+			Expect(errorEnvelope.Error.Cause).NotTo(BeNil())
+			Expect(errorEnvelope.Error.Cause.ConflictCauses).To(HaveLen(1))
+			Expect(errorEnvelope.Error.Cause.ConflictCauses[0].Origin).To(Equal(OriginInternal))
+			Expect(errorEnvelope.Error.Cause.ConflictCauses[0].Message).NotTo(BeEmpty())
+
 			By("cleaning up the Workspace")
 			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())
 		})


### PR DESCRIPTION
### What this PR does

This PR adds an `internalConflictResponse` helper (Option A from the issue) that populates `conflict_cause[]` with `origin: "INTERNAL"`, making the envelope consistent with Kubernetes-originated 409 responses:

```
$ curl -sk -X PUT  -H "Kubeflow-Userid: admin" -H "Content-Type: application/json" \
  -d '{"data": {"revision": "stale-revision-that-does-not-match", "paused": false,
       "podTemplate": {"podMetadata": {"labels": {}, "annotations": {}},
                       "volumes": {"home": "test222", "data": []},
                       "options": {"imageConfig": "jupyter-scipy:v1.10.0", "podConfig": "tiny_cpu"}}}}' \
  https://localhost:8443/workspaces/api/v1/workspaces/default/test123 | jq
```
which returns the following
```json
{
  "error": {
    "code": "409",
    "message": "current workspace revision does not match request",
    "cause": {
      "conflict_cause": [
        {
          "origin": "INTERNAL",
          "message": "current workspace revision does not match request"
        }
      ]
    }
  }
}
```

Option A from the original issue was chosen over making `conflictResponse` auto-fill `INTERNAL` when k8s causes are empty, because a genuine Kubernetes 409 (e.g. `apierrors.NewConflict`) can arrive without `Details.Causes` and would then be wrongly mislabeled as internal.

### Scope note

Beyond the `Workspace` update path described in #862, the same fix is applied to the `WorkspaceKind` update path (`ErrWorkspaceKindRevisionConflict`, introduced in #1171), which had the identical issue.

### Acceptance criteria checklist

- [x] Revision mismatch 409 response includes `origin: "INTERNAL"` in the conflict cause
- [x] Revision mismatch 409 response includes a meaningful message in `conflict_cause[].message`
- [x] Error envelope schema is consistent with other 409 Conflict errors
- [x] Swagger/OpenAPI documentation requires no updates
- [x] Unit tests verify the error response structure for revision conflicts

Fixes #862 