### PR TITLE
feat: Add support to convert from yaml to form in WorkspaceKind Edit

### DIFF
--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/WorkspaceKindForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import isEqual from 'lodash-es/isEqual';
 import yaml from 'js-yaml';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
@@ -41,6 +41,7 @@ import { WorkspaceKindFormPodTemplate } from './podTemplate/WorkspaceKindFormPod
 import {
   convertFormDataToUpdate,
   EMPTY_WORKSPACE_KIND_FORM_DATA,
+  generateUniqueId,
   isValidWorkspaceKindUpdate,
 } from './helpers';
 import { WorkspaceKindYamlEditor } from './yamlEditor/WorkspaceKindYamlEditor';
@@ -120,6 +121,10 @@ const convertToFormData = (
             }
           : undefined,
         nodeSelector: v.spec.nodeSelector,
+        tolerations: v.spec.tolerations?.map((t) => ({
+          id: generateUniqueId(),
+          ...t,
+        })),
       })),
     },
     podTemplate: {
@@ -158,6 +163,7 @@ export const WorkspaceKindForm: React.FC = () => {
   const [editYamlValue, setEditYamlValue] = useState('');
   const [originalYaml, setOriginalYaml] = useState('');
   const [yamlParseError, setYamlParseError] = useState<string | null>(null);
+  const lastApiObjectRef = useRef<WorkspacekindsWorkspaceKindUpdate | null>(null);
   const mode: FormMode = useCurrentRouteKey() === 'workspaceKindCreate' ? 'create' : 'edit';
   const [validated, setValidated] = useState<ValidationStatus>(
     mode === 'edit' ? 'success' : 'default',
@@ -181,6 +187,7 @@ export const WorkspaceKindForm: React.FC = () => {
     const converted = convertToFormData(initialFormData);
     replaceData(converted);
     setOriginalFormData(converted);
+    lastApiObjectRef.current = initialFormData;
     const yamlStr = yaml.dump(initialFormData, { noRefs: true });
     setOriginalYaml(yamlStr);
     setEditYamlValue(yamlStr);
@@ -190,18 +197,34 @@ export const WorkspaceKindForm: React.FC = () => {
     (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, tabKey: string | number) => {
       const newTab = tabKey as number;
       if (newTab === YAML_TAB_KEY && activeTabKey === FORM_TAB_KEY) {
-        const updateObj = convertFormDataToUpdate(
-          data,
-          initialFormData as WorkspacekindsWorkspaceKindUpdate,
-        );
+        const updateObj = convertFormDataToUpdate(data, lastApiObjectRef.current!);
         const yamlStr = yaml.dump(updateObj, { noRefs: true });
         setEditYamlValue(yamlStr);
         setOriginalYaml(yamlStr);
+        lastApiObjectRef.current = updateObj;
         setYamlParseError(null);
+      } else if (newTab === FORM_TAB_KEY && activeTabKey === YAML_TAB_KEY) {
+        try {
+          const parsed = yaml.load(editYamlValue);
+          if (!isValidWorkspaceKindUpdate(parsed)) {
+            setYamlParseError(
+              'Invalid WorkspaceKind update structure: must include revision, spawner, and podTemplate',
+            );
+            return;
+          }
+          const typedParsed = parsed as WorkspacekindsWorkspaceKindUpdate;
+          const newFormData = convertToFormData(typedParsed);
+          replaceData(newFormData);
+          lastApiObjectRef.current = typedParsed;
+          setYamlParseError(null);
+        } catch (e) {
+          setYamlParseError((e as Error).message);
+          return;
+        }
       }
       setActiveTabKey(newTab);
     },
-    [activeTabKey, data, initialFormData],
+    [activeTabKey, data, editYamlValue, replaceData],
   );
 
   const handleRevert = useCallback(() => {
@@ -209,6 +232,7 @@ export const WorkspaceKindForm: React.FC = () => {
       const converted = convertToFormData(initialFormData);
       replaceData(converted);
       setOriginalFormData(converted);
+      lastApiObjectRef.current = initialFormData;
       const yamlStr = yaml.dump(initialFormData, { noRefs: true });
       setOriginalYaml(yamlStr);
       setEditYamlValue(yamlStr);
@@ -267,10 +291,7 @@ export const WorkspaceKindForm: React.FC = () => {
       } else {
         const updateResult = await safeApiCall(() =>
           api.workspaceKinds.updateWorkspaceKind(routeParams?.kind || '', {
-            data: convertFormDataToUpdate(
-              data,
-              initialFormData as WorkspacekindsWorkspaceKindUpdate,
-            ),
+            data: convertFormDataToUpdate(data, lastApiObjectRef.current!),
           }),
         );
         if (!updateResult.ok) {
@@ -293,7 +314,6 @@ export const WorkspaceKindForm: React.FC = () => {
     api.workspaceKinds,
     routeParams?.kind,
     data,
-    initialFormData,
     navigate,
     notification,
     yamlValue,
@@ -327,7 +347,6 @@ export const WorkspaceKindForm: React.FC = () => {
   if (mode === 'edit' && initialFormDataError) {
     return <LoadError title="Failed to load workspace kind data" error={initialFormDataError} />;
   }
-  //TODO: Remove warning edit warning when we have a way to reflect changes in the form from the YAML
   return (
     <>
       <PageGroup isFilled={false} stickyOnBreakpoint={{ default: 'top' }}>
@@ -350,7 +369,7 @@ export const WorkspaceKindForm: React.FC = () => {
                     </p>
                   ) : (
                     `View and edit the Workspace Kind using the form or the YAML editor.
-                      Changing the form will affect the YAML, but edits to the YAML will not affect the form.`
+                      Changes are synced between the form and YAML when switching tabs.`
                   )}
                 </Content>
               </FlexItem>

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/__tests__/helpers.spec.ts
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/Form/__tests__/helpers.spec.ts
@@ -1,6 +1,143 @@
-import { getResources } from '~/app/pages/WorkspaceKinds/Form/helpers';
+import { getResources, convertFormDataToUpdate } from '~/app/pages/WorkspaceKinds/Form/helpers';
 import { mockPodConfig } from '~/__mocks__/mockResources';
-import { WorkspaceKindPodConfigValue } from '~/app/types';
+import { WorkspaceKindFormData, WorkspaceKindPodConfigValue, ImagePullPolicy } from '~/app/types';
+import {
+  WorkspacekindsWorkspaceKindUpdate,
+  V1PullPolicy,
+  V1ResourceList,
+} from '~/generated/data-contracts';
+
+const buildMockApiUpdate = (
+  overrides?: Partial<WorkspacekindsWorkspaceKindUpdate>,
+): WorkspacekindsWorkspaceKindUpdate => ({
+  revision: 'rev-1',
+  spawner: {
+    displayName: 'Test WK',
+    description: 'A test workspace kind',
+    deprecated: false,
+    deprecationMessage: '',
+    hidden: false,
+    icon: { url: 'https://example.com/icon.png' },
+    logo: { url: 'https://example.com/logo.png' },
+  },
+  podTemplate: {
+    options: {
+      imageConfig: {
+        spawner: { default: 'img-1' },
+        values: [
+          {
+            id: 'img-1',
+            spawner: {
+              displayName: 'Image One',
+              description: 'First image',
+              hidden: false,
+              labels: [{ key: 'lang', value: 'python' }],
+            },
+            spec: {
+              image: 'registry.io/img:v1',
+              imagePullPolicy: V1PullPolicy.PullIfNotPresent,
+              ports: [{ id: 'http', port: 8888, displayName: 'HTTP' }],
+            },
+          },
+        ],
+      },
+      podConfig: {
+        spawner: { default: 'pod-1' },
+        values: [
+          {
+            id: 'pod-1',
+            spawner: {
+              displayName: 'Pod One',
+              description: 'First pod config',
+              hidden: false,
+              labels: [{ key: 'size', value: 'small' }],
+            },
+            spec: {
+              resources: {
+                requests: { cpu: '1', memory: '2Gi' } as unknown as V1ResourceList,
+                limits: { cpu: '2', memory: '4Gi' } as unknown as V1ResourceList,
+              },
+              nodeSelector: { 'kubernetes.io/os': 'linux' },
+            },
+          },
+        ],
+      },
+    },
+    podMetadata: {
+      labels: { app: 'test' },
+      annotations: { note: 'test-annotation' },
+    },
+    ports: [{ id: 'http', defaultDisplayName: 'HTTP', protocol: 'HTTP' as never }],
+    serviceAccount: { name: 'default-editor' },
+    volumeMounts: { home: '/home/jovyan' },
+    culling: {
+      enabled: true,
+      maxInactiveSeconds: 3600,
+      activityProbe: {
+        jupyter: { lastActivity: true },
+      },
+    },
+  },
+  ...overrides,
+});
+
+const buildMockFormData = (): WorkspaceKindFormData => ({
+  properties: {
+    displayName: 'Test WK',
+    description: 'A test workspace kind',
+    deprecated: false,
+    deprecationMessage: '',
+    hidden: false,
+    icon: { url: 'https://example.com/icon.png' },
+    logo: { url: 'https://example.com/logo.png' },
+  },
+  imageConfig: {
+    default: 'img-1',
+    values: [
+      {
+        id: 'img-1',
+        displayName: 'Image One',
+        description: 'First image',
+        hidden: false,
+        labels: [{ key: 'lang', value: 'python' }],
+        image: 'registry.io/img:v1',
+        imagePullPolicy: ImagePullPolicy.IfNotPresent,
+        ports: [{ id: 'http', port: 8888, displayName: 'HTTP', protocol: 'HTTP' as const }],
+      },
+    ],
+  },
+  podConfig: {
+    default: 'pod-1',
+    values: [
+      {
+        id: 'pod-1',
+        displayName: 'Pod One',
+        description: 'First pod config',
+        hidden: false,
+        labels: [{ key: 'size', value: 'small' }],
+        resources: {
+          requests: { cpu: '1', memory: '2Gi' },
+          limits: { cpu: '2', memory: '4Gi' },
+        },
+        nodeSelector: { 'kubernetes.io/os': 'linux' },
+      },
+    ],
+  },
+  podTemplate: {
+    podMetadata: {
+      labels: { app: 'test' },
+      annotations: { note: 'test-annotation' },
+    },
+    volumeMounts: { home: '/home/jovyan' },
+    culling: {
+      enabled: true,
+      maxInactiveSeconds: 3600,
+      activityProbe: {
+        jupyter: { lastActivity: true },
+      },
+    },
+  },
+});
 
 describe('getResources', () => {
   it('should convert k8s resource object to PodResourceEntry array with correct structure', () => {
@@ -63,5 +200,133 @@ describe('getResources', () => {
       request: '',
       limit: '',
     });
+  });
+});
+
+describe('convertFormDataToUpdate', () => {
+  it('should preserve spawner properties from form data', () => {
+    const formData = buildMockFormData();
+    const original = buildMockApiUpdate();
+
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.revision).toBe('rev-1');
+    expect(result.spawner.displayName).toBe('Test WK');
+    expect(result.spawner.description).toBe('A test workspace kind');
+    expect(result.spawner.deprecated).toBe(false);
+    expect(result.spawner.hidden).toBe(false);
+    expect(result.spawner.icon).toEqual({ url: 'https://example.com/icon.png' });
+    expect(result.spawner.logo).toEqual({ url: 'https://example.com/logo.png' });
+  });
+
+  it('should preserve podTemplate metadata from form data', () => {
+    const formData = buildMockFormData();
+    const original = buildMockApiUpdate();
+
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.podTemplate.podMetadata).toEqual({
+      labels: { app: 'test' },
+      annotations: { note: 'test-annotation' },
+    });
+    expect(result.podTemplate.volumeMounts).toEqual({ home: '/home/jovyan' });
+  });
+
+  it('should preserve culling config from form data', () => {
+    const formData = buildMockFormData();
+    const original = buildMockApiUpdate();
+
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.podTemplate.culling).toEqual({
+      enabled: true,
+      maxInactiveSeconds: 3600,
+      activityProbe: {
+        jupyter: { lastActivity: true },
+      },
+    });
+  });
+
+  it('should map image config values correctly', () => {
+    const formData = buildMockFormData();
+    const original = buildMockApiUpdate();
+
+    const result = convertFormDataToUpdate(formData, original);
+    const img = result.podTemplate.options.imageConfig.values[0];
+
+    expect(img.id).toBe('img-1');
+    expect(img.spawner.displayName).toBe('Image One');
+    expect(img.spawner.description).toBe('First image');
+    expect(img.spec.image).toBe('registry.io/img:v1');
+    expect(img.spec.ports).toEqual([{ id: 'http', port: 8888, displayName: 'HTTP' }]);
+  });
+
+  it('should map pod config values with resources correctly', () => {
+    const formData = buildMockFormData();
+    const original = buildMockApiUpdate();
+
+    const result = convertFormDataToUpdate(formData, original);
+    const pod = result.podTemplate.options.podConfig.values[0];
+
+    expect(pod.id).toBe('pod-1');
+    expect(pod.spawner.displayName).toBe('Pod One');
+    expect(pod.spec.resources).toEqual({
+      requests: { cpu: '1', memory: '2Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    });
+    expect(pod.spec.nodeSelector).toEqual({ 'kubernetes.io/os': 'linux' });
+  });
+
+  it('should preserve non-form fields from original via spreading', () => {
+    const original = buildMockApiUpdate();
+    // Add a non-form field to a pod config spec
+    (
+      original.podTemplate.options.podConfig.values[0].spec as unknown as Record<string, unknown>
+    ).affinity = {
+      nodeAffinity: {
+        requiredDuringSchedulingIgnoredDuringExecution: {
+          nodeSelectorTerms: [{ matchExpressions: [{ key: 'gpu', operator: 'Exists' }] }],
+        },
+      },
+    };
+
+    const formData = buildMockFormData();
+    const result = convertFormDataToUpdate(formData, original);
+
+    // The affinity field should be preserved from the original via ...originalValue?.spec spread
+    expect(
+      (result.podTemplate.options.podConfig.values[0].spec as unknown as Record<string, unknown>)
+        .affinity,
+    ).toBeDefined();
+  });
+
+  it('should preserve non-form podTemplate fields from original via spreading', () => {
+    const original = buildMockApiUpdate();
+    // Add non-form podTemplate fields
+    (original.podTemplate as unknown as Record<string, unknown>).extraEnv = [
+      { name: 'MY_VAR', value: 'test' },
+    ];
+
+    const formData = buildMockFormData();
+    const result = convertFormDataToUpdate(formData, original);
+
+    // extraEnv should be preserved via ...original.podTemplate spread
+    expect((result.podTemplate as unknown as Record<string, unknown>).extraEnv).toEqual([
+      { name: 'MY_VAR', value: 'test' },
+    ]);
+  });
+
+  it('should convert empty string optional fields to undefined', () => {
+    const formData = buildMockFormData();
+    formData.properties.deprecationMessage = '';
+    formData.properties.icon = { url: '' };
+    formData.properties.logo = { url: '' };
+
+    const original = buildMockApiUpdate();
+    const result = convertFormDataToUpdate(formData, original);
+
+    expect(result.spawner.deprecationMessage).toBeUndefined();
+    expect(result.spawner.icon).toEqual({ url: undefined });
+    expect(result.spawner.logo).toEqual({ url: undefined });
   });
 });


### PR DESCRIPTION
closes: #1234

- Added `lastApiObjectRef` to support bidirectional conversion when users toggle between Form and YAML when editing WorkspaceKind
- Added unit tests