### PR TITLE
fix: Fixup shebang validation for the activity probe

### DIFF
--- a/workspaces/controller/internal/webhook/workspacekind_webhook.go
+++ b/workspaces/controller/internal/webhook/workspacekind_webhook.go
@@ -775,11 +775,12 @@ func validateActivityProbe(activityProbe *kubefloworgv1beta1.ActivityProbe, path
 		}
 		if !shebangRegex.MatchString(shebangLine) {
 			errs = append(errs, field.Invalid(path.Child("podExec", "script"), script, "script shebang is invalid (e.g., '#!/bin/bash')"))
-		} else if len(shebangLine)-2 > 255 {
+		} else if len(shebangLine) > 255 {
 			// According to `execve(2)` man page (https://man7.org/linux/man-pages/man2/execve.2.html):
 			// "The kernel imposes a maximum length on the text following the "#!" characters...
 			// On Linux, the limit is 127 characters before Linux 5.1, and 255 characters since Linux 5.1."
 			// This is defined by `BINPRM_BUF_SIZE` (256 bytes, including null terminator) in the Linux kernel `<linux/binfmts.h>`.
+			// However the "#!" counts towards the overall limit, contrary to what the wording in the manpage seems to imply.
 			errs = append(errs, field.Invalid(path.Child("podExec", "script"), script, "shebang line exceeds the 255 character limit"))
 		}
 	}


### PR DESCRIPTION
- path_len=253, shebang_total=255 -> Interpreter ran correctly
- path_len=254, shebang_total=256 -> Path truncated, fell back to default shell
- path_len=255, shebang_total=257 -> Path truncated

cc @siyuanfoundation

---

Verified by Andy via:
```bash
docker run --rm debian:bookworm bash -c '
mkdir -p /tmp/sb
# Build deep nested path (~212 chars)
base="/tmp/sb"
for i in $(seq 1 5); do
    seg=$(printf "d%.0s" $(seq 1 40))
    base="$base/$seg"
done
mkdir -p "$base"

# Create interpreter that prints "OK"
cat > "$base/real" << EOF
#!/bin/bash
echo "OK"
EOF
chmod +x "$base/real"

# Create symlinks at exact path lengths and test
for path_len in 250 251 252 253 254 255 256 257 258 259 260; do
    name_len=$((path_len - ${#base} - 1))
    name=$(printf "i%.0s" $(seq 1 $name_len))
    ln -sf "$base/real" "$base/$name"
    interp="$base/$name"
    script="/tmp/sb/test_${path_len}"
    printf "#!%s\necho body\n" "$interp" > "$script"
    chmod +x "$script"
    output=$("$script" 2>&1)
    rc=$?
    printf "path_len=%3d  shebang_total=%3d  exit=%d  output=%s\n" \
        "${#interp}" "$((${#interp} + 2))" "$rc" "$output"
done
'
```

Which outputs:
```
path_len=250  shebang_total=252  exit=0  output=OK
path_len=251  shebang_total=253  exit=0  output=OK
path_len=252  shebang_total=254  exit=0  output=OK
path_len=253  shebang_total=255  exit=0  output=OK
path_len=254  shebang_total=256  exit=0  output=body
path_len=255  shebang_total=257  exit=0  output=body
path_len=256  shebang_total=258  exit=0  output=body
path_len=257  shebang_total=259  exit=0  output=body
path_len=258  shebang_total=260  exit=0  output=body
path_len=259  shebang_total=261  exit=0  output=body
path_len=260  shebang_total=262  exit=0  output=body
```

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
