### PR TITLE
feat: add redirect/hidden confirmation modal to workspace form

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
@@ -1,3 +1,51 @@
+class RedirectConfirmModal {
+  find() {
+    return cy.findByTestId('redirect-confirm-modal');
+  }
+
+  assertModalVisible() {
+    return this.find().should('be.visible');
+  }
+
+  assertModalNotExists() {
+    cy.findByTestId('redirect-confirm-modal').should('not.exist');
+  }
+
+  findApplyRedirectButton() {
+    return this.find().findByTestId('apply-redirect-button');
+  }
+
+  clickApplyRedirect() {
+    return this.findApplyRedirectButton().click();
+  }
+
+  assertApplyRedirectButtonExists() {
+    return this.findApplyRedirectButton().should('exist');
+  }
+
+  assertApplyRedirectButtonNotExists() {
+    return this.find().findByTestId('apply-redirect-button').should('not.exist');
+  }
+
+  findContinueButton() {
+    return this.find().findByTestId('continue-button');
+  }
+
+  clickContinue() {
+    return this.findContinueButton().click();
+  }
+
+  findCancelButton() {
+    return this.find().findByTestId('cancel-button');
+  }
+
+  clickCancel() {
+    return this.findCancelButton().click();
+  }
+}
+
+const redirectConfirmModal = new RedirectConfirmModal();
+
 /**
  * Base class for workspace form page objects (create and edit).
  * Contains shared methods for interacting with the WorkspaceForm component.
@@ -282,6 +330,15 @@ class WorkspaceForm {
     return cy.findByTestId('summary-diff-new');
   }
 
+  /**
+   * Clicks Next and dismisses the redirect confirm modal by clicking "Keep Selection" (Continue).
+   * Use when navigating past a step that has a redirected or hidden option selected.
+   */
+  advancePastRedirectModal(): void {
+    this.clickNext();
+    redirectConfirmModal.clickContinue();
+  }
+
   findRedirectSummaryIcon(step: number, suffix: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId(`redirect-icon-${step}-${suffix}`);
   }
@@ -441,52 +498,6 @@ class SecretsCreateModal {
   }
 }
 
-class RedirectConfirmModal {
-  find() {
-    return cy.findByTestId('redirect-confirm-modal');
-  }
-
-  assertModalVisible() {
-    return this.find().should('be.visible');
-  }
-
-  assertModalNotExists() {
-    cy.findByTestId('redirect-confirm-modal').should('not.exist');
-  }
-
-  findApplyRedirectButton() {
-    return this.find().findByTestId('apply-redirect-button');
-  }
-
-  clickApplyRedirect() {
-    return this.findApplyRedirectButton().click();
-  }
-
-  assertApplyRedirectButtonExists() {
-    return this.findApplyRedirectButton().should('exist');
-  }
-
-  assertApplyRedirectButtonNotExists() {
-    return this.find().findByTestId('apply-redirect-button').should('not.exist');
-  }
-
-  findContinueButton() {
-    return this.find().findByTestId('continue-button');
-  }
-
-  clickContinue() {
-    return this.findContinueButton().click();
-  }
-
-  findCancelButton() {
-    return this.find().findByTestId('cancel-button');
-  }
-
-  clickCancel() {
-    return this.findCancelButton().click();
-  }
-}
-
 export { WorkspaceForm };
+export { redirectConfirmModal };
 export const secretsCreateModal = new SecretsCreateModal();
-export const redirectConfirmModal = new RedirectConfirmModal();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
@@ -441,5 +441,52 @@ class SecretsCreateModal {
   }
 }
 
+class RedirectConfirmModal {
+  find() {
+    return cy.findByTestId('redirect-confirm-modal');
+  }
+
+  assertModalVisible() {
+    return this.find().should('be.visible');
+  }
+
+  assertModalNotExists() {
+    cy.findByTestId('redirect-confirm-modal').should('not.exist');
+  }
+
+  findApplyRedirectButton() {
+    return this.find().findByTestId('apply-redirect-button');
+  }
+
+  clickApplyRedirect() {
+    return this.findApplyRedirectButton().click();
+  }
+
+  assertApplyRedirectButtonExists() {
+    return this.findApplyRedirectButton().should('exist');
+  }
+
+  assertApplyRedirectButtonNotExists() {
+    return this.find().findByTestId('apply-redirect-button').should('not.exist');
+  }
+
+  findContinueButton() {
+    return this.find().findByTestId('continue-button');
+  }
+
+  clickContinue() {
+    return this.findContinueButton().click();
+  }
+
+  findCancelButton() {
+    return this.find().findByTestId('cancel-button');
+  }
+
+  clickCancel() {
+    return this.findCancelButton().click();
+  }
+}
+
 export { WorkspaceForm };
 export const secretsCreateModal = new SecretsCreateModal();
