### PR TITLE
fix: add text wrapping to option card titles and descriptions

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -15,6 +15,13 @@
 .pf-v6-c-card__body.workspace-option-card__description {
   font-size: var(--pf-v6-global--FontSize--xs);
   color: var(--pf-v6-c-content--small--Color);
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.pf-v6-c-card__header .pf-v6-c-card__title {
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .pf-v6-c-card__header.workspace-option-card__header--with-icons .pf-v6-c-card__title {


### PR DESCRIPTION
closes: #1142

## Description

Option titles and descriptions in WorkspaceKind and Workspace option
selection cards do not wrap properly when they exceed the card width.
Long text either overflows or gets truncated, hiding important
information from the user.

## Changes

- Added \overflow-wrap: break-word\ to \.workspace-option-card__description\
  so long descriptions wrap within the card boundaries
- Added \overflow-wrap: break-word\ to \.pf-v6-c-card__header .pf-v6-c-card__title\
  so long titles wrap within the card boundaries

## Testing

- All existing unit tests pass
- CSS change only — no logic or type changes
- Verified with Prettier

## Checklist

- [x] The PR description links to the related issue
- [x] The PR title follows semantic commit conventions
- [x] Commits include DCO sign-off
- [x] Only relevant files are changed
- [x] Prettier formatting passes