### PR TITLE
chore: Update list of authorized users for slash commands and planning labels

### DIFF
--- a/.github/workflows/slash-commands.yaml
+++ b/.github/workflows/slash-commands.yaml
@@ -11,7 +11,7 @@ jobs:
   handle-slash-command:
     if: |
       github.event.issue.pull_request == null
-      && contains('["thesuperzapper", "ederign", "andyatmiami", "paulovmr", "jenny-s51", "harshad16", "thaorell", "liavweiss", "christian-heusel"]', github.event.comment.user.login)
+      && contains('["thesuperzapper", "andyatmiami", "paulovmr", "harshad16", "thaorell", "christian-heusel"]', github.event.comment.user.login)
       && (
           contains(github.event.comment.body, '/add-sub-issue')
           || contains(github.event.comment.body, '/remove-sub-issue')

--- a/.github/workflows/slash-commands.yaml
+++ b/.github/workflows/slash-commands.yaml
@@ -11,7 +11,7 @@ jobs:
   handle-slash-command:
     if: |
       github.event.issue.pull_request == null
-      && contains('["thesuperzapper", "andyatmiami", "paulovmr", "harshad16", "thaorell", "christian-heusel"]', github.event.comment.user.login)
+      && contains('["thesuperzapper", "andyatmiami", "paulovmr", "harshad16", "thaorell", "christian-heusel", "Jefftree", "richabanker", "siyuanfoundation"]', github.event.comment.user.login)
       && (
           contains(github.event.comment.body, '/add-sub-issue')
           || contains(github.event.comment.body, '/remove-sub-issue')

--- a/.github/workflows/validate-planning-label.yml
+++ b/.github/workflows/validate-planning-label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, labeled]
 
 env:
-  AUTHORIZED_USERS: '["thesuperzapper", "ederign", "andyatmiami", "paulovmr", "jenny-s51", "harshad16", "thaorell", "liavweiss", "christian-heusel"]'
+  AUTHORIZED_USERS: '["thesuperzapper", "andyatmiami", "paulovmr", "harshad16", "thaorell", "christian-heusel"]'
 
 permissions:
   issues: write

--- a/.github/workflows/validate-planning-label.yml
+++ b/.github/workflows/validate-planning-label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, labeled]
 
 env:
-  AUTHORIZED_USERS: '["thesuperzapper", "andyatmiami", "paulovmr", "harshad16", "thaorell", "christian-heusel"]'
+  AUTHORIZED_USERS: '["thesuperzapper", "andyatmiami", "paulovmr", "harshad16", "thaorell", "christian-heusel", "Jefftree", "richabanker", "siyuanfoundation"]'
 
 permissions:
   issues: write


### PR DESCRIPTION
## `chore: Allowlist feature owners to use planning labels`

Currently some of the feature owners are not able to use the planning labels to complete the currently underspecified part of their assigned features, which creates a artificial dependency on the projects maintainers and core team.

The list of users to be added was obtained like this and verified manually:

    $ gh issue list --label "kind/plan-feature" --json assignees | jq -r ".[].assignees[].login" | sort --uniq

Not all of the feature owners are Kubeflow Organization members yet, however they are already contributing very nicely and are considered trusted both by their employer and the wider K8S ecosystem, so this is most likely more a matter of time until we get their PRs merged.

## `chore: Remove inactive members from slash commands`

It does not really make sense to grant this capability to people who are currently not involved in the project and hence not aware of our planning process and methodology.

---

cc @Jefftree @richabanker @siyuanfoundation

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
