### PR TITLE
fix: Avoid activityRules webhook warning in jupyterlab sample

### DIFF
--- a/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml
@@ -10,7 +10,7 @@ spec:
   ## ================================================================
   activityRules:
     - config:
-        secondsSinceActive: 3600
+        secondsSinceActive: 7200
         minRunningSeconds: 300
       match:
         matchNamespace:


### PR DESCRIPTION
The first activityRule's `secondsSinceActive` was equal to `probeIntervalSeconds`, which is less than the required 2x ratio and triggered a webhook warning on apply:

    $ kubectl kustomize workspaces/controller/manifests/kustomize/samples/ | kubectl apply -f -
    [...]
    Warning: spec.activityRules[0].config.secondsSinceActive (3600) is less than twice the probeIntervalSeconds (3600). This may cause Workspaces to be paused too quickly or prematurely.
    [...]

Align it with the other samples by using 7200 as target value:
```
$ grep -nrw secondsSinceActive workspaces/controller/manifests/kustomize/samples/
workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml:8:        secondsSinceActive: 7200
workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml:8:        secondsSinceActive: 7200
workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml:13:        secondsSinceActive: 7200
workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml:23:        secondsSinceActive: 86400
```

Related-to: http://github.com/kubeflow/notebooks/pulls/1239

cc @siyuanfoundation

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
