### PR TITLE
fix: inject kubeflow-userid header for Swagger UI "Try it out"

### DIFF
--- a/workspaces/backend/api/swagger_handler.go
+++ b/workspaces/backend/api/swagger_handler.go
@@ -17,21 +17,104 @@ limitations under the License.
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
+	"github.com/swaggo/swag"
 
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	"github.com/kubeflow/notebooks/workspaces/backend/openapi"
 )
 
+// swaggerDocPath is the internal route path (rooted at constants.PathPrefix) at which the Go
+// handler sees requests for the OpenAPI definition. This is distinct from the external browser
+// path used by httpSwagger.URL() (see openapi.SwaggerInfo.BasePath below).
+var swaggerDocPath = constants.PathPrefix + "/swagger/doc.json"
+
+const (
+	// userIdSecurityScheme is the name of the security scheme which we inject into the OpenAPI
+	// definition served by the Swagger UI, so users can set the user id header with the
+	// "Authorize" button.
+	//
+	// NOTE: the name of the user id header is configurable (see EnvConfig.UserIdHeader), so this
+	//       scheme can only be resolved at runtime, and is not part of `openapi/swagger.json`.
+	userIdSecurityScheme = "UserIdHeader"
+
+	// defaultSwaggerUserId is the user id which the Swagger UI is pre-authorized with, so
+	// "Try it out" works without any manual steps.
+	//
+	// NOTE: this matches the user which is bound to the admin ClusterRole in the Tilt dev cluster.
+	defaultSwaggerUserId = "admin"
+)
+
 func (a *App) GetSwaggerHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// intercept the OpenAPI definition, so we can inject the user id header security scheme
+	if r.URL.Path == swaggerDocPath {
+		a.serveSwaggerDoc(w, r)
+		return
+	}
+
 	httpSwagger.Handler(
 		// this url is the one that the swagger frontend uses to fetch the OpenAPI definition
 		httpSwagger.URL(fmt.Sprintf("%s/swagger/doc.json", openapi.SwaggerInfo.BasePath)),
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("list"),
 		httpSwagger.DomID("swagger-ui"),
+		httpSwagger.PersistAuthorization(true),
+		// pre-authorize the UI with a default user id, so "Try it out" works out of the box
+		//
+		// NOTE: this must run from the `onComplete` callback, which fires once the definition has
+		//       been fetched and rendered, rather than from `AfterScript`, which runs right after
+		//       `SwaggerUIBundle()` returns, before the security schemes have loaded (in which
+		//       case `preauthorizeApiKey` silently does nothing).
+		httpSwagger.UIConfig(map[string]string{
+			"onComplete": fmt.Sprintf(`() => { window.ui.preauthorizeApiKey(%q, %q) }`, userIdSecurityScheme, defaultSwaggerUserId),
+		}),
 	).ServeHTTP(w, r)
+}
+
+// serveSwaggerDoc serves the OpenAPI definition with the user id header security scheme injected.
+func (a *App) serveSwaggerDoc(w http.ResponseWriter, r *http.Request) {
+	doc, err := swag.ReadDoc(openapi.SwaggerInfo.InstanceName())
+	if err != nil {
+		a.serverErrorResponse(w, r, fmt.Errorf("failed to read OpenAPI definition: %w", err))
+		return
+	}
+
+	var spec map[string]any
+	if err := json.Unmarshal([]byte(doc), &spec); err != nil {
+		a.serverErrorResponse(w, r, fmt.Errorf("failed to unmarshal OpenAPI definition: %w", err))
+		return
+	}
+
+	spec["securityDefinitions"] = map[string]any{
+		userIdSecurityScheme: map[string]any{
+			"type": "apiKey",
+			"in":   "header",
+			"name": a.Config.UserIdHeader,
+			"description": fmt.Sprintf(
+				"The %q header, which identifies the user making the request. "+
+					"In production, this header is typically set by an authenticating proxy (e.g. oauth2-proxy). <br><br>"+
+					"<b>Note:</b> The Swagger UI is pre-authorized as %q by default, click \"Logout\" and enter another value to send the requests as a different user.",
+				a.Config.UserIdHeader, defaultSwaggerUserId,
+			),
+		},
+	}
+	spec["security"] = []any{
+		map[string]any{userIdSecurityScheme: []any{}},
+	}
+
+	out, err := json.Marshal(spec)
+	if err != nil {
+		a.serverErrorResponse(w, r, fmt.Errorf("failed to marshal OpenAPI definition: %w", err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if _, err := w.Write(out); err != nil {
+		a.logger.Error("failed to write OpenAPI definition", "error", err)
+	}
 }

--- a/workspaces/backend/cmd/main.go
+++ b/workspaces/backend/cmd/main.go
@@ -48,6 +48,10 @@ import (
 //	@consumes	application/json
 //	@produces	application/json
 
+// NOTE: the security definition for the user id header is not declared here, but injected at
+//       runtime by the Swagger UI handler (see `api/swagger_handler.go`), because the name of
+//       the header is configurable with the `--userid-header` flag.
+
 func main() {
 	// Define command line flags
 	cfg := &config.EnvConfig{}

--- a/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml
@@ -21,7 +21,6 @@ spec:
       url: "https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg"
 
   filterRules:
-
   - scope: IMAGE_CONFIG
     effect:
       ui:

--- a/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml
@@ -21,7 +21,6 @@ spec:
       url: "https://upload.wikimedia.org/wikipedia/commons/1/1b/R_logo.svg"
 
   filterRules:
-
     - scope: POD_CONFIG
       effect:
         ui:


### PR DESCRIPTION
The backend's request authenticator requires the configured user id
header (default kubeflow-userid) on every request. The Swagger UI has no
way to prompt for it, so every "Try it out" call was failing with
401. Add a Swagger UI config to set the header to "admin", matching the
user bound to the admin ClusterRole in the Tilt dev cluster.

<img width="2255" height="1329" alt="image" src="https://github.com/user-attachments/assets/04748788-c188-4dd7-adcf-859796e63b78" />



<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
