### PR TITLE
feat: add gzip/zstd response compression to backend

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/klauspost/compress/gzhttp"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -130,5 +131,7 @@ func (a *App) Routes() http.Handler {
 		router.GET(constants.SwaggerPath, a.GetSwaggerHandler)
 	}
 
-	return a.recoverPanic(a.enableCORS(router))
+	handler := gzhttp.GzipHandler(router)
+
+	return a.recoverPanic(a.enableCORS(handler))
 }

--- a/workspaces/backend/api/middleware_test.go
+++ b/workspaces/backend/api/middleware_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/klauspost/compress/gzhttp"
+	"github.com/klauspost/compress/zstd"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("compression", func() {
+
+	const (
+		testRequestPath      = "/test"
+		testSmallRequestPath = "/test-small"
+	)
+
+	var (
+		app        *App
+		compressed http.Handler
+	)
+
+	// largePayload is intentionally larger than gzhttp's default MinSize (1024 bytes)
+	// so that it is eligible for compression.
+	largePayload := func() map[string]string {
+		return map[string]string{"data": strings.Repeat("kubeflow-notebooks-compression-test", 100)}
+	}
+
+	// smallPayload mirrors a tiny response (e.g. the healthcheck endpoint), which should
+	// stay under the MinSize threshold and therefore never be compressed.
+	smallPayload := func() map[string]string {
+		return map[string]string{"data": "ok"}
+	}
+
+	BeforeEach(func() {
+		app = &App{}
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			payload := largePayload()
+			if r.URL.Path == testSmallRequestPath {
+				payload = smallPayload()
+			}
+			err := app.WriteJSON(w, http.StatusOK, payload, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		compressed = gzhttp.GzipHandler(next)
+	})
+
+	DescribeTable("negotiating the response encoding",
+		func(requestPath string, acceptEncoding string, expectedEncoding string) {
+			r := httptest.NewRequest(http.MethodGet, requestPath, http.NoBody)
+			if acceptEncoding != "" {
+				r.Header.Set("Accept-Encoding", acceptEncoding)
+			}
+			w := httptest.NewRecorder()
+
+			compressed.ServeHTTP(w, r)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Encoding")).To(Equal(expectedEncoding))
+
+			// the handler only advertises Vary once it has actually compressed the body
+			if expectedEncoding != "" {
+				Expect(w.Header().Get("Vary")).To(ContainSubstring("Accept-Encoding"))
+			}
+
+			var body io.Reader = w.Body
+			switch expectedEncoding {
+			case "gzip":
+				gzReader, err := gzip.NewReader(w.Body)
+				Expect(err).NotTo(HaveOccurred())
+				defer gzReader.Close()
+				body = gzReader
+			case "zstd":
+				zstdReader, err := zstd.NewReader(w.Body)
+				Expect(err).NotTo(HaveOccurred())
+				defer zstdReader.Close()
+				body = zstdReader
+			}
+
+			decompressed, err := io.ReadAll(body)
+			Expect(err).NotTo(HaveOccurred())
+
+			payload := largePayload()
+			if requestPath == testSmallRequestPath {
+				payload = smallPayload()
+			}
+			expected, err := json.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decompressed).To(MatchJSON(expected))
+		},
+		Entry("compresses a large response with gzip when the client accepts it",
+			testRequestPath, "gzip", "gzip"),
+		Entry("compresses a large response with zstd when the client accepts it",
+			testRequestPath, "zstd", "zstd"),
+		Entry("prefers zstd over gzip when the client accepts both at equal quality",
+			testRequestPath, "gzip, zstd", "zstd"),
+		Entry("does not compress the response when the client sends no Accept-Encoding",
+			testRequestPath, "", ""),
+		Entry("does not compress small responses even when the client accepts compression",
+			testSmallRequestPath, "gzip, zstd", ""),
+	)
+})

--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -6,6 +6,7 @@ replace github.com/kubeflow/notebooks/workspaces/controller => ../controller
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/klauspost/compress v1.19.1
 	github.com/kubeflow/notebooks/workspaces/controller v0.0.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/workspaces/backend/go.sum
+++ b/workspaces/backend/go.sum
@@ -80,6 +80,8 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
## Summary
- Wraps the backend HTTP handler with `github.com/klauspost/compress/gzhttp`, negotiating gzip or zstd per-request based on the client's `Accept-Encoding` header.
- Uses library defaults: 1024-byte minimum response size before compressing (avoids making tiny responses larger from framing overhead), zstd preferred over gzip when a client accepts both at equal quality.

This will be especially useful when we proceed with the work in #885, as this way the payload size towards the client can be drastically reduced.

## Impact / testing results

Benchmarked every non-mutating endpoint via repeated requests with `Accept-Encoding: identity|gzip|zstd`:

| Endpoint | Uncompressed | gzip | zstd |
|---|---:|---:|---:|
| `GET /workspacekinds` | 7,143 B | 1,238 B (-82.7%) | 1,332 B (-81.3%) |
| `GET /workspacekinds/{name}` | 5,108 B | 1,517 B (-70.3%) | 1,653 B (-67.6%) |
| `GET /persistentvolumeclaims/{ns}` | 5,488 B | 802 B (-85.4%) | 792 B (-85.6%) |
| `POST /workspacekinds/{name}/podtemplate/options/listvalues` | 3,149 B | 752 B (-76.1%) | 805 B (-74.4%) |
| `GET /workspaces` | 1,322 B | 670 B (-49.3%) | 713 B (-46.1%) |

Small responses (healthcheck, namespaces, secrets, single-workspace detail which are all under ~450 B) correctly stayed uncompressed on every variant, confirming the 1024-byte threshold works as intended.

**Load test** ([`hatoo/oha`](https://github.com/hatoo/oha)):

```
$ oha -z 5sec --insecure https://localhost:8443/workspaces/api/v1/workspacekinds\?namespaceFilter\=default -H "kubeflow-userid: admin" [--disable-compression] --no-tui
```

| Variant | Req/sec | Mean latency | p99 latency |
|---|---:|---:|---:|
| Uncompressed | 1,234.6 | 40.60 ms | 110.71 ms |
| gzip | 1,449.5 (+17.4%) | 34.64 ms (-14.7%) | 53.62 ms (-51.6%) |
| zstd | 1,396.4 (+13.1%) | 35.92 ms (-11.5%) | 69.23 ms (-37.5%) |


Under concurrency, compression measurably reduces contention for the shared network/tunnel bandwidth. Single uncontended requests showed no latency difference either way, as expected.

## Test plan
- [x] `make lint` / `make test` in `workspaces/backend/` (new `api/middleware_test.go` covers gzip, zstd, zstd-preferred-on-tie, uncompressed-when-no-Accept-Encoding, and under-threshold-stays-uncompressed)
- [x] Manual verification against a live Tilt dev cluster: correct `Content-Encoding`/`Vary` headers, Swagger UI still renders correctly compressed, size/latency benchmarked across GET and POST endpoints