+export const redirectConfirmModal = new RedirectConfirmModal();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -47,15 +47,13 @@ const selectImage = (imageId: string): void => {
   createWorkspace.checkExtraFilter('showHidden');
   createWorkspace.selectImage(imageId);
   createWorkspace.assertImageSelected(imageId);
-  createWorkspace.clickNext();
-  redirectConfirmModal.clickContinue();
+  createWorkspace.advancePastRedirectModal();
 };
 
 const selectPodConfig = (podConfigId: string): void => {
   createWorkspace.selectPodConfig(podConfigId);
   createWorkspace.assertPodConfigSelected(podConfigId);
-  createWorkspace.clickNext();
-  redirectConfirmModal.clickContinue();
+  createWorkspace.advancePastRedirectModal();
 };
 
 const buildMockImageConfigValue = (
@@ -168,8 +166,7 @@ describe('Create workspace', () => {
       createWorkspace.assertNextButtonEnabled();
 
       // Step 3: Select Pod Config
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
       createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
       createWorkspace.assertNextButtonEnabled();
 
@@ -178,8 +175,7 @@ describe('Create workspace', () => {
       createWorkspace.assertNextButtonEnabled();
 
       // Step 4: Properties
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
       createWorkspace.assertProgressStepVisible(STEP_NAMES.PROPERTIES);
       createWorkspace.assertNextButtonDisabled();
 
@@ -304,12 +300,10 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showRedirected');
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
 
       createWorkspace.selectPodConfig(mockPodConfig.id);
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
 
       createWorkspace.typeWorkspaceName('my-test-workspace');
 
@@ -438,8 +432,7 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showRedirected');
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
 
       // Select first pod config
       createWorkspace.selectPodConfig(mockPodConfig.id);
@@ -479,8 +472,7 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showRedirected');
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
 
       createWorkspace.selectPodConfig(mockPodConfig.id);
 
@@ -594,8 +586,7 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showRedirected');
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
-      createWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal();
 
       // Select the single available pod config
       createWorkspace.selectPodConfig(mockPodConfig.id);

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -1,7 +1,10 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
 import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
-import { secretsCreateModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
+import {
+  redirectConfirmModal,
+  secretsCreateModal,
+} from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import {
   buildMockNamespace,
@@ -45,12 +48,14 @@ const selectImage = (imageId: string): void => {
   createWorkspace.selectImage(imageId);
   createWorkspace.assertImageSelected(imageId);
   createWorkspace.clickNext();
+  redirectConfirmModal.clickContinue();
 };
 
 const selectPodConfig = (podConfigId: string): void => {
   createWorkspace.selectPodConfig(podConfigId);
   createWorkspace.assertPodConfigSelected(podConfigId);
   createWorkspace.clickNext();
+  redirectConfirmModal.clickContinue();
 };
 
 const buildMockImageConfigValue = (
@@ -164,6 +169,7 @@ describe('Create workspace', () => {
 
       // Step 3: Select Pod Config
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
       createWorkspace.assertNextButtonEnabled();
 
@@ -173,6 +179,7 @@ describe('Create workspace', () => {
 
       // Step 4: Properties
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       createWorkspace.assertProgressStepVisible(STEP_NAMES.PROPERTIES);
       createWorkspace.assertNextButtonDisabled();
 
@@ -298,9 +305,11 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.selectPodConfig(mockPodConfig.id);
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.typeWorkspaceName('my-test-workspace');
 
@@ -430,6 +439,7 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       // Select first pod config
       createWorkspace.selectPodConfig(mockPodConfig.id);
@@ -470,6 +480,7 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.selectPodConfig(mockPodConfig.id);
 
@@ -584,6 +595,7 @@ describe('Create workspace', () => {
       createWorkspace.checkExtraFilter('showHidden');
       createWorkspace.selectImage(mockImage.id);
       createWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       // Select the single available pod config
       createWorkspace.selectPodConfig(mockPodConfig.id);
@@ -1581,6 +1593,173 @@ describe('Create workspace', () => {
       createWorkspace.clickNext();
 
       createWorkspace.assertPodConfigSelected(bigGpuPod.id);
+    });
+  });
+
+  describe('Redirect and hidden confirmation', () => {
+    const navigateToImageStep = (): void => {
+      navigateToCreateWorkspace();
+      selectWorkspaceKind(mockWorkspaceKind.name);
+    };
+
+    const navigateToPodConfigStep = (): void => {
+      navigateToImageStep();
+      createWorkspace.selectImage('jupyterlab_scipy_210');
+      createWorkspace.clickNext();
+    };
+
+    describe('Image redirect', () => {
+      it('should show redirect modal when clicking Next with a redirected image', () => {
+        navigateToImageStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectImage('jupyterlab_scipy_180');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.assertModalVisible();
+        redirectConfirmModal.assertApplyRedirectButtonExists();
+      });
+
+      it('should apply redirect and advance to pod config step', () => {
+        navigateToImageStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectImage('jupyterlab_scipy_180');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickApplyRedirect();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
+
+        createWorkspace.clickPrevious();
+        createWorkspace.assertImageSelected('jupyterlab_scipy_210');
+      });
+
+      it('should keep original selection and advance when clicking Continue', () => {
+        navigateToImageStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectImage('jupyterlab_scipy_180');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickContinue();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
+
+        createWorkspace.clickPrevious();
+        createWorkspace.assertImageSelected('jupyterlab_scipy_180');
+      });
+
+      it('should close modal and stay on image step when clicking Cancel', () => {
+        navigateToImageStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectImage('jupyterlab_scipy_180');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickCancel();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.IMAGE);
+        createWorkspace.assertImageSelected('jupyterlab_scipy_180');
+      });
+    });
+
+    describe('Image hidden only', () => {
+      it('should show warning modal without Apply Redirect button', () => {
+        navigateToImageStep();
+
+        createWorkspace.checkExtraFilter('showHidden');
+        createWorkspace.selectImage('jupyterlab_scipy_220_hidden');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.assertModalVisible();
+        redirectConfirmModal.assertApplyRedirectButtonNotExists();
+      });
+
+      it('should advance when clicking Continue', () => {
+        navigateToImageStep();
+
+        createWorkspace.checkExtraFilter('showHidden');
+        createWorkspace.selectImage('jupyterlab_scipy_220_hidden');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickContinue();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
+      });
+    });
+
+    describe('Pod config redirect', () => {
+      it('should show redirect modal when clicking Next with a redirected pod config', () => {
+        navigateToPodConfigStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectPodConfig('tiny_cpu');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.assertModalVisible();
+        redirectConfirmModal.assertApplyRedirectButtonExists();
+      });
+
+      it('should apply redirect and advance to properties step', () => {
+        navigateToPodConfigStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectPodConfig('tiny_cpu');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickApplyRedirect();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.PROPERTIES);
+
+        createWorkspace.clickPrevious();
+        createWorkspace.assertPodConfigSelected('small_cpu');
+      });
+
+      it('should close modal and stay on pod config step when clicking Cancel', () => {
+        navigateToPodConfigStep();
+
+        createWorkspace.checkExtraFilter('showRedirected');
+        createWorkspace.selectPodConfig('tiny_cpu');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickCancel();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.POD_CONFIG);
+        createWorkspace.assertPodConfigSelected('tiny_cpu');
+      });
+    });
+
+    describe('Pod config hidden only', () => {
+      it('should show warning modal without Apply Redirect button', () => {
+        navigateToPodConfigStep();
+
+        createWorkspace.checkExtraFilter('showHidden');
+        createWorkspace.selectPodConfig('large_cpu_hidden');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.assertModalVisible();
+        redirectConfirmModal.assertApplyRedirectButtonNotExists();
+      });
+
+      it('should advance when clicking Continue', () => {
+        navigateToPodConfigStep();
+
+        createWorkspace.checkExtraFilter('showHidden');
+        createWorkspace.selectPodConfig('large_cpu_hidden');
+        createWorkspace.clickNext();
+
+        redirectConfirmModal.clickContinue();
+
+        redirectConfirmModal.assertModalNotExists();
+        createWorkspace.assertProgressStepVisible(STEP_NAMES.PROPERTIES);
+      });
     });
   });
 });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
@@ -12,7 +12,6 @@ import {
   buildMockWorkspaceKindInfo,
   buildMockWorkspaceUpdate,
 } from '~/shared/mock/mockBuilder';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
@@ -161,10 +160,8 @@ describe('Edit workspace', () => {
 
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
+      editWorkspace.advancePastRedirectModal();
       editWorkspace.clickNext();
 
       editWorkspace.assertSaveButtonExists();
@@ -201,10 +198,8 @@ describe('Edit workspace', () => {
 
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
+      editWorkspace.advancePastRedirectModal();
       editWorkspace.clickNext();
 
       editWorkspace.clickSave();
@@ -248,8 +243,7 @@ describe('Edit workspace', () => {
       editWorkspace.checkExtraFilter('showRedirected');
       editWorkspace.checkExtraFilter('showHidden');
       editWorkspace.selectImage(newImageConfigId);
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
 
       // Step 3: Pod Config Selection - change to a different pod config
       editWorkspace.selectPodConfig(newPodConfigId);
@@ -297,8 +291,7 @@ describe('Edit workspace', () => {
 
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
 
       editWorkspace.assertPodConfigSelected(POD_CONFIG_ID);
     });
@@ -310,10 +303,8 @@ describe('Edit workspace', () => {
 
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
+      editWorkspace.advancePastRedirectModal();
 
       editWorkspace.assertWorkspaceName(TEST_WORKSPACE_NAME);
 
@@ -407,10 +398,8 @@ describe('Edit workspace', () => {
 
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
+      editWorkspace.advancePastRedirectModal();
 
       editWorkspace.assertWorkspaceNameCannotBeChangedHelperTextVisible();
     });
@@ -422,10 +411,8 @@ describe('Edit workspace', () => {
 
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
+      editWorkspace.advancePastRedirectModal();
 
       editWorkspace.assertWorkspaceNameInputDisabled();
     });
@@ -448,14 +435,12 @@ describe('Edit workspace', () => {
       editWorkspace.checkExtraFilter('showRedirected');
       editWorkspace.assertImageSelected(IMAGE_CONFIG_ID);
       editWorkspace.assertNextButtonEnabled();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
 
       // Step 3: Pod Config Selection
       editWorkspace.assertPodConfigSelected(POD_CONFIG_ID);
       editWorkspace.assertNextButtonEnabled();
-      editWorkspace.clickNext();
-      redirectConfirmModal.clickContinue();
+      editWorkspace.advancePastRedirectModal();
 
       // Step 4: Properties
       editWorkspace.assertNextButtonEnabled();
@@ -506,10 +491,8 @@ describe('Edit workspace — volume detach behavior', () => {
     visitEditWorkspace();
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext(); // workspace kind → image
-    editWorkspace.clickNext(); // image → pod config
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext(); // pod config → properties
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal(); // image → pod config
+    editWorkspace.advancePastRedirectModal(); // pod config → properties
 
     volumesManagement.expandVolumesSection();
     cy.wait('@listPVCs');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/editWorkspace.cy.ts
@@ -12,6 +12,7 @@ import {
   buildMockWorkspaceKindInfo,
   buildMockWorkspaceUpdate,
 } from '~/shared/mock/mockBuilder';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { interceptListValues } from '~/__tests__/cypress/cypress/utils/testBuilders';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
@@ -161,7 +162,9 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
 
       editWorkspace.assertSaveButtonExists();
@@ -199,7 +202,9 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
 
       editWorkspace.clickSave();
@@ -244,6 +249,7 @@ describe('Edit workspace', () => {
       editWorkspace.checkExtraFilter('showHidden');
       editWorkspace.selectImage(newImageConfigId);
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       // Step 3: Pod Config Selection - change to a different pod config
       editWorkspace.selectPodConfig(newPodConfigId);
@@ -292,6 +298,7 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       editWorkspace.assertPodConfigSelected(POD_CONFIG_ID);
     });
@@ -304,7 +311,9 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       editWorkspace.assertWorkspaceName(TEST_WORKSPACE_NAME);
 
@@ -399,7 +408,9 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       editWorkspace.assertWorkspaceNameCannotBeChangedHelperTextVisible();
     });
@@ -412,7 +423,9 @@ describe('Edit workspace', () => {
       cy.wait('@getWorkspaceKinds');
       editWorkspace.clickNext();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       editWorkspace.assertWorkspaceNameInputDisabled();
     });
@@ -436,11 +449,13 @@ describe('Edit workspace', () => {
       editWorkspace.assertImageSelected(IMAGE_CONFIG_ID);
       editWorkspace.assertNextButtonEnabled();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       // Step 3: Pod Config Selection
       editWorkspace.assertPodConfigSelected(POD_CONFIG_ID);
       editWorkspace.assertNextButtonEnabled();
       editWorkspace.clickNext();
+      redirectConfirmModal.clickContinue();
 
       // Step 4: Properties
       editWorkspace.assertNextButtonEnabled();
@@ -492,7 +507,9 @@ describe('Edit workspace — volume detach behavior', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext(); // workspace kind → image
     editWorkspace.clickNext(); // image → pod config
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext(); // pod config → properties
+    redirectConfirmModal.clickContinue();
 
     volumesManagement.expandVolumesSection();
     cy.wait('@listPVCs');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
@@ -1,5 +1,6 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import {
@@ -95,7 +96,9 @@ describe('SecretsAttachModal', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     cy.contains('button', 'Secrets').click();
     cy.wait('@listSecrets'); // Wait for secrets to load after expanding section
   });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
@@ -1,6 +1,5 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import {
@@ -95,10 +94,8 @@ describe('SecretsAttachModal', () => {
     cy.wait('@getWorkspace');
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal();
+    editWorkspace.advancePastRedirectModal();
     cy.contains('button', 'Secrets').click();
     cy.wait('@listSecrets'); // Wait for secrets to load after expanding section
   });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
@@ -1,5 +1,6 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import {
   secretsManagement,
   secretsModal,
@@ -130,7 +131,9 @@ describe('Edit Secret Modal', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     secretsManagement.expandSecretsSection();
     cy.wait('@listSecrets');
   });
@@ -244,7 +247,9 @@ describe('Edit Secret Modal', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     secretsManagement.expandSecretsSection();
     cy.wait('@listSecretsImmutable');
 
@@ -300,7 +305,9 @@ describe('Edit Secret Modal', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     secretsManagement.expandSecretsSection();
     cy.wait('@listSecretsUpdated');
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
@@ -1,6 +1,5 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import {
   secretsManagement,
   secretsModal,
@@ -130,10 +129,8 @@ describe('Edit Secret Modal', () => {
     cy.wait('@getWorkspace');
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal();
+    editWorkspace.advancePastRedirectModal();
     secretsManagement.expandSecretsSection();
     cy.wait('@listSecrets');
   });
@@ -246,10 +243,8 @@ describe('Edit Secret Modal', () => {
     cy.wait('@getWorkspace');
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal();
+    editWorkspace.advancePastRedirectModal();
     secretsManagement.expandSecretsSection();
     cy.wait('@listSecretsImmutable');
 
@@ -304,10 +299,8 @@ describe('Edit Secret Modal', () => {
     cy.wait('@getWorkspace');
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal();
+    editWorkspace.advancePastRedirectModal();
     secretsManagement.expandSecretsSection();
     cy.wait('@listSecretsUpdated');
 

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
@@ -1,5 +1,6 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import {
   secretsManagement,
   secretsAttachModal,
@@ -124,7 +125,9 @@ describe('Secrets Expandable Key/Value Pairs', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext(); // Skip workspace kind step
     editWorkspace.clickNext(); // Skip image step
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext(); // Skip pod config step, now on properties
+    redirectConfirmModal.clickContinue();
 
     // Expand the Secrets section (it's collapsed by default)
     cy.contains('button', 'Secrets').click();
@@ -225,7 +228,9 @@ describe('Secrets Management - Attach Modal', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext();
+    redirectConfirmModal.clickContinue();
 
     cy.contains('button', 'Secrets').click();
   });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
@@ -1,6 +1,5 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import {
   secretsManagement,
   secretsAttachModal,
@@ -124,10 +123,8 @@ describe('Secrets Expandable Key/Value Pairs', () => {
     // Navigate to properties step where secrets are visible
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext(); // Skip workspace kind step
-    editWorkspace.clickNext(); // Skip image step
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext(); // Skip pod config step, now on properties
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal(); // Skip image step
+    editWorkspace.advancePastRedirectModal(); // Skip pod config step, now on properties
 
     // Expand the Secrets section (it's collapsed by default)
     cy.contains('button', 'Secrets').click();
@@ -227,10 +224,8 @@ describe('Secrets Management - Attach Modal', () => {
     cy.wait('@getWorkspace');
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext();
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal();
+    editWorkspace.advancePastRedirectModal();
 
     cy.contains('button', 'Secrets').click();
   });

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryRedirectPopover.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryRedirectPopover.cy.ts
@@ -1,5 +1,6 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
@@ -92,7 +93,9 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
   describe('Pinning behavior', () => {
     it('should pin popover on icon click', () => {
       createWorkspace.clickNext(); // Pod config
+      redirectConfirmModal.clickContinue();
       createWorkspace.clickNext(); // Properties
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').click();
       createWorkspace.assertPopoverContentVisible(1, 'current');
@@ -103,7 +106,9 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
 
     it('should unpin popover on second click', () => {
       createWorkspace.clickNext(); // Pod config
+      redirectConfirmModal.clickContinue();
       createWorkspace.clickNext(); // Properties
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').click();
       createWorkspace.assertPopoverContentVisible(1, 'current');
@@ -114,7 +119,9 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
 
     it('should not start delayed hide timer when popover is pinned', () => {
       createWorkspace.clickNext(); // Pod config
+      redirectConfirmModal.clickContinue();
       createWorkspace.clickNext(); // Properties
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').click();
       createWorkspace.assertPopoverContentVisible(1, 'current');
@@ -129,7 +136,9 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
   describe('Keyboard accessibility', () => {
     it('should pin popover on Enter key', () => {
       createWorkspace.clickNext(); // Pod config
+      redirectConfirmModal.clickContinue();
       createWorkspace.clickNext(); // Properties
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').focus();
       createWorkspace.findRedirectSummaryIcon(1, 'current').type('{enter}');
@@ -138,7 +147,9 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
 
     it('should pin popover on Space key', () => {
       createWorkspace.clickNext(); // Pod config
+      redirectConfirmModal.clickContinue();
       createWorkspace.clickNext(); // Properties
+      redirectConfirmModal.clickContinue();
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').focus();
       createWorkspace.findRedirectSummaryIcon(1, 'current').type(' ');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryRedirectPopover.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/summaryRedirectPopover.cy.ts
@@ -1,6 +1,5 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
@@ -92,10 +91,8 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
 
   describe('Pinning behavior', () => {
     it('should pin popover on icon click', () => {
-      createWorkspace.clickNext(); // Pod config
-      redirectConfirmModal.clickContinue();
-      createWorkspace.clickNext(); // Properties
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal(); // Pod config
+      createWorkspace.advancePastRedirectModal(); // Properties
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').click();
       createWorkspace.assertPopoverContentVisible(1, 'current');
@@ -105,10 +102,8 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
     });
 
     it('should unpin popover on second click', () => {
-      createWorkspace.clickNext(); // Pod config
-      redirectConfirmModal.clickContinue();
-      createWorkspace.clickNext(); // Properties
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal(); // Pod config
+      createWorkspace.advancePastRedirectModal(); // Properties
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').click();
       createWorkspace.assertPopoverContentVisible(1, 'current');
@@ -118,10 +113,8 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
     });
 
     it('should not start delayed hide timer when popover is pinned', () => {
-      createWorkspace.clickNext(); // Pod config
-      redirectConfirmModal.clickContinue();
-      createWorkspace.clickNext(); // Properties
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal(); // Pod config
+      createWorkspace.advancePastRedirectModal(); // Properties
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').click();
       createWorkspace.assertPopoverContentVisible(1, 'current');
@@ -135,10 +128,8 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
 
   describe('Keyboard accessibility', () => {
     it('should pin popover on Enter key', () => {
-      createWorkspace.clickNext(); // Pod config
-      redirectConfirmModal.clickContinue();
-      createWorkspace.clickNext(); // Properties
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal(); // Pod config
+      createWorkspace.advancePastRedirectModal(); // Properties
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').focus();
       createWorkspace.findRedirectSummaryIcon(1, 'current').type('{enter}');
@@ -146,10 +137,8 @@ describe('Summary Redirect Popover - Delayed Hide Behavior', () => {
     });
 
     it('should pin popover on Space key', () => {
-      createWorkspace.clickNext(); // Pod config
-      redirectConfirmModal.clickContinue();
-      createWorkspace.clickNext(); // Properties
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal(); // Pod config
+      createWorkspace.advancePastRedirectModal(); // Properties
 
       createWorkspace.findRedirectSummaryIcon(1, 'current').focus();
       createWorkspace.findRedirectSummaryIcon(1, 'current').type(' ');

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
@@ -1,5 +1,6 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import {
   volumesManagement,
   volumesAttachModal,
@@ -167,7 +168,9 @@ describe('Volumes Management - Attach and Create', () => {
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext(); // Skip workspace kind step
     editWorkspace.clickNext(); // Skip image step
+    redirectConfirmModal.clickContinue();
     editWorkspace.clickNext(); // Skip pod config step, now on properties
+    redirectConfirmModal.clickContinue();
 
     // Expand the Data Volumes section
     cy.contains('button', 'Data Volumes').click();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
@@ -1,6 +1,5 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { editWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/editWorkspace';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import {
   volumesManagement,
   volumesAttachModal,
@@ -167,10 +166,8 @@ describe('Volumes Management - Attach and Create', () => {
     cy.wait('@getWorkspace');
     cy.wait('@getWorkspaceKinds');
     editWorkspace.clickNext(); // Skip workspace kind step
-    editWorkspace.clickNext(); // Skip image step
-    redirectConfirmModal.clickContinue();
-    editWorkspace.clickNext(); // Skip pod config step, now on properties
-    redirectConfirmModal.clickContinue();
+    editWorkspace.advancePastRedirectModal(); // Skip image step
+    editWorkspace.advancePastRedirectModal(); // Skip pod config step, now on properties
 
     // Expand the Data Volumes section
     cy.contains('button', 'Data Volumes').click();

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceFormStyling.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceFormStyling.cy.ts
@@ -1,5 +1,6 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
+import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
@@ -175,7 +176,9 @@ describe('Workspace Form Styling', () => {
       createWorkspace.selectImage('redirect-image');
 
       createWorkspace.clickNext(); // Pod config
+      redirectConfirmModal.clickContinue();
       createWorkspace.clickNext(); // Properties - now at summary
+      redirectConfirmModal.clickContinue();
     });
 
     it('should apply summary-redirect-icon-button class to redirect icon', () => {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceFormStyling.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaceFormStyling.cy.ts
@@ -1,6 +1,5 @@
 import { mockModArchResponse } from 'mod-arch-core';
 import { createWorkspace } from '~/__tests__/cypress/cypress/pages/workspaces/createWorkspace';
-import { redirectConfirmModal } from '~/__tests__/cypress/cypress/pages/workspaces/workspaceForm';
 import { buildMockNamespace, buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
 import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { navBar } from '~/__tests__/cypress/cypress/pages/components/navBar';
@@ -175,10 +174,8 @@ describe('Workspace Form Styling', () => {
       createWorkspace.checkExtraFilter('showRedirected');
       createWorkspace.selectImage('redirect-image');
 
-      createWorkspace.clickNext(); // Pod config
-      redirectConfirmModal.clickContinue();
-      createWorkspace.clickNext(); // Properties - now at summary
-      redirectConfirmModal.clickContinue();
+      createWorkspace.advancePastRedirectModal(); // Pod config
+      createWorkspace.advancePastRedirectModal(); // Properties - now at summary
     });
 
     it('should apply summary-redirect-icon-button class to redirect icon', () => {

--- a/workspaces/frontend/src/app/hooks/useRedirectConfirmation.ts
+++ b/workspaces/frontend/src/app/hooks/useRedirectConfirmation.ts
@@ -1,0 +1,154 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  OptionsImageConfigValue,
+  OptionsPodConfigValue,
+  WorkspacesRedirectStep,
+} from '~/generated/data-contracts';
+import {
+  OptionValue,
+  resolveRedirectChain,
+} from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
+
+interface StepRedirectInfoNone {
+  needsConfirmation: false;
+}
+
+interface StepRedirectInfoConfirm {
+  needsConfirmation: true;
+  optionType: 'image' | 'podConfig';
+  selectedOption: OptionValue;
+  redirectChain: WorkspacesRedirectStep[] | undefined;
+  finalTarget: OptionValue | undefined;
+}
+
+type StepRedirectInfo = StepRedirectInfoNone | StepRedirectInfoConfirm;
+
+interface UseRedirectConfirmationParams {
+  currentStep: number;
+  imageStep: number;
+  podConfigStep: number;
+  selectedImage: OptionsImageConfigValue | undefined;
+  selectedPodConfig: OptionsPodConfigValue | undefined;
+  allImageOptions: OptionsImageConfigValue[];
+  allPodConfigOptions: OptionsPodConfigValue[];
+  onImageSelect: (image: OptionsImageConfigValue | undefined) => void;
+  onPodConfigSelect: (podConfig: OptionsPodConfigValue | undefined) => void;
+  onAdvanceStep: () => void;
+}
+
+interface UseRedirectConfirmationResult {
+  redirectInfo: StepRedirectInfo;
+  isModalOpen: boolean;
+  openModal: () => void;
+  handleApplyRedirect: () => void;
+  handleContinueWithWarning: () => void;
+  closeModal: () => void;
+}
+
+const buildRedirectInfo = (
+  optionType: StepRedirectInfoConfirm['optionType'],
+  selectedOption: OptionValue,
+  allOptions: OptionValue[],
+): StepRedirectInfoConfirm | undefined => {
+  if (selectedOption.redirect) {
+    const { chain, finalTarget } = resolveRedirectChain(selectedOption, allOptions);
+    return {
+      needsConfirmation: true,
+      optionType,
+      selectedOption,
+      redirectChain: chain,
+      finalTarget,
+    };
+  }
+  if (selectedOption.hidden) {
+    return {
+      needsConfirmation: true,
+      optionType,
+      selectedOption,
+      redirectChain: undefined,
+      finalTarget: undefined,
+    };
+  }
+  return undefined;
+};
+
+const useRedirectConfirmation = ({
+  currentStep,
+  imageStep,
+  podConfigStep,
+  selectedImage,
+  selectedPodConfig,
+  allImageOptions,
+  allPodConfigOptions,
+  onImageSelect,
+  onPodConfigSelect,
+  onAdvanceStep,
+}: UseRedirectConfirmationParams): UseRedirectConfirmationResult => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const redirectInfo = useMemo<StepRedirectInfo>(() => {
+    if (currentStep === imageStep && selectedImage) {
+      const result = buildRedirectInfo('image', selectedImage, allImageOptions);
+      if (result) {
+        return result;
+      }
+    }
+
+    if (currentStep === podConfigStep && selectedPodConfig) {
+      const result = buildRedirectInfo('podConfig', selectedPodConfig, allPodConfigOptions);
+      if (result) {
+        return result;
+      }
+    }
+
+    return { needsConfirmation: false };
+  }, [
+    currentStep,
+    imageStep,
+    podConfigStep,
+    selectedImage,
+    selectedPodConfig,
+    allImageOptions,
+    allPodConfigOptions,
+  ]);
+
+  const openModal = useCallback(() => {
+    setIsModalOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+
+  const handleApplyRedirect = useCallback(() => {
+    if (!redirectInfo.needsConfirmation || !redirectInfo.finalTarget) {
+      return;
+    }
+
+    if (redirectInfo.optionType === 'image') {
+      onImageSelect(redirectInfo.finalTarget as OptionsImageConfigValue);
+    } else {
+      onPodConfigSelect(redirectInfo.finalTarget as OptionsPodConfigValue);
+    }
+
+    setIsModalOpen(false);
+    onAdvanceStep();
+  }, [redirectInfo, onImageSelect, onPodConfigSelect, onAdvanceStep]);
+
+  const handleContinueWithWarning = useCallback(() => {
+    setIsModalOpen(false);
+    onAdvanceStep();
+  }, [onAdvanceStep]);
+
+  return {
+    redirectInfo,
+    isModalOpen,
+    openModal,
+    handleApplyRedirect,
+    handleContinueWithWarning,
+    closeModal,
+  };
+};
+
+export { useRedirectConfirmation };
+export type { StepRedirectInfo, StepRedirectInfoConfirm, StepRedirectInfoNone };

--- a/workspaces/frontend/src/app/hooks/useRedirectConfirmation.ts
+++ b/workspaces/frontend/src/app/hooks/useRedirectConfirmation.ts
@@ -19,6 +19,7 @@ interface StepRedirectInfoConfirm {
   selectedOption: OptionValue;
   redirectChain: WorkspacesRedirectStep[] | undefined;
   finalTarget: OptionValue | undefined;
+  cycleDetected: boolean;
 }
 
 type StepRedirectInfo = StepRedirectInfoNone | StepRedirectInfoConfirm;
@@ -51,13 +52,14 @@ const buildRedirectInfo = (
   allOptions: OptionValue[],
 ): StepRedirectInfoConfirm | undefined => {
   if (selectedOption.redirect) {
-    const { chain, finalTarget } = resolveRedirectChain(selectedOption, allOptions);
+    const { chain, finalTarget, cycleDetected } = resolveRedirectChain(selectedOption, allOptions);
     return {
       needsConfirmation: true,
       optionType,
       selectedOption,
       redirectChain: chain,
       finalTarget,
+      cycleDetected,
     };
   }
   if (selectedOption.hidden) {
@@ -67,6 +69,7 @@ const buildRedirectInfo = (
       selectedOption,
       redirectChain: undefined,
       finalTarget: undefined,
+      cycleDetected: false,
     };
   }
   return undefined;

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -33,13 +33,13 @@ import { WorkspaceFormPropertiesSelection } from '~/app/pages/Workspaces/Form/pr
 import { WorkspaceFormData } from '~/app/types';
 import usePodTemplateOptionsListValues from '~/app/hooks/usePodTemplateOptionsListValues';
 import useWorkspaceFormData from '~/app/hooks/useWorkspaceFormData';
+import { useRedirectConfirmation } from '~/app/hooks/useRedirectConfirmation';
 import { useTypedNavigate } from '~/app/routerHelper';
 import {
   ApiErrorEnvelope,
   OptionsImageConfigValue,
   OptionsPodConfigValue,
   WorkspacekindsWorkspaceKindListItem,
-  WorkspacesRedirectStep,
 } from '~/generated/data-contracts';
 import { extractErrorMessage } from '~/shared/api/apiUtils';
 import { ErrorAlert } from '~/shared/components/ErrorAlert';
@@ -48,25 +48,7 @@ import { LoadingSpinner } from '~/app/components/LoadingSpinner';
 import { LoadError } from '~/app/components/LoadError';
 import { submitFormData } from '~/app/pages/Workspaces/Form/submitHelper';
 import { WorkspaceFormSummaryPanel } from '~/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel';
-import {
-  OptionValue,
-  resolveRedirectChain,
-} from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
 import { WorkspaceFormRedirectConfirmModal } from '~/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal';
-
-interface StepRedirectInfoNone {
-  needsConfirmation: false;
-}
-
-interface StepRedirectInfoConfirm {
-  needsConfirmation: true;
-  optionType: 'image' | 'podConfig';
-  selectedOption: OptionValue;
-  redirectChain: WorkspacesRedirectStep[] | undefined;
-  finalTarget: OptionValue | undefined;
-}
-
-type StepRedirectInfo = StepRedirectInfoNone | StepRedirectInfoConfirm;
 
 enum WorkspaceFormSteps {
   KindSelection,
@@ -103,7 +85,6 @@ const WorkspaceForm: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentStep, setCurrentStep] = useState(WorkspaceFormSteps.KindSelection);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
-  const [redirectConfirmModalOpen, setRedirectConfirmModalOpen] = useState(false);
 
   const [data, setData, resetData, replaceData] =
     useGenericObjectState<WorkspaceFormData>(initialFormData);
@@ -150,6 +131,18 @@ const WorkspaceForm: React.FC = () => {
       setData('podConfig', allValuesData.podConfig.default);
     }
   }, [allValuesData, allValuesLoaded, data.kind, data.imageConfig, data.podConfig, setData]);
+
+  // Clear podConfig when filtered values reload and the current selection is no longer compatible
+  useEffect(() => {
+    if (!filteredValuesLoaded || !filteredValuesData || !data.podConfig) {
+      return;
+    }
+    const podConfigOptions = filteredValuesData.podConfig.values ?? [];
+    const isStillValid = podConfigOptions.some((pc) => pc.id === data.podConfig);
+    if (!isStillValid) {
+      setData('podConfig', undefined);
+    }
+  }, [filteredValuesData, filteredValuesLoaded, data.podConfig, setData]);
 
   const getStepVariant = useCallback(
     (step: WorkspaceFormSteps) => {
@@ -222,66 +215,78 @@ const WorkspaceForm: React.FC = () => {
     [filteredValuesData, allValuesData, data.podConfig],
   );
 
-  const currentStepRedirectInfo = useMemo<StepRedirectInfo>(() => {
-    const buildRedirectInfo = (
-      optionType: StepRedirectInfoConfirm['optionType'],
-      selectedOption: OptionValue,
-      allOptions: OptionValue[],
-    ): StepRedirectInfoConfirm | undefined => {
-      if (selectedOption.redirect) {
-        const { chain, finalTarget } = resolveRedirectChain(selectedOption, allOptions);
-        return {
-          needsConfirmation: true,
-          optionType,
-          selectedOption,
-          redirectChain: chain,
-          finalTarget,
-        };
+  const handleKindSelect = useCallback(
+    (kind: WorkspacekindsWorkspaceKindListItem | undefined) => {
+      if (!kind) {
+        return;
       }
-      if (selectedOption.hidden) {
-        return {
-          needsConfirmation: true,
-          optionType,
-          selectedOption,
-          redirectChain: undefined,
-          finalTarget: undefined,
-        };
+      if (mode === 'create') {
+        resetData();
+        setData('kind', kind);
       }
-      return undefined;
-    };
+    },
+    [mode, resetData, setData],
+  );
 
-    if (currentStep === WorkspaceFormSteps.ImageSelection && selectedImage) {
-      const result = buildRedirectInfo(
-        'image',
-        selectedImage,
-        allValuesData?.imageConfig.values ?? [],
-      );
-      if (result) {
-        return result;
+  const handleImageSelect = useCallback(
+    (image: OptionsImageConfigValue | undefined) => {
+      if (image) {
+        if (image.hidden || image.redirect !== undefined) {
+          imageFilterControlRef.current?.adaptFiltersForImage(image);
+        }
+        setData('imageConfig', image.id);
+      } else {
+        setData('imageConfig', undefined);
       }
-    }
+    },
+    [setData],
+  );
 
-    if (currentStep === WorkspaceFormSteps.PodConfigSelection && selectedPodConfig) {
-      const result = buildRedirectInfo(
-        'podConfig',
-        selectedPodConfig,
-        (filteredValuesData ?? allValuesData)?.podConfig.values ?? [],
-      );
-      if (result) {
-        return result;
+  const handlePodConfigSelect = useCallback(
+    (podConfig: OptionsPodConfigValue | undefined) => {
+      if (podConfig) {
+        if (podConfig.hidden || podConfig.redirect !== undefined) {
+          podConfigFilterControlRef.current?.adaptFiltersForPodConfig(podConfig);
+        }
+        setData('podConfig', podConfig.id);
+      } else {
+        setData('podConfig', undefined);
       }
-    }
+    },
+    [setData],
+  );
 
-    return { needsConfirmation: false };
-  }, [currentStep, selectedImage, selectedPodConfig, allValuesData, filteredValuesData]);
+  const advanceStep = useCallback(() => {
+    setCurrentStep((prev) => prev + 1);
+  }, []);
+
+  const {
+    redirectInfo: currentStepRedirectInfo,
+    isModalOpen: redirectConfirmModalOpen,
+    openModal: openRedirectModal,
+    handleApplyRedirect,
+    handleContinueWithWarning,
+    closeModal: closeRedirectModal,
+  } = useRedirectConfirmation({
+    currentStep,
+    imageStep: WorkspaceFormSteps.ImageSelection,
+    podConfigStep: WorkspaceFormSteps.PodConfigSelection,
+    selectedImage,
+    selectedPodConfig,
+    allImageOptions: allValuesData?.imageConfig.values ?? [],
+    allPodConfigOptions: (filteredValuesData ?? allValuesData)?.podConfig.values ?? [],
+    onImageSelect: handleImageSelect,
+    onPodConfigSelect: handlePodConfigSelect,
+    onAdvanceStep: advanceStep,
+  });
 
   const nextStep = useCallback(() => {
     if (currentStepRedirectInfo.needsConfirmation) {
-      setRedirectConfirmModalOpen(true);
+      openRedirectModal();
       return;
     }
     setCurrentStep(currentStep + 1);
-  }, [currentStep, currentStepRedirectInfo]);
+  }, [currentStep, currentStepRedirectInfo, openRedirectModal]);
 
   const canGoToNextStep = useMemo(
     () => currentStep < Object.keys(WorkspaceFormSteps).length / 2 - 1,
@@ -332,69 +337,6 @@ const WorkspaceForm: React.FC = () => {
   const cancel = useCallback(() => {
     navigate('workspaces');
   }, [navigate]);
-
-  const handleKindSelect = useCallback(
-    (kind: WorkspacekindsWorkspaceKindListItem | undefined) => {
-      if (!kind) {
-        return;
-      }
-      if (mode === 'create') {
-        resetData();
-        setData('kind', kind);
-      }
-    },
-    [mode, resetData, setData],
-  );
-
-  const handleImageSelect = useCallback(
-    (image: OptionsImageConfigValue | undefined) => {
-      if (image) {
-        // Clear filters if the selected image is hidden or redirected
-        if (image.hidden || image.redirect !== undefined) {
-          imageFilterControlRef.current?.adaptFiltersForImage(image);
-        }
-        setData('imageConfig', image.id);
-      } else {
-        setData('imageConfig', undefined);
-      }
-    },
-    [setData],
-  );
-
-  const handlePodConfigSelect = useCallback(
-    (podConfig: OptionsPodConfigValue | undefined) => {
-      if (podConfig) {
-        // Clear filters if the selected pod config is hidden or redirected
-        if (podConfig.hidden || podConfig.redirect !== undefined) {
-          podConfigFilterControlRef.current?.adaptFiltersForPodConfig(podConfig);
-        }
-        setData('podConfig', podConfig.id);
-      } else {
-        setData('podConfig', undefined);
-      }
-    },
-    [setData],
-  );
-
-  const handleApplyRedirect = useCallback(() => {
-    if (!currentStepRedirectInfo.needsConfirmation || !currentStepRedirectInfo.finalTarget) {
-      return;
-    }
-
-    if (currentStepRedirectInfo.optionType === 'image') {
-      handleImageSelect(currentStepRedirectInfo.finalTarget as OptionsImageConfigValue);
-    } else {
-      handlePodConfigSelect(currentStepRedirectInfo.finalTarget as OptionsPodConfigValue);
-    }
-
-    setRedirectConfirmModalOpen(false);
-    setCurrentStep(currentStep + 1);
-  }, [currentStep, currentStepRedirectInfo, handleImageSelect, handlePodConfigSelect]);
-
-  const handleContinueWithWarning = useCallback(() => {
-    setRedirectConfirmModalOpen(false);
-    setCurrentStep(currentStep + 1);
-  }, [currentStep]);
 
   // Get original values for edit mode diff
   const originalImage = useMemo(
@@ -649,7 +591,7 @@ const WorkspaceForm: React.FC = () => {
       {currentStepRedirectInfo.needsConfirmation && (
         <WorkspaceFormRedirectConfirmModal
           isOpen={redirectConfirmModalOpen}
-          onClose={() => setRedirectConfirmModalOpen(false)}
+          onClose={closeRedirectModal}
           onApplyRedirect={handleApplyRedirect}
           onContinue={handleContinueWithWarning}
           optionType={currentStepRedirectInfo.optionType}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -598,6 +598,7 @@ const WorkspaceForm: React.FC = () => {
           selectedOption={currentStepRedirectInfo.selectedOption}
           redirectChain={currentStepRedirectInfo.redirectChain}
           finalTarget={currentStepRedirectInfo.finalTarget}
+          cycleDetected={currentStepRedirectInfo.cycleDetected}
         />
       )}
     </Drawer>

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -39,6 +39,7 @@ import {
   OptionsImageConfigValue,
   OptionsPodConfigValue,
   WorkspacekindsWorkspaceKindListItem,
+  WorkspacesRedirectStep,
 } from '~/generated/data-contracts';
 import { extractErrorMessage } from '~/shared/api/apiUtils';
 import { ErrorAlert } from '~/shared/components/ErrorAlert';
@@ -47,6 +48,25 @@ import { LoadingSpinner } from '~/app/components/LoadingSpinner';
 import { LoadError } from '~/app/components/LoadError';
 import { submitFormData } from '~/app/pages/Workspaces/Form/submitHelper';
 import { WorkspaceFormSummaryPanel } from '~/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel';
+import {
+  OptionValue,
+  resolveRedirectChain,
+} from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
+import { WorkspaceFormRedirectConfirmModal } from '~/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal';
+
+interface StepRedirectInfoNone {
+  needsConfirmation: false;
+}
+
+interface StepRedirectInfoConfirm {
+  needsConfirmation: true;
+  optionType: 'image' | 'podConfig';
+  selectedOption: OptionValue;
+  redirectChain: WorkspacesRedirectStep[] | undefined;
+  finalTarget: OptionValue | undefined;
+}
+
+type StepRedirectInfo = StepRedirectInfoNone | StepRedirectInfoConfirm;
 
 enum WorkspaceFormSteps {
   KindSelection,
@@ -83,6 +103,7 @@ const WorkspaceForm: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentStep, setCurrentStep] = useState(WorkspaceFormSteps.KindSelection);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
+  const [redirectConfirmModalOpen, setRedirectConfirmModalOpen] = useState(false);
 
   const [data, setData, resetData, replaceData] =
     useGenericObjectState<WorkspaceFormData>(initialFormData);
@@ -180,11 +201,6 @@ const WorkspaceForm: React.FC = () => {
     setCurrentStep(newStep);
   }, [currentStep]);
 
-  const nextStep = useCallback(() => {
-    const newStep = currentStep + 1;
-    setCurrentStep(newStep);
-  }, [currentStep]);
-
   const navigateToStep = useCallback((step: number) => {
     setCurrentStep(step);
   }, []);
@@ -205,6 +221,67 @@ const WorkspaceForm: React.FC = () => {
       ),
     [filteredValuesData, allValuesData, data.podConfig],
   );
+
+  const currentStepRedirectInfo = useMemo<StepRedirectInfo>(() => {
+    const buildRedirectInfo = (
+      optionType: StepRedirectInfoConfirm['optionType'],
+      selectedOption: OptionValue,
+      allOptions: OptionValue[],
+    ): StepRedirectInfoConfirm | undefined => {
+      if (selectedOption.redirect) {
+        const { chain, finalTarget } = resolveRedirectChain(selectedOption, allOptions);
+        return {
+          needsConfirmation: true,
+          optionType,
+          selectedOption,
+          redirectChain: chain,
+          finalTarget,
+        };
+      }
+      if (selectedOption.hidden) {
+        return {
+          needsConfirmation: true,
+          optionType,
+          selectedOption,
+          redirectChain: undefined,
+          finalTarget: undefined,
+        };
+      }
+      return undefined;
+    };
+
+    if (currentStep === WorkspaceFormSteps.ImageSelection && selectedImage) {
+      const result = buildRedirectInfo(
+        'image',
+        selectedImage,
+        allValuesData?.imageConfig.values ?? [],
+      );
+      if (result) {
+        return result;
+      }
+    }
+
+    if (currentStep === WorkspaceFormSteps.PodConfigSelection && selectedPodConfig) {
+      const result = buildRedirectInfo(
+        'podConfig',
+        selectedPodConfig,
+        (filteredValuesData ?? allValuesData)?.podConfig.values ?? [],
+      );
+      if (result) {
+        return result;
+      }
+    }
+
+    return { needsConfirmation: false };
+  }, [currentStep, selectedImage, selectedPodConfig, allValuesData, filteredValuesData]);
+
+  const nextStep = useCallback(() => {
+    if (currentStepRedirectInfo.needsConfirmation) {
+      setRedirectConfirmModalOpen(true);
+      return;
+    }
+    setCurrentStep(currentStep + 1);
+  }, [currentStep, currentStepRedirectInfo]);
 
   const canGoToNextStep = useMemo(
     () => currentStep < Object.keys(WorkspaceFormSteps).length / 2 - 1,
@@ -298,6 +375,26 @@ const WorkspaceForm: React.FC = () => {
     },
     [setData],
   );
+
+  const handleApplyRedirect = useCallback(() => {
+    if (!currentStepRedirectInfo.needsConfirmation || !currentStepRedirectInfo.finalTarget) {
+      return;
+    }
+
+    if (currentStepRedirectInfo.optionType === 'image') {
+      handleImageSelect(currentStepRedirectInfo.finalTarget as OptionsImageConfigValue);
+    } else {
+      handlePodConfigSelect(currentStepRedirectInfo.finalTarget as OptionsPodConfigValue);
+    }
+
+    setRedirectConfirmModalOpen(false);
+    setCurrentStep(currentStep + 1);
+  }, [currentStep, currentStepRedirectInfo, handleImageSelect, handlePodConfigSelect]);
+
+  const handleContinueWithWarning = useCallback(() => {
+    setRedirectConfirmModalOpen(false);
+    setCurrentStep(currentStep + 1);
+  }, [currentStep]);
 
   // Get original values for edit mode diff
   const originalImage = useMemo(
@@ -549,6 +646,18 @@ const WorkspaceForm: React.FC = () => {
           </Flex>
         </DrawerContentBody>
       </DrawerContent>
+      {currentStepRedirectInfo.needsConfirmation && (
+        <WorkspaceFormRedirectConfirmModal
+          isOpen={redirectConfirmModalOpen}
+          onClose={() => setRedirectConfirmModalOpen(false)}
+          onApplyRedirect={handleApplyRedirect}
+          onContinue={handleContinueWithWarning}
+          optionType={currentStepRedirectInfo.optionType}
+          selectedOption={currentStepRedirectInfo.selectedOption}
+          redirectChain={currentStepRedirectInfo.redirectChain}
+          finalTarget={currentStepRedirectInfo.finalTarget}
+        />
+      )}
     </Drawer>
   );
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection';
+import { Icon } from '@patternfly/react-core/dist/esm/components/Icon';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core/dist/esm/components/Modal';
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import {
+  OptionsImageConfigValue,
+  OptionsPodConfigValue,
+  WorkspacesRedirectMessageLevel,
+  WorkspacesRedirectStep,
+} from '~/generated/data-contracts';
+
+type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
+
+interface WorkspaceFormRedirectConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onApplyRedirect: () => void;
+  onContinue: () => void;
+  optionType: 'image' | 'podConfig';
+  selectedOption: OptionValue;
+  redirectChain?: WorkspacesRedirectStep[];
+  finalTarget?: OptionValue;
+}
+
+const getLevelIcon = (level?: string) => {
+  switch (level) {
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
+      return (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+      );
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
+      return (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      );
+    default:
+      return (
+        <Icon status="info">
+          <InfoCircleIcon />
+        </Icon>
+      );
+  }
+};
+
+const getLevelColor = (level?: string): 'blue' | 'orange' | 'red' => {
+  switch (level) {
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
+      return 'orange';
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
+      return 'red';
+    default:
+      return 'blue';
+  }
+};
+
+const getLevelText = (level?: string): string => {
+  switch (level) {
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
+      return 'Warning';
+    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
+      return 'Danger';
+    default:
+      return 'Info';
+  }
+};
+
+const optionTypeLabel = (optionType: 'image' | 'podConfig'): string =>
+  optionType === 'image' ? 'image' : 'pod config';
+
+export const WorkspaceFormRedirectConfirmModal: React.FC<
+  WorkspaceFormRedirectConfirmModalProps
+> = ({
+  isOpen,
+  onClose,
+  onApplyRedirect,
+  onContinue,
+  optionType,
+  selectedOption,
+  redirectChain,
+  finalTarget,
+}) => {
+  const hasRedirect = redirectChain && redirectChain.length > 0;
+  const typeLabel = optionTypeLabel(optionType);
+
+  const title = hasRedirect
+    ? `${optionType === 'image' ? 'Image' : 'Pod Config'} Redirect`
+    : `Hidden ${optionType === 'image' ? 'Image' : 'Pod Config'}`;
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="redirect-confirm-modal"
+    >
+      <ModalHeader title={title} titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          {hasRedirect ? (
+            <>
+              <StackItem>
+                <Content>
+                  <p>
+                    Your administrator has redirected the {typeLabel} you selected (
+                    {selectedOption.displayName}).
+                    {finalTarget
+                      ? ` If you apply the redirect, "${finalTarget.displayName}" will be used instead.`
+                      : ' The redirect target could not be resolved.'}
+                  </p>
+                </Content>
+              </StackItem>
+              <StackItem>
+                <Stack hasGutter>
+                  {redirectChain.map((step, index) => (
+                    <StackItem key={index}>
+                      <Content style={{ display: 'flex', alignItems: 'baseline' }}>
+                        {getLevelIcon(step.message?.level)}
+                        <ExpandableSection
+                          toggleText={` ${step.source.displayName} → ${step.target.displayName}`}
+                        >
+                          <Stack hasGutter>
+                            {step.message && (
+                              <>
+                                <StackItem>
+                                  <Flex
+                                    alignItems={{ default: 'alignItemsCenter' }}
+                                    spaceItems={{ default: 'spaceItemsSm' }}
+                                  >
+                                    <FlexItem>
+                                      <Label color={getLevelColor(step.message.level)} isCompact>
+                                        {getLevelText(step.message.level)}
+                                      </Label>
+                                    </FlexItem>
+                                  </Flex>
+                                </StackItem>
+                                {step.message.text && (
+                                  <StackItem>
+                                    <Content>{step.message.text}</Content>
+                                  </StackItem>
+                                )}
+                              </>
+                            )}
+                          </Stack>
+                        </ExpandableSection>
+                      </Content>
+                    </StackItem>
+                  ))}
+                </Stack>
+              </StackItem>
+              {selectedOption.hidden && (
+                <StackItem>
+                  <Content>
+                    <p>
+                      <strong>Note:</strong> This {typeLabel} has also been hidden by your
+                      administrator.
+                    </p>
+                  </Content>
+                </StackItem>
+              )}
+            </>
+          ) : (
+            <StackItem>
+              <Content>
+                <p>
+                  The {typeLabel} you selected <b>{selectedOption.displayName}</b> has been hidden
+                  by your administrator. This option may be deprecated or unsupported. You can still
+                  use it if you are sure of your choice.
+                </p>
+              </Content>
+            </StackItem>
+          )}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
+        {hasRedirect && (
+          <Button
+            variant="primary"
+            onClick={onApplyRedirect}
+            isDisabled={!finalTarget}
+            data-testid="apply-redirect-button"
+          >
+            Apply Redirect
+          </Button>
+        )}
+        <Button
+          variant={hasRedirect ? 'secondary' : 'primary'}
+          onClick={onContinue}
+          data-testid="continue-button"
+        >
+          Continue
+        </Button>
+        <Button variant="link" onClick={onClose} data-testid="cancel-button">
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal.tsx
@@ -181,7 +181,8 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
                 <p>
                   The {typeLabel} you selected <b>{selectedOption.displayName}</b> has been hidden
                   by your administrator. This option may be deprecated or unsupported. You can still
-                  use it if you are sure of your choice.
+                  use it if you are sure of your choice, or cancel and select a different{' '}
+                  {typeLabel} from the available options.
                 </p>
               </Content>
             </StackItem>
@@ -204,7 +205,7 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
           onClick={onContinue}
           data-testid="continue-button"
         >
-          Continue
+          {hasRedirect ? 'Skip Redirect' : 'Use Hidden Option'}
         </Button>
         <Button variant="link" onClick={onClose} data-testid="cancel-button">
           Cancel

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal.tsx
@@ -34,52 +34,42 @@ interface WorkspaceFormRedirectConfirmModalProps {
   selectedOption: OptionValue;
   redirectChain?: WorkspacesRedirectStep[];
   finalTarget?: OptionValue;
+  cycleDetected: boolean;
 }
 
-const getLevelIcon = (level?: string) => {
-  switch (level) {
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
-      return (
-        <Icon status="warning">
-          <ExclamationTriangleIcon />
-        </Icon>
-      );
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
-      return (
-        <Icon status="danger">
-          <ExclamationCircleIcon />
-        </Icon>
-      );
-    default:
-      return (
-        <Icon status="info">
-          <InfoCircleIcon />
-        </Icon>
-      );
-  }
+const DEFAULT_LEVEL_CONFIG = {
+  icon: InfoCircleIcon,
+  iconStatus: 'info' as const,
+  color: 'blue' as const,
+  text: 'Info',
 };
 
-const getLevelColor = (level?: string): 'blue' | 'orange' | 'red' => {
-  switch (level) {
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
-      return 'orange';
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
-      return 'red';
-    default:
-      return 'blue';
+const LEVEL_CONFIG: Record<
+  WorkspacesRedirectMessageLevel,
+  {
+    icon: React.ComponentType;
+    iconStatus: 'info' | 'warning' | 'danger';
+    color: 'blue' | 'orange' | 'red';
+    text: string;
   }
+> = {
+  [WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning]: {
+    icon: ExclamationTriangleIcon,
+    iconStatus: 'warning',
+    color: 'orange',
+    text: 'Warning',
+  },
+  [WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger]: {
+    icon: ExclamationCircleIcon,
+    iconStatus: 'danger',
+    color: 'red',
+    text: 'Danger',
+  },
+  [WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo]: DEFAULT_LEVEL_CONFIG,
 };
 
-const getLevelText = (level?: string): string => {
-  switch (level) {
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning:
-      return 'Warning';
-    case WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger:
-      return 'Danger';
-    default:
-      return 'Info';
-  }
-};
+const getLevelConfig = (level?: WorkspacesRedirectMessageLevel) =>
+  level ? LEVEL_CONFIG[level] : DEFAULT_LEVEL_CONFIG;
 
 const optionTypeLabel = (optionType: 'image' | 'podConfig'): string =>
   optionType === 'image' ? 'image' : 'pod config';
@@ -95,13 +85,17 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
   selectedOption,
   redirectChain,
   finalTarget,
+  cycleDetected,
 }) => {
   const hasRedirect = redirectChain && redirectChain.length > 0;
   const typeLabel = optionTypeLabel(optionType);
+  const typeTitle = optionType === 'image' ? 'Image' : 'Pod Config';
 
-  const title = hasRedirect
-    ? `${optionType === 'image' ? 'Image' : 'Pod Config'} Redirect`
-    : `Hidden ${optionType === 'image' ? 'Image' : 'Pod Config'}`;
+  const title = cycleDetected
+    ? `${typeTitle} Redirect Misconfiguration`
+    : hasRedirect
+      ? `${typeTitle} Redirect`
+      : `Hidden ${typeTitle}`;
 
   return (
     <Modal
@@ -113,7 +107,18 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
       <ModalHeader title={title} titleIconVariant="warning" />
       <ModalBody>
         <Stack hasGutter>
-          {hasRedirect ? (
+          {cycleDetected ? (
+            <StackItem>
+              <Content>
+                <p>
+                  The {typeLabel} you selected (<b>{selectedOption.displayName}</b>) has a circular
+                  redirect configuration. This is a misconfiguration that should be reported to your
+                  administrator. You can still use the currently selected {typeLabel}, or cancel and
+                  choose a different option.
+                </p>
+              </Content>
+            </StackItem>
+          ) : hasRedirect ? (
             <>
               <StackItem>
                 <Content>
@@ -128,40 +133,46 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
               </StackItem>
               <StackItem>
                 <Stack hasGutter>
-                  {redirectChain.map((step, index) => (
-                    <StackItem key={index}>
-                      <Content style={{ display: 'flex', alignItems: 'baseline' }}>
-                        {getLevelIcon(step.message?.level)}
-                        <ExpandableSection
-                          toggleText={` ${step.source.displayName} → ${step.target.displayName}`}
-                        >
-                          <Stack hasGutter>
-                            {step.message && (
-                              <>
-                                <StackItem>
-                                  <Flex
-                                    alignItems={{ default: 'alignItemsCenter' }}
-                                    spaceItems={{ default: 'spaceItemsSm' }}
-                                  >
-                                    <FlexItem>
-                                      <Label color={getLevelColor(step.message.level)} isCompact>
-                                        {getLevelText(step.message.level)}
-                                      </Label>
-                                    </FlexItem>
-                                  </Flex>
-                                </StackItem>
-                                {step.message.text && (
+                  {redirectChain.map((step, index) => {
+                    const config = getLevelConfig(step.message?.level);
+                    const LevelIcon = config.icon;
+                    return (
+                      <StackItem key={index}>
+                        <Content style={{ display: 'flex', alignItems: 'baseline' }}>
+                          <Icon status={config.iconStatus}>
+                            <LevelIcon />
+                          </Icon>
+                          <ExpandableSection
+                            toggleText={` ${step.source.displayName} → ${step.target.displayName}`}
+                          >
+                            <Stack hasGutter>
+                              {step.message && (
+                                <>
                                   <StackItem>
-                                    <Content>{step.message.text}</Content>
+                                    <Flex
+                                      alignItems={{ default: 'alignItemsCenter' }}
+                                      spaceItems={{ default: 'spaceItemsSm' }}
+                                    >
+                                      <FlexItem>
+                                        <Label color={config.color} isCompact>
+                                          {config.text}
+                                        </Label>
+                                      </FlexItem>
+                                    </Flex>
                                   </StackItem>
-                                )}
-                              </>
-                            )}
-                          </Stack>
-                        </ExpandableSection>
-                      </Content>
-                    </StackItem>
-                  ))}
+                                  {step.message.text && (
+                                    <StackItem>
+                                      <Content>{step.message.text}</Content>
+                                    </StackItem>
+                                  )}
+                                </>
+                              )}
+                            </Stack>
+                          </ExpandableSection>
+                        </Content>
+                      </StackItem>
+                    );
+                  })}
                 </Stack>
               </StackItem>
               {selectedOption.hidden && (
@@ -190,7 +201,7 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
         </Stack>
       </ModalBody>
       <ModalFooter>
-        {hasRedirect && (
+        {hasRedirect && !cycleDetected && (
           <Button
             variant="primary"
             onClick={onApplyRedirect}
@@ -201,11 +212,15 @@ export const WorkspaceFormRedirectConfirmModal: React.FC<
           </Button>
         )}
         <Button
-          variant={hasRedirect ? 'secondary' : 'primary'}
+          variant={hasRedirect && !cycleDetected ? 'secondary' : 'primary'}
           onClick={onContinue}
           data-testid="continue-button"
         >
-          {hasRedirect ? 'Skip Redirect' : 'Use Hidden Option'}
+          {cycleDetected
+            ? 'Keep Current Selection'
+            : hasRedirect
+              ? 'Skip Redirect'
+              : 'Use Hidden Option'}
         </Button>
         <Button variant="link" onClick={onClose} data-testid="cancel-button">
           Cancel

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
@@ -10,13 +10,9 @@ import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { HiddenIconWithPopover } from '~/app/components/HiddenIconWithPopover';
 import { RedirectIconWithPopover } from '~/app/components/RedirectIconWithPopover';
 import {
-  OptionsImageConfigValue,
-  OptionsPodConfigValue,
-  WorkspacesRedirectStep,
-} from '~/generated/data-contracts';
-import { transformRedirectMessageLevel } from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
-
-type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
+  OptionValue,
+  resolveRedirectChain,
+} from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
 
 interface WorkspaceFormOptionCardProps {
   option: OptionValue;
@@ -29,53 +25,6 @@ interface WorkspaceFormOptionCardProps {
   onActivePopoverChange: (id: string | null) => void;
   onPinnedPopoverChange: (id: string | null) => void;
 }
-
-const transformRedirectToChain = (
-  option: OptionValue,
-  allOptions: OptionValue[],
-): WorkspacesRedirectStep[] | undefined => {
-  if (!option.redirect) {
-    return undefined;
-  }
-
-  const targetOption = allOptions.find((opt) => opt.id === option.redirect?.to);
-
-  const targetInfo = targetOption
-    ? {
-        id: targetOption.id,
-        displayName: targetOption.displayName,
-        description: targetOption.description,
-        labels: (targetOption.labels ?? []).map((label) => ({
-          key: label.key,
-          value: label.value,
-        })),
-      }
-    : {
-        id: option.redirect.to,
-        displayName: `${option.redirect.to} (not found)`,
-        description: '',
-        labels: [],
-      };
-
-  const step: WorkspacesRedirectStep = {
-    source: {
-      id: option.id,
-      displayName: option.displayName,
-      description: option.description,
-      labels: (option.labels ?? []).map((label) => ({ key: label.key, value: label.value })),
-    },
-    target: targetInfo,
-  };
-
-  if (option.redirect.message) {
-    step.message = {
-      level: transformRedirectMessageLevel(option.redirect.message.level),
-      text: option.redirect.message.text,
-    };
-  }
-
-  return [step];
-};
 
 export const WorkspaceFormOptionCard: React.FC<
   WorkspaceFormOptionCardProps & { allOptions: OptionValue[] }
@@ -91,7 +40,9 @@ export const WorkspaceFormOptionCard: React.FC<
   onPinnedPopoverChange,
   allOptions,
 }) => {
-  const redirectChain = transformRedirectToChain(option, allOptions);
+  const { chain: redirectChain } = option.redirect
+    ? resolveRedirectChain(option, allOptions)
+    : { chain: undefined };
   const cardId = option.id.replace(/ /g, '-');
   const popoverIdHidden = `hidden-${cardId}`;
   const popoverIdRedirect = `redirect-${cardId}`;

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
@@ -13,9 +13,8 @@ import {
   OptionsImageConfigValue,
   OptionsPodConfigValue,
   WorkspacesRedirectStep,
-  WorkspacesRedirectMessageLevel,
-  OptionsRedirectMessageLevel,
 } from '~/generated/data-contracts';
+import { transformRedirectMessageLevel } from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
 
 type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
 
@@ -30,21 +29,6 @@ interface WorkspaceFormOptionCardProps {
   onActivePopoverChange: (id: string | null) => void;
   onPinnedPopoverChange: (id: string | null) => void;
 }
-
-const transformRedirectMessageLevel = (
-  level?: OptionsRedirectMessageLevel,
-): WorkspacesRedirectMessageLevel => {
-  switch (level) {
-    case OptionsRedirectMessageLevel.RedirectMessageLevelInfo:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
-    case OptionsRedirectMessageLevel.RedirectMessageLevelWarning:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning;
-    case OptionsRedirectMessageLevel.RedirectMessageLevelDanger:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger;
-    default:
-      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
-  }
-};
 
 const transformRedirectToChain = (
   option: OptionValue,

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/resolveRedirectChain.spec.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/resolveRedirectChain.spec.ts
@@ -22,6 +22,7 @@ describe('resolveRedirectChain', () => {
 
     expect(result.chain).toEqual([]);
     expect(result.finalTarget).toBeUndefined();
+    expect(result.cycleDetected).toBe(false);
   });
 
   it('resolves a single-hop redirect', () => {
@@ -34,6 +35,7 @@ describe('resolveRedirectChain', () => {
     expect(result.chain[0].source.id).toBe('A');
     expect(result.chain[0].target.id).toBe('B');
     expect(result.finalTarget).toBe(optB);
+    expect(result.cycleDetected).toBe(false);
   });
 
   it('resolves a multi-hop redirect chain', () => {
@@ -61,6 +63,7 @@ describe('resolveRedirectChain', () => {
     expect(result.chain[0].source.id).toBe('A');
     expect(result.chain[0].target.id).toBe('B');
     expect(result.finalTarget).toBeUndefined();
+    expect(result.cycleDetected).toBe(true);
   });
 
   it('handles missing target gracefully', () => {
@@ -162,6 +165,23 @@ describe('resolveRedirectChain', () => {
 
     expect(result.chain).toHaveLength(0);
     expect(result.finalTarget).toBeUndefined();
+    expect(result.cycleDetected).toBe(true);
+  });
+
+  it('detects a cycle that forms mid-chain after valid hops', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B', { redirect: { to: 'C' } });
+    const optC = makeOption('C', { redirect: { to: 'B' } });
+
+    const result = resolveRedirectChain(optA, [optA, optB, optC]);
+
+    expect(result.chain).toHaveLength(2);
+    expect(result.chain[0].source.id).toBe('A');
+    expect(result.chain[0].target.id).toBe('B');
+    expect(result.chain[1].source.id).toBe('B');
+    expect(result.chain[1].target.id).toBe('C');
+    expect(result.finalTarget).toBeUndefined();
+    expect(result.cycleDetected).toBe(true);
   });
 
   it('handles three-node cycle with undefined finalTarget', () => {
@@ -177,5 +197,6 @@ describe('resolveRedirectChain', () => {
     expect(result.chain[1].source.id).toBe('B');
     expect(result.chain[1].target.id).toBe('C');
     expect(result.finalTarget).toBeUndefined();
+    expect(result.cycleDetected).toBe(true);
   });
 });

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/resolveRedirectChain.spec.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/resolveRedirectChain.spec.ts
@@ -51,7 +51,7 @@ describe('resolveRedirectChain', () => {
     expect(result.finalTarget).toBe(optC);
   });
 
-  it('detects cycles and terminates the chain', () => {
+  it('detects cycles and returns undefined finalTarget', () => {
     const optA = makeOption('A', { redirect: { to: 'B' } });
     const optB = makeOption('B', { redirect: { to: 'A' } });
 
@@ -60,7 +60,7 @@ describe('resolveRedirectChain', () => {
     expect(result.chain).toHaveLength(1);
     expect(result.chain[0].source.id).toBe('A');
     expect(result.chain[0].target.id).toBe('B');
-    expect(result.finalTarget).toBe(optB);
+    expect(result.finalTarget).toBeUndefined();
   });
 
   it('handles missing target gracefully', () => {
@@ -164,7 +164,7 @@ describe('resolveRedirectChain', () => {
     expect(result.finalTarget).toBeUndefined();
   });
 
-  it('handles three-node cycle', () => {
+  it('handles three-node cycle with undefined finalTarget', () => {
     const optA = makeOption('A', { redirect: { to: 'B' } });
     const optB = makeOption('B', { redirect: { to: 'C' } });
     const optC = makeOption('C', { redirect: { to: 'A' } });
@@ -176,6 +176,6 @@ describe('resolveRedirectChain', () => {
     expect(result.chain[0].target.id).toBe('B');
     expect(result.chain[1].source.id).toBe('B');
     expect(result.chain[1].target.id).toBe('C');
-    expect(result.finalTarget).toBe(optC);
+    expect(result.finalTarget).toBeUndefined();
   });
 });

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/resolveRedirectChain.spec.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/resolveRedirectChain.spec.ts
@@ -1,0 +1,181 @@
+import { OptionsRedirectMessageLevel } from '~/generated/data-contracts';
+import {
+  resolveRedirectChain,
+  OptionValue,
+} from '~/app/pages/Workspaces/Form/utils/resolveRedirectChain';
+
+const makeOption = (id: string, overrides: Partial<OptionValue> = {}): OptionValue =>
+  ({
+    id,
+    displayName: `Display ${id}`,
+    description: `Description ${id}`,
+    hidden: false,
+    labels: [{ key: 'env', value: 'test' }],
+    redirect: undefined,
+    ...overrides,
+  }) as OptionValue;
+
+describe('resolveRedirectChain', () => {
+  it('returns empty chain when option has no redirect', () => {
+    const option = makeOption('A');
+    const result = resolveRedirectChain(option, [option]);
+
+    expect(result.chain).toEqual([]);
+    expect(result.finalTarget).toBeUndefined();
+  });
+
+  it('resolves a single-hop redirect', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B');
+
+    const result = resolveRedirectChain(optA, [optA, optB]);
+
+    expect(result.chain).toHaveLength(1);
+    expect(result.chain[0].source.id).toBe('A');
+    expect(result.chain[0].target.id).toBe('B');
+    expect(result.finalTarget).toBe(optB);
+  });
+
+  it('resolves a multi-hop redirect chain', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B', { redirect: { to: 'C' } });
+    const optC = makeOption('C');
+
+    const result = resolveRedirectChain(optA, [optA, optB, optC]);
+
+    expect(result.chain).toHaveLength(2);
+    expect(result.chain[0].source.id).toBe('A');
+    expect(result.chain[0].target.id).toBe('B');
+    expect(result.chain[1].source.id).toBe('B');
+    expect(result.chain[1].target.id).toBe('C');
+    expect(result.finalTarget).toBe(optC);
+  });
+
+  it('detects cycles and terminates the chain', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B', { redirect: { to: 'A' } });
+
+    const result = resolveRedirectChain(optA, [optA, optB]);
+
+    expect(result.chain).toHaveLength(1);
+    expect(result.chain[0].source.id).toBe('A');
+    expect(result.chain[0].target.id).toBe('B');
+    expect(result.finalTarget).toBe(optB);
+  });
+
+  it('handles missing target gracefully', () => {
+    const optA = makeOption('A', { redirect: { to: 'missing' } });
+
+    const result = resolveRedirectChain(optA, [optA]);
+
+    expect(result.chain).toHaveLength(1);
+    expect(result.chain[0].source.id).toBe('A');
+    expect(result.chain[0].target.id).toBe('missing');
+    expect(result.chain[0].target.displayName).toBe('missing (not found)');
+    expect(result.finalTarget).toBeUndefined();
+  });
+
+  it('handles multi-hop with missing intermediate target', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    // B is missing from allOptions
+    const optC = makeOption('C');
+
+    const result = resolveRedirectChain(optA, [optA, optC]);
+
+    expect(result.chain).toHaveLength(1);
+    expect(result.chain[0].target.displayName).toBe('B (not found)');
+    expect(result.finalTarget).toBeUndefined();
+  });
+
+  it('preserves redirect message with level and text', () => {
+    const optA = makeOption('A', {
+      redirect: {
+        to: 'B',
+        message: {
+          level: OptionsRedirectMessageLevel.RedirectMessageLevelWarning,
+          text: 'Option A is deprecated',
+        },
+      },
+    });
+    const optB = makeOption('B');
+
+    const result = resolveRedirectChain(optA, [optA, optB]);
+
+    expect(result.chain[0].message).toEqual({
+      level: 'Warning',
+      text: 'Option A is deprecated',
+    });
+  });
+
+  it('handles redirect without message', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B');
+
+    const result = resolveRedirectChain(optA, [optA, optB]);
+
+    expect(result.chain[0].message).toBeUndefined();
+  });
+
+  it('preserves labels on source and target', () => {
+    const optA = makeOption('A', {
+      redirect: { to: 'B' },
+      labels: [{ key: 'k1', value: 'v1' }],
+    });
+    const optB = makeOption('B', {
+      labels: [{ key: 'k2', value: 'v2' }],
+    });
+
+    const result = resolveRedirectChain(optA, [optA, optB]);
+
+    expect(result.chain[0].source.labels).toEqual([{ key: 'k1', value: 'v1' }]);
+    expect(result.chain[0].target.labels).toEqual([{ key: 'k2', value: 'v2' }]);
+  });
+
+  it('handles options with no labels', () => {
+    const optA = makeOption('A', {
+      redirect: { to: 'B' },
+      labels: undefined,
+    });
+    const optB = makeOption('B', { labels: undefined });
+
+    const result = resolveRedirectChain(optA, [optA, optB]);
+
+    expect(result.chain[0].source.labels).toEqual([]);
+    expect(result.chain[0].target.labels).toEqual([]);
+  });
+
+  it('does not mutate input arrays', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B');
+    const allOptions = [optA, optB];
+    const originalOptions = JSON.parse(JSON.stringify(allOptions));
+
+    resolveRedirectChain(optA, allOptions);
+
+    expect(allOptions).toEqual(originalOptions);
+  });
+
+  it('handles self-redirect as a cycle', () => {
+    const optA = makeOption('A', { redirect: { to: 'A' } });
+
+    const result = resolveRedirectChain(optA, [optA]);
+
+    expect(result.chain).toHaveLength(0);
+    expect(result.finalTarget).toBeUndefined();
+  });
+
+  it('handles three-node cycle', () => {
+    const optA = makeOption('A', { redirect: { to: 'B' } });
+    const optB = makeOption('B', { redirect: { to: 'C' } });
+    const optC = makeOption('C', { redirect: { to: 'A' } });
+
+    const result = resolveRedirectChain(optA, [optA, optB, optC]);
+
+    expect(result.chain).toHaveLength(2);
+    expect(result.chain[0].source.id).toBe('A');
+    expect(result.chain[0].target.id).toBe('B');
+    expect(result.chain[1].source.id).toBe('B');
+    expect(result.chain[1].target.id).toBe('C');
+    expect(result.finalTarget).toBe(optC);
+  });
+});

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/resolveRedirectChain.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/resolveRedirectChain.ts
@@ -54,11 +54,13 @@ export const resolveRedirectChain = (
   const visited = new Set<string>([option.id]);
   const chain: WorkspacesRedirectStep[] = [];
   let current = option;
+  let cycleDetected = false;
 
   while (current.redirect) {
     const targetId = current.redirect.to;
 
     if (visited.has(targetId)) {
+      cycleDetected = true;
       break;
     }
     visited.add(targetId);
@@ -90,7 +92,7 @@ export const resolveRedirectChain = (
     return { chain, finalTarget: undefined };
   }
 
-  const finalTarget = optionsMap.get(chain[chain.length - 1].target.id);
+  const finalTarget = cycleDetected ? undefined : optionsMap.get(chain[chain.length - 1].target.id);
 
   return { chain, finalTarget };
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/resolveRedirectChain.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/resolveRedirectChain.ts
@@ -11,6 +11,7 @@ export type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
 export interface RedirectChainResult {
   chain: WorkspacesRedirectStep[];
   finalTarget: OptionValue | undefined;
+  cycleDetected: boolean;
 }
 
 export const transformRedirectMessageLevel = (
@@ -47,7 +48,7 @@ export const resolveRedirectChain = (
   allOptions: OptionValue[],
 ): RedirectChainResult => {
   if (!option.redirect) {
-    return { chain: [], finalTarget: undefined };
+    return { chain: [], finalTarget: undefined, cycleDetected: false };
   }
 
   const optionsMap = new Map(allOptions.map((opt) => [opt.id, opt]));
@@ -89,10 +90,10 @@ export const resolveRedirectChain = (
   }
 
   if (chain.length === 0) {
-    return { chain, finalTarget: undefined };
+    return { chain, finalTarget: undefined, cycleDetected };
   }
 
   const finalTarget = cycleDetected ? undefined : optionsMap.get(chain[chain.length - 1].target.id);
 
-  return { chain, finalTarget };
+  return { chain, finalTarget, cycleDetected };
 };

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/resolveRedirectChain.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/resolveRedirectChain.ts
@@ -1,0 +1,96 @@
+import {
+  OptionsImageConfigValue,
+  OptionsPodConfigValue,
+  OptionsRedirectMessageLevel,
+  WorkspacesRedirectMessageLevel,
+  WorkspacesRedirectStep,
+} from '~/generated/data-contracts';
+
+export type OptionValue = OptionsImageConfigValue | OptionsPodConfigValue;
+
+export interface RedirectChainResult {
+  chain: WorkspacesRedirectStep[];
+  finalTarget: OptionValue | undefined;
+}
+
+export const transformRedirectMessageLevel = (
+  level?: OptionsRedirectMessageLevel,
+): WorkspacesRedirectMessageLevel => {
+  switch (level) {
+    case OptionsRedirectMessageLevel.RedirectMessageLevelInfo:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
+    case OptionsRedirectMessageLevel.RedirectMessageLevelWarning:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelWarning;
+    case OptionsRedirectMessageLevel.RedirectMessageLevelDanger:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelDanger;
+    default:
+      return WorkspacesRedirectMessageLevel.RedirectMessageLevelInfo;
+  }
+};
+
+const toOptionInfo = (option: OptionValue) => ({
+  id: option.id,
+  displayName: option.displayName,
+  description: option.description,
+  labels: (option.labels ?? []).map((label) => ({ key: label.key, value: label.value })),
+});
+
+const toNotFoundInfo = (id: string) => ({
+  id,
+  displayName: `${id} (not found)`,
+  description: '',
+  labels: [],
+});
+
+export const resolveRedirectChain = (
+  option: OptionValue,
+  allOptions: OptionValue[],
+): RedirectChainResult => {
+  if (!option.redirect) {
+    return { chain: [], finalTarget: undefined };
+  }
+
+  const optionsMap = new Map(allOptions.map((opt) => [opt.id, opt]));
+  const visited = new Set<string>([option.id]);
+  const chain: WorkspacesRedirectStep[] = [];
+  let current = option;
+
+  while (current.redirect) {
+    const targetId = current.redirect.to;
+
+    if (visited.has(targetId)) {
+      break;
+    }
+    visited.add(targetId);
+
+    const targetOption = optionsMap.get(targetId);
+
+    const step: WorkspacesRedirectStep = {
+      source: toOptionInfo(current),
+      target: targetOption ? toOptionInfo(targetOption) : toNotFoundInfo(targetId),
+    };
+
+    if (current.redirect.message) {
+      step.message = {
+        level: transformRedirectMessageLevel(current.redirect.message.level),
+        text: current.redirect.message.text,
+      };
+    }
+
+    chain.push(step);
+
+    if (!targetOption) {
+      break;
+    }
+
+    current = targetOption;
+  }
+
+  if (chain.length === 0) {
+    return { chain, finalTarget: undefined };
+  }
+
+  const finalTarget = optionsMap.get(chain[chain.length - 1].target.id);
+
+  return { chain, finalTarget };
+};


### PR DESCRIPTION
 closes: #1144

Redirect confirmation modal integration
  - Added StepRedirectInfo discriminated union type to model redirect/hidden state for the current form step
  - Integrated WorkspaceFormRedirectConfirmModal into WorkspaceForm with handlers for apply, continue, and cancel actions
  - Extracted transformRedirectMessageLevel from WorkspaceFormOptionCard into the shared resolveRedirectChain utility to avoid duplication

  Cypress E2E tests
  - Added RedirectConfirmModal page object in workspaceForm.ts
  - Added 10 new tests covering image redirect (apply/continue/cancel), image hidden-only, pod config redirect (apply/cancel), and pod config
  hidden-only flows
  - Updated existing create and edit workspace tests to handle the new modal during step navigation

Examples:

Hidden image warning:
<img width="592" height="351" alt="Screenshot 2026-07-15 at 1 50 12 PM" src="https://github.com/user-attachments/assets/29d00a11-0bb4-488d-8274-87b87004c392" />

Redirection
<img width="552" height="328" alt="Screenshot 2026-07-15 at 1 50 21 PM" src="https://github.com/user-attachments/assets/6c76e435-78b6-4263-b031-fdd288f620b6" />
 warning:
