### PR TITLE
chore: integrate podtemplate/details endpoint into frontend

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -11,6 +11,7 @@ import type {
   ApiStorageClassListEnvelope,
   ApiWorkspaceActionPauseEnvelope,
   ApiWorkspaceCreateEnvelope,
+  ApiWorkspaceDetailsEnvelope,
   ApiWorkspaceEnvelope,
   ApiWorkspaceKindCreateEnvelope,
   ApiWorkspaceKindEnvelope,
@@ -78,6 +79,11 @@ declare global {
           type: 'POST /api/:apiVersion/workspaces/:namespace/:workspaceName/actions/pause',
           options: { path: { apiVersion: string; namespace: string; workspaceName: string } },
           response: ApiWorkspaceActionPauseEnvelope | ApiErrorEnvelope,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/:apiVersion/workspaces/:namespace/:workspaceName/podtemplate/details',
+          options: { path: { apiVersion: string; namespace: string; workspaceName: string } },
+          response: ApiWorkspaceDetailsEnvelope | ApiErrorEnvelope,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'PUT /api/:apiVersion/workspaces/:namespace/:workspaceName',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsAttach.cy.ts
@@ -29,6 +29,7 @@ describe('SecretsAttachModal', () => {
 
   const mockWorkspaceUpdate = buildMockWorkspaceUpdateFromWorkspace({
     workspace: mockWorkspaceListItem,
+    volumes: { secrets: [] },
   });
 
   const mockSecrets = [

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsEdit.cy.ts
@@ -30,13 +30,14 @@ describe('Edit Secret Modal', () => {
     state: V1Beta1WorkspaceState.WorkspaceStateRunning,
   });
 
-  // Add a secret to the workspace
-  mockWorkspaceListItem.podTemplate.volumes.secrets = [
-    { secretName: 'test-secret', mountPath: '/mnt/secrets', defaultMode: 420 },
-  ];
+  const testSecrets = [{ secretName: 'test-secret', mountPath: '/mnt/secrets', defaultMode: 420 }];
+
+  // Add a secret to the workspace list item (for list view)
+  mockWorkspaceListItem.podTemplate.volumes.secrets = testSecrets;
 
   const mockWorkspaceUpdate = buildMockWorkspaceUpdateFromWorkspace({
     workspace: mockWorkspaceListItem,
+    volumes: { secrets: testSecrets },
   });
 
   const mockSecrets = [
@@ -198,9 +199,10 @@ describe('Edit Secret Modal', () => {
       workspaceKind: mockWorkspaceKindInfo,
       state: V1Beta1WorkspaceState.WorkspaceStateRunning,
     });
-    workspaceWithImmutableSecret.podTemplate.volumes.secrets = [
+    const immutableSecrets = [
       { secretName: 'immutable-secret', mountPath: '/mnt/immutable', defaultMode: 420 },
     ];
+    workspaceWithImmutableSecret.podTemplate.volumes.secrets = immutableSecrets;
 
     // Re-intercept getWorkspaces with updated workspace data
     cy.interceptApi(
@@ -212,6 +214,7 @@ describe('Edit Secret Modal', () => {
     // Re-intercept getWorkspace with updated workspace data
     const updatedWorkspace = buildMockWorkspaceUpdateFromWorkspace({
       workspace: workspaceWithImmutableSecret,
+      volumes: { secrets: immutableSecrets },
     });
     cy.interceptApi(
       'GET /api/:apiVersion/workspaces/:namespace/:workspaceName',
@@ -271,13 +274,15 @@ describe('Edit Secret Modal', () => {
     ).as('listSecretsUpdated');
 
     // Add this secret to workspace and re-visit the page
-    mockWorkspaceListItem.podTemplate.volumes.secrets = [
+    const noUpdateSecrets = [
       { secretName: 'no-update-secret', mountPath: '/mnt/no-update', defaultMode: 420 },
     ];
+    mockWorkspaceListItem.podTemplate.volumes.secrets = noUpdateSecrets;
 
     // Re-intercept getWorkspace with updated workspace data
     const updatedWorkspace = buildMockWorkspaceUpdateFromWorkspace({
       workspace: mockWorkspaceListItem,
+      volumes: { secrets: noUpdateSecrets },
     });
     cy.interceptApi(
       'GET /api/:apiVersion/workspaces/:namespace/:workspaceName',

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/secretsManagement.cy.ts
@@ -32,14 +32,16 @@ describe('Secrets Expandable Key/Value Pairs', () => {
   });
 
   // Override the secrets in the workspace
-  mockWorkspaceListItem.podTemplate.volumes.secrets = [
+  const testSecrets = [
     { secretName: 'api-key-secret', mountPath: '/mnt/secrets', defaultMode: 420 },
     { secretName: 'db-credentials', mountPath: '/mnt/db', defaultMode: 384 },
   ];
+  mockWorkspaceListItem.podTemplate.volumes.secrets = testSecrets;
 
   // Create the WorkspaceUpdate format for the getWorkspace API call
   const mockWorkspaceUpdate = buildMockWorkspaceUpdateFromWorkspace({
     workspace: mockWorkspaceListItem,
+    volumes: { secrets: testSecrets },
   });
 
   beforeEach(() => {
@@ -170,6 +172,7 @@ describe('Secrets Management - Attach Modal', () => {
 
   const mockWorkspaceUpdate = buildMockWorkspaceUpdateFromWorkspace({
     workspace: mockWorkspaceListItem,
+    volumes: { secrets: [] },
   });
 
   const mockSecrets = [

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/volumesManagement.cy.ts
@@ -43,6 +43,7 @@ describe('Volumes Management - Attach and Create', () => {
 
   const mockWorkspaceUpdate = buildMockWorkspaceUpdateFromWorkspace({
     workspace: mockWorkspaceListItem,
+    volumes: { data: [] },
   });
 
   // Create mock PVCs for attach modal

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaces.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaces.cy.ts
@@ -12,6 +12,7 @@ import {
   buildMockActionsWorkspaceActionPause,
   buildMockNamespace,
   buildMockWorkspace,
+  buildMockWorkspaceDetails,
   buildMockWorkspaceKindInfo,
   buildMockWorkspaceList,
 } from '~/shared/mock/mockBuilder';
@@ -682,6 +683,18 @@ describe('Workspaces', () => {
         mockModArchResponse(mockWorkspaces),
       ).as('getWorkspaces');
 
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspaces/:namespace/:workspaceName/podtemplate/details',
+        {
+          path: {
+            apiVersion: NOTEBOOKS_API_VERSION,
+            namespace: mockNamespace.name,
+            workspaceName,
+          },
+        },
+        mockModArchResponse(buildMockWorkspaceDetails()),
+      ).as('getWorkspaceDetails');
+
       navigateToNamespace(mockNamespace.name);
 
       return { mockNamespace, mockWorkspaces };
@@ -1024,6 +1037,30 @@ describe('Workspaces', () => {
           { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
           mockModArchResponse(mockWorkspaces),
         ).as('getWorkspaces');
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/workspaces/:namespace/:workspaceName/podtemplate/details',
+          {
+            path: {
+              apiVersion: NOTEBOOKS_API_VERSION,
+              namespace: mockNamespace.name,
+              workspaceName: TEST_WORKSPACE_NAME,
+            },
+          },
+          mockModArchResponse(buildMockWorkspaceDetails()),
+        ).as('getWorkspaceDetails');
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/workspaces/:namespace/:workspaceName/podtemplate/details',
+          {
+            path: {
+              apiVersion: NOTEBOOKS_API_VERSION,
+              namespace: mockNamespace.name,
+              workspaceName: workspace2Name,
+            },
+          },
+          mockModArchResponse(buildMockWorkspaceDetails()),
+        ).as('getWorkspace2Details');
 
         navigateToNamespace(mockNamespace.name);
 

--- a/workspaces/frontend/src/app/components/DetailsLoadingState.tsx
+++ b/workspaces/frontend/src/app/components/DetailsLoadingState.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+
+interface DetailsLoadingStateProps {
+  error?: Error;
+  loaded: boolean;
+  children: React.ReactNode;
+}
+
+export const DetailsLoadingState: React.FC<DetailsLoadingStateProps> = ({
+  error,
+  loaded,
+  children,
+}) => {
+  if (error) {
+    return (
+      <Content component="small" data-testid="details-loading-error">
+        Failed to load details
+      </Content>
+    );
+  }
+  if (loaded) {
+    return <>{children}</>;
+  }
+  return <Spinner size="md" data-testid="details-loading-spinner" />;
+};

--- a/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceDetails.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceDetails.spec.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from '~/__tests__/unit/testUtils/hooks';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import { useWorkspaceDetails } from '~/app/hooks/useWorkspaceDetails';
+import { NotebookApis } from '~/shared/api/notebookApi';
+import { buildMockWorkspaceDetails } from '~/shared/mock/mockBuilder';
+
+jest.mock('~/app/hooks/useNotebookAPI', () => ({
+  useNotebookAPI: jest.fn(),
+}));
+
+const mockUseNotebookAPI = useNotebookAPI as jest.MockedFunction<typeof useNotebookAPI>;
+
+describe('useWorkspaceDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns error when API unavailable', async () => {
+    mockUseNotebookAPI.mockReturnValue({
+      api: {} as NotebookApis,
+      apiAvailable: false,
+      refreshAllAPI: jest.fn(),
+    });
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useWorkspaceDetails('test-ns', 'test-workspace'),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toBeNull();
+    expect(loaded).toBe(false);
+    expect(error).toBeDefined();
+  });
+
+  it('stays in initial state when namespace is undefined', () => {
+    mockUseNotebookAPI.mockReturnValue({
+      api: {} as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+    const { result } = renderHook(() => useWorkspaceDetails(undefined, 'test-workspace'));
+
+    const [data, loaded, error] = result.current;
+    expect(data).toBeNull();
+    expect(loaded).toBe(false);
+    expect(error).toBeUndefined();
+  });
+
+  it('stays in initial state when name is undefined', () => {
+    mockUseNotebookAPI.mockReturnValue({
+      api: {} as NotebookApis,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+    const { result } = renderHook(() => useWorkspaceDetails('test-ns', undefined));
+
+    const [data, loaded, error] = result.current;
+    expect(data).toBeNull();
+    expect(loaded).toBe(false);
+    expect(error).toBeUndefined();
+  });
+
+  it('fetches workspace details successfully', async () => {
+    const mockDetails = buildMockWorkspaceDetails();
+    const getWorkspacePodTemplateDetails = jest.fn().mockResolvedValue({ data: mockDetails });
+    const api = {
+      workspaces: { getWorkspacePodTemplateDetails },
+    } as unknown as NotebookApis;
+
+    mockUseNotebookAPI.mockReturnValue({
+      api,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useWorkspaceDetails('test-ns', 'test-workspace'),
+    );
+    await waitForNextUpdate();
+
+    const [data, loaded, error] = result.current;
+    expect(data).toEqual(mockDetails);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+    expect(getWorkspacePodTemplateDetails).toHaveBeenCalledWith('test-ns', 'test-workspace');
+  });
+});

--- a/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
@@ -99,9 +99,10 @@ describe('useWorkspaceFormData', () => {
     await waitForNextUpdate();
 
     const workspaceFormData = result.current[0];
-    const expectedHomeVolume = mockWorkspace.podTemplate.volumes.home
+    const { podTemplate } = mockWorkspaceUpdate;
+    const expectedHomeVolume = podTemplate.volumes.home
       ? {
-          pvcName: mockWorkspaceUpdate.podTemplate.volumes.home,
+          pvcName: podTemplate.volumes.home,
           mountPath: '',
           readOnly: false,
           isAttached: true,
@@ -109,15 +110,15 @@ describe('useWorkspaceFormData', () => {
       : undefined;
     expect(workspaceFormData).toEqual({
       kind: mockWorkspaceKind,
-      imageConfig: mockWorkspace.podTemplate.options.imageConfig.current.id,
-      podConfig: mockWorkspace.podTemplate.options.podConfig.current.id,
+      imageConfig: podTemplate.options.imageConfig,
+      podConfig: podTemplate.options.podConfig,
       properties: {
         workspaceName: mockWorkspace.name,
-        volumes: (mockWorkspace.podTemplate.volumes.data ?? []).map((v) => ({
+        volumes: podTemplate.volumes.data.map((v) => ({
           ...v,
           isAttached: true,
         })),
-        secrets: (mockWorkspace.podTemplate.volumes.secrets ?? []).map((s) => ({
+        secrets: (podTemplate.volumes.secrets ?? []).map((s) => ({
           ...s,
           isAttached: true,
         })),

--- a/workspaces/frontend/src/app/hooks/useWorkspaceDetails.ts
+++ b/workspaces/frontend/src/app/hooks/useWorkspaceDetails.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { FetchState, FetchStateCallbackPromise, useFetchState, NotReadyError } from 'mod-arch-core';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import { DetailsWorkspaceDetails } from '~/generated/data-contracts';
+
+export const useWorkspaceDetails = (
+  namespace: string | undefined,
+  name: string | undefined,
+): FetchState<DetailsWorkspaceDetails | null> => {
+  const { api, apiAvailable } = useNotebookAPI();
+
+  const call = useCallback<FetchStateCallbackPromise<DetailsWorkspaceDetails | null>>(async () => {
+    if (!apiAvailable) {
+      return Promise.reject(new Error('API not yet available'));
+    }
+    if (!namespace || !name) {
+      return Promise.reject(new NotReadyError('Workspace not yet selected'));
+    }
+    const response = await api.workspaces.getWorkspacePodTemplateDetails(namespace, name);
+    return response.data;
+  }, [api.workspaces, apiAvailable, namespace, name]);
+
+  return useFetchState(call, null);
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetails.tsx
@@ -20,6 +20,7 @@ import { WorkspaceDetailsActivity } from '~/app/pages/Workspaces/Details/Workspa
 import { WorkspaceDetailsPodTemplate } from '~/app/pages/Workspaces/Details/WorkspaceDetailsPodTemplate';
 import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
 import { WorkspaceResources } from '~/app/pages/Workspaces/WorkspaceResources';
+import { useWorkspaceDetails } from '~/app/hooks/useWorkspaceDetails';
 
 type WorkspaceDetailsProps = {
   workspace: WorkspacesWorkspaceListItem;
@@ -34,6 +35,10 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
   onEditClick,
   onDeleteClick,
 }) => {
+  const [details, detailsLoaded, detailsError] = useWorkspaceDetails(
+    workspace.namespace,
+    workspace.name,
+  );
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
 
   const handleTabClick = (
@@ -107,7 +112,12 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
           hidden={activeTabKey !== 0}
         >
           <TabContentBody hasPadding>
-            <WorkspaceDetailsOverview workspace={workspace} />
+            <WorkspaceDetailsOverview
+              workspace={workspace}
+              details={details}
+              detailsLoaded={detailsLoaded}
+              detailsError={detailsError}
+            />
           </TabContentBody>
         </TabContent>
 
@@ -132,7 +142,12 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
           hidden={activeTabKey !== 2}
         >
           <TabContentBody hasPadding>
-            <WorkspaceResources workspace={workspace} />
+            <WorkspaceResources
+              workspace={workspace}
+              details={details}
+              detailsLoaded={detailsLoaded}
+              detailsError={detailsError}
+            />
           </TabContentBody>
         </TabContent>
         <TabContent

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
@@ -8,6 +8,7 @@ import {
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { hasWorkspacePendingUpdate } from '~/shared/utilities/WorkspaceUtils';
 
 const DATE_FORMAT = 'PPpp';
 
@@ -19,9 +20,7 @@ export const WorkspaceDetailsActivity: React.FunctionComponent<WorkspaceDetailsA
   workspace,
 }) => {
   const { activity, pausedTime } = workspace;
-  const pendingRestart =
-    (workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
-    (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0;
+  const pendingRestart = hasWorkspacePendingUpdate(workspace);
 
   return (
     <DescriptionList isHorizontal>

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
@@ -18,7 +18,10 @@ type WorkspaceDetailsActivityProps = {
 export const WorkspaceDetailsActivity: React.FunctionComponent<WorkspaceDetailsActivityProps> = ({
   workspace,
 }) => {
-  const { activity, pausedTime, pendingRestart } = workspace;
+  const { activity, pausedTime } = workspace;
+  const pendingRestart =
+    (workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
+    (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0;
 
   return (
     <DescriptionList isHorizontal>

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
@@ -7,15 +7,23 @@ import {
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { Label, LabelGroup } from '@patternfly/react-core/dist/esm/components/Label';
-import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
+import { Content } from '@patternfly/react-core/dist/esm/components/Content';
+import { DetailsWorkspaceDetails, WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
 import { WorkspacePackageDetails } from '~/app/pages/Workspaces/WorkspacePackageDetails';
 
 type WorkspaceDetailsOverviewProps = {
   workspace: WorkspacesWorkspaceListItem;
+  details: DetailsWorkspaceDetails | null;
+  detailsLoaded: boolean;
+  detailsError?: Error;
 };
 
 export const WorkspaceDetailsOverview: React.FunctionComponent<WorkspaceDetailsOverviewProps> = ({
   workspace,
+  details,
+  detailsLoaded,
+  detailsError,
 }) => (
   <DescriptionList isHorizontal>
     <DescriptionListGroup>
@@ -31,13 +39,19 @@ export const WorkspaceDetailsOverview: React.FunctionComponent<WorkspaceDetailsO
     <DescriptionListGroup>
       <DescriptionListTerm>Labels</DescriptionListTerm>
       <DescriptionListDescription>
-        <LabelGroup>
-          {Object.entries(workspace.podTemplate.podMetadata.labels).map(([key, value]) => (
-            <Label key={key} isCompact>
-              {key}={value}
-            </Label>
-          ))}
-        </LabelGroup>
+        {detailsError ? (
+          <Content component="small">Failed to load details</Content>
+        ) : detailsLoaded ? (
+          <LabelGroup>
+            {Object.entries(details?.podMetadata.labels ?? {}).map(([key, value]) => (
+              <Label key={key} isCompact>
+                {key}={value}
+              </Label>
+            ))}
+          </LabelGroup>
+        ) : (
+          <Spinner size="md" />
+        )}
       </DescriptionListDescription>
     </DescriptionListGroup>
     <Divider />

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsOverview.tsx
@@ -7,9 +7,8 @@ import {
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { Label, LabelGroup } from '@patternfly/react-core/dist/esm/components/Label';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { DetailsWorkspaceDetails, WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { DetailsLoadingState } from '~/app/components/DetailsLoadingState';
 import { WorkspacePackageDetails } from '~/app/pages/Workspaces/WorkspacePackageDetails';
 
 type WorkspaceDetailsOverviewProps = {
@@ -39,9 +38,7 @@ export const WorkspaceDetailsOverview: React.FunctionComponent<WorkspaceDetailsO
     <DescriptionListGroup>
       <DescriptionListTerm>Labels</DescriptionListTerm>
       <DescriptionListDescription>
-        {detailsError ? (
-          <Content component="small">Failed to load details</Content>
-        ) : detailsLoaded ? (
+        <DetailsLoadingState error={detailsError} loaded={detailsLoaded}>
           <LabelGroup>
             {Object.entries(details?.podMetadata.labels ?? {}).map(([key, value]) => (
               <Label key={key} isCompact>
@@ -49,9 +46,7 @@ export const WorkspaceDetailsOverview: React.FunctionComponent<WorkspaceDetailsO
               </Label>
             ))}
           </LabelGroup>
-        ) : (
-          <Spinner size="md" />
-        )}
+        </DetailsLoadingState>
       </DescriptionListDescription>
     </DescriptionListGroup>
     <Divider />

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceResources.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceResources.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionListDescription,
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 import { DatabaseIcon } from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import { LockedIcon } from '@patternfly/react-icons/dist/esm/icons/locked-icon';
 import {
@@ -16,28 +17,31 @@ import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { formatResourceFromWorkspace } from '~/shared/utilities/WorkspaceUtils';
-import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { DetailsWorkspaceDetails, WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
 
 interface WorkspaceResourcesProps {
   workspace: WorkspacesWorkspaceListItem;
+  details: DetailsWorkspaceDetails | null;
+  detailsLoaded: boolean;
+  detailsError?: Error;
 }
 
-export const WorkspaceResources: React.FC<WorkspaceResourcesProps> = ({ workspace }) => {
-  const workspaceDataVol = workspace.podTemplate.volumes.data ?? [];
-
-  const singleDataVolRenderer = (
-    data: {
-      pvcName: string;
-      mountPath: string;
-      readOnly: boolean;
-    },
-    index: number,
-  ) => (
+export const WorkspaceResources: React.FC<WorkspaceResourcesProps> = ({
+  workspace,
+  details,
+  detailsLoaded,
+  detailsError,
+}) => {
+  const singleDataVolRenderer = (data: {
+    pvcName: string;
+    mountPath: string;
+    readOnly: boolean;
+  }) => (
     <Flex
       gap={{ default: 'gapSm' }}
       alignItems={{ default: 'alignItemsFlexStart' }}
       flexWrap={{ default: 'nowrap' }}
-      key={index}
+      key={data.pvcName}
     >
       <FlexItem>
         <DatabaseIcon />
@@ -82,7 +86,13 @@ export const WorkspaceResources: React.FC<WorkspaceResourcesProps> = ({ workspac
       <DescriptionListGroup>
         <DescriptionListTerm>Home volume</DescriptionListTerm>
         <DescriptionListDescription>
-          {workspace.podTemplate.volumes.home?.pvcName ?? 'None'}
+          {detailsError ? (
+            <Content component="small">Failed to load details</Content>
+          ) : detailsLoaded ? (
+            (details?.volumes.home.pvcName ?? 'None')
+          ) : (
+            <Spinner size="md" />
+          )}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />
@@ -91,9 +101,15 @@ export const WorkspaceResources: React.FC<WorkspaceResourcesProps> = ({ workspac
           Cluster storage
         </DescriptionListTerm>
         <DescriptionListDescription>
-          <Flex direction={{ default: 'column' }}>
-            {workspaceDataVol.map((data, index) => singleDataVolRenderer(data, index))}
-          </Flex>
+          {detailsError ? (
+            <Content component="small">Failed to load details</Content>
+          ) : detailsLoaded ? (
+            <Flex direction={{ default: 'column' }}>
+              {(details?.volumes.data ?? []).map((data) => singleDataVolRenderer(data))}
+            </Flex>
+          ) : (
+            <Spinner size="md" />
+          )}
         </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceResources.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceResources.tsx
@@ -6,7 +6,6 @@ import {
   DescriptionListDescription,
 } from '@patternfly/react-core/dist/esm/components/DescriptionList';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 import { DatabaseIcon } from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import { LockedIcon } from '@patternfly/react-icons/dist/esm/icons/locked-icon';
 import {
@@ -16,6 +15,7 @@ import {
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { DetailsLoadingState } from '~/app/components/DetailsLoadingState';
 import { formatResourceFromWorkspace } from '~/shared/utilities/WorkspaceUtils';
 import { DetailsWorkspaceDetails, WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
 
@@ -86,13 +86,9 @@ export const WorkspaceResources: React.FC<WorkspaceResourcesProps> = ({
       <DescriptionListGroup>
         <DescriptionListTerm>Home volume</DescriptionListTerm>
         <DescriptionListDescription>
-          {detailsError ? (
-            <Content component="small">Failed to load details</Content>
-          ) : detailsLoaded ? (
-            (details?.volumes.home.pvcName ?? 'None')
-          ) : (
-            <Spinner size="md" />
-          )}
+          <DetailsLoadingState error={detailsError} loaded={detailsLoaded}>
+            {details?.volumes.home.pvcName ?? 'None'}
+          </DetailsLoadingState>
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />
@@ -101,15 +97,11 @@ export const WorkspaceResources: React.FC<WorkspaceResourcesProps> = ({
           Cluster storage
         </DescriptionListTerm>
         <DescriptionListDescription>
-          {detailsError ? (
-            <Content component="small">Failed to load details</Content>
-          ) : detailsLoaded ? (
+          <DetailsLoadingState error={detailsError} loaded={detailsLoaded}>
             <Flex direction={{ default: 'column' }}>
               {(details?.volumes.data ?? []).map((data) => singleDataVolRenderer(data))}
             </Flex>
-          ) : (
-            <Spinner size="md" />
-          )}
+          </DetailsLoadingState>
         </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -43,7 +43,7 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
 }) => {
   const notification = useNotification();
   const workspacePendingUpdate =
-    workspace?.pendingRestart &&
+    !!workspace &&
     ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
       (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
   const [actionOnGoing, setActionOnGoing] = useState<StartAction | null>(null);

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStartActionModal.tsx
@@ -21,6 +21,7 @@ import {
   ApiWorkspaceActionPauseEnvelope,
   WorkspacesWorkspaceListItem,
 } from '~/generated/data-contracts';
+import { hasWorkspacePendingUpdate } from '~/shared/utilities/WorkspaceUtils';
 
 interface StartActionAlertProps {
   onClose: () => void;
@@ -42,10 +43,7 @@ export const WorkspaceStartActionModal: React.FC<StartActionAlertProps> = ({
   onActionDone,
 }) => {
   const notification = useNotification();
-  const workspacePendingUpdate =
-    !!workspace &&
-    ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
-      (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
+  const workspacePendingUpdate = hasWorkspacePendingUpdate(workspace);
   const [actionOnGoing, setActionOnGoing] = useState<StartAction | null>(null);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
 

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -21,6 +21,7 @@ import {
   ApiWorkspaceActionPauseEnvelope,
   WorkspacesWorkspaceListItem,
 } from '~/generated/data-contracts';
+import { hasWorkspacePendingUpdate } from '~/shared/utilities/WorkspaceUtils';
 
 interface StopActionAlertProps {
   onClose: () => void;
@@ -42,10 +43,7 @@ export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
   onActionDone,
 }) => {
   const notification = useNotification();
-  const workspacePendingUpdate =
-    !!workspace &&
-    ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
-      (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
+  const workspacePendingUpdate = hasWorkspacePendingUpdate(workspace);
   const [actionOnGoing, setActionOnGoing] = useState<StopAction | null>(null);
   const [error, setError] = useState<string | ApiErrorEnvelope | null>(null);
 
@@ -119,7 +117,7 @@ export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
             </StackItem>
           )}
           <StackItem>
-            {workspacePendingUpdate ? (
+            {workspace && workspacePendingUpdate ? (
               <>
                 <WorkspaceRedirectInformationViewTitle />
                 <WorkspaceRedirectInformationView

--- a/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/workspaceActions/WorkspaceStopActionModal.tsx
@@ -43,7 +43,7 @@ export const WorkspaceStopActionModal: React.FC<StopActionAlertProps> = ({
 }) => {
   const notification = useNotification();
   const workspacePendingUpdate =
-    workspace?.pendingRestart &&
+    !!workspace &&
     ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
       (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
   const [actionOnGoing, setActionOnGoing] = useState<StopAction | null>(null);

--- a/workspaces/frontend/src/shared/mock/mockBuilder.ts
+++ b/workspaces/frontend/src/shared/mock/mockBuilder.ts
@@ -871,11 +871,19 @@ export const buildMockPodMetadataMutate = (
 export const buildMockPodVolumesMutate = (
   podVolumesMutate?: Partial<WorkspacesPodVolumesMutate>,
 ): WorkspacesPodVolumesMutate => ({
+  home: '/home',
   data: [
     {
       pvcName: 'Volume-Data1',
       mountPath: '/data',
       readOnly: true,
+    },
+  ],
+  secrets: [
+    {
+      defaultMode: 0o644,
+      mountPath: '/secrets',
+      secretName: 'secret-1',
     },
   ],
   ...podVolumesMutate,
@@ -921,27 +929,8 @@ export const buildMockWorkspaceUpdateFromWorkspace = (args: {
       imageConfig: args.workspace?.podTemplate?.options.imageConfig.current.id ?? '',
       podConfig: args.workspace?.podTemplate?.options.podConfig.current.id ?? '',
     }),
-    podMetadata: buildMockPodMetadataMutate(
-      args.podMetadata ?? {
-        labels: args.workspace?.podTemplate?.podMetadata.labels,
-        annotations: args.workspace?.podTemplate?.podMetadata.annotations,
-      },
-    ),
-    volumes: buildMockPodVolumesMutate(
-      args.volumes ?? {
-        home: args.workspace?.podTemplate?.volumes.home?.mountPath ?? '',
-        data: args.workspace?.podTemplate?.volumes.data?.map((d) => ({
-          pvcName: d.pvcName,
-          mountPath: d.mountPath,
-          readOnly: d.readOnly,
-        })),
-        secrets: args.workspace?.podTemplate?.volumes.secrets?.map((s) => ({
-          defaultMode: s.defaultMode,
-          mountPath: s.mountPath,
-          secretName: s.secretName,
-        })),
-      },
-    ),
+    podMetadata: buildMockPodMetadataMutate(args.podMetadata),
+    volumes: buildMockPodVolumesMutate(args.volumes),
   }),
   revision: args.workspaceUpdate?.revision ?? '1234567890',
   ...args.workspaceUpdate,

--- a/workspaces/frontend/src/shared/mock/mockBuilder.ts
+++ b/workspaces/frontend/src/shared/mock/mockBuilder.ts
@@ -1,5 +1,6 @@
 import {
   ActionsWorkspaceActionPause,
+  DetailsWorkspaceDetails,
   HealthCheckHealthCheck,
   HealthCheckServiceStatus,
   NamespacesNamespace,
@@ -911,6 +912,8 @@ export const buildMockWorkspaceUpdate = (
 export const buildMockWorkspaceUpdateFromWorkspace = (args: {
   workspace?: Partial<WorkspacesWorkspaceListItem>;
   workspaceUpdate?: Partial<WorkspacesWorkspaceUpdate>;
+  podMetadata?: Partial<WorkspacesPodMetadataMutate>;
+  volumes?: Partial<WorkspacesPodVolumesMutate>;
 }): WorkspacesWorkspaceUpdate => ({
   paused: args.workspace?.paused ?? false,
   podTemplate: buildMockPodTemplateMutate({
@@ -918,23 +921,27 @@ export const buildMockWorkspaceUpdateFromWorkspace = (args: {
       imageConfig: args.workspace?.podTemplate?.options.imageConfig.current.id ?? '',
       podConfig: args.workspace?.podTemplate?.options.podConfig.current.id ?? '',
     }),
-    podMetadata: buildMockPodMetadataMutate({
-      labels: args.workspace?.podTemplate?.podMetadata.labels,
-      annotations: args.workspace?.podTemplate?.podMetadata.annotations,
-    }),
-    volumes: buildMockPodVolumesMutate({
-      home: args.workspace?.podTemplate?.volumes.home?.mountPath ?? '',
-      data: args.workspace?.podTemplate?.volumes.data?.map((d) => ({
-        pvcName: d.pvcName,
-        mountPath: d.mountPath,
-        readOnly: d.readOnly,
-      })),
-      secrets: args.workspace?.podTemplate?.volumes.secrets?.map((s) => ({
-        defaultMode: s.defaultMode,
-        mountPath: s.mountPath,
-        secretName: s.secretName,
-      })),
-    }),
+    podMetadata: buildMockPodMetadataMutate(
+      args.podMetadata ?? {
+        labels: args.workspace?.podTemplate?.podMetadata.labels,
+        annotations: args.workspace?.podTemplate?.podMetadata.annotations,
+      },
+    ),
+    volumes: buildMockPodVolumesMutate(
+      args.volumes ?? {
+        home: args.workspace?.podTemplate?.volumes.home?.mountPath ?? '',
+        data: args.workspace?.podTemplate?.volumes.data?.map((d) => ({
+          pvcName: d.pvcName,
+          mountPath: d.mountPath,
+          readOnly: d.readOnly,
+        })),
+        secrets: args.workspace?.podTemplate?.volumes.secrets?.map((s) => ({
+          defaultMode: s.defaultMode,
+          mountPath: s.mountPath,
+          secretName: s.secretName,
+        })),
+      },
+    ),
   }),
   revision: args.workspaceUpdate?.revision ?? '1234567890',
   ...args.workspaceUpdate,
@@ -996,4 +1003,19 @@ export const buildMockPVCCreate = (pvc?: Partial<PvcsPVCCreate>): PvcsPVCCreate 
   requests: { storage: '10Gi' },
   storageClassName: 'standard',
   ...pvc,
+});
+
+export const buildMockWorkspaceDetails = (
+  details?: Partial<DetailsWorkspaceDetails>,
+): DetailsWorkspaceDetails => ({
+  podMetadata: {
+    labels: { labelKey1: 'labelValue1', labelKey2: 'labelValue2' },
+    annotations: { annotationKey1: 'annotationValue1', annotationKey2: 'annotationValue2' },
+  },
+  volumes: {
+    home: { pvcName: 'Volume-Home', mountPath: '/home', readOnly: false },
+    data: [{ pvcName: 'Volume-Data1', mountPath: '/data', readOnly: true }],
+    secrets: [{ defaultMode: 0o644, mountPath: '/secrets', secretName: 'secret-1' }],
+  },
+  ...details,
 });

--- a/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
@@ -18,7 +18,11 @@ import {
   mockWorkspaceUpdate,
 } from '~/shared/mock/mockNotebookServiceData';
 import { buildAxiosError, isInvalidWorkspace, isInvalidYaml } from '~/shared/mock/mockUtils';
-import { buildMockWorkspaceKindUpdate, buildMockWorkspaceUpdateFromWorkspace } from './mockBuilder';
+import {
+  buildMockWorkspaceDetails,
+  buildMockWorkspaceKindUpdate,
+  buildMockWorkspaceUpdateFromWorkspace,
+} from './mockBuilder';
 
 const delay = (ms: number) =>
   new Promise((resolve) => {
@@ -70,12 +74,23 @@ export const mockNotebookApisImpl = (): NotebookApis => ({
     deleteWorkspace: async () => {
       await delay(1500);
     },
-    getWorkspacePodTemplateDetails: async () => ({
-      data: {
-        podMetadata: { labels: {}, annotations: {} },
-        volumes: { home: { pvcName: 'home-pvc', mountPath: '/home/jovyan', readOnly: false } },
-      },
-    }),
+    getWorkspacePodTemplateDetails: async (_namespace, workspaceName) => {
+      const workspace = mockAllWorkspaces.find((w) => w.name === workspaceName);
+      return {
+        data: buildMockWorkspaceDetails({
+          podMetadata: workspace?.podTemplate.podMetadata ?? { labels: {}, annotations: {} },
+          volumes: {
+            home: workspace?.podTemplate.volumes.home ?? {
+              pvcName: 'home-pvc',
+              mountPath: '/home/jovyan',
+              readOnly: false,
+            },
+            data: workspace?.podTemplate.volumes.data,
+            secrets: workspace?.podTemplate.volumes.secrets,
+          },
+        }),
+      };
+    },
     updateWorkspacePauseState: async (_namespace, _workspaceName, body) => {
       await delay(1500);
       return {

--- a/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookApis.ts
@@ -74,23 +74,9 @@ export const mockNotebookApisImpl = (): NotebookApis => ({
     deleteWorkspace: async () => {
       await delay(1500);
     },
-    getWorkspacePodTemplateDetails: async (_namespace, workspaceName) => {
-      const workspace = mockAllWorkspaces.find((w) => w.name === workspaceName);
-      return {
-        data: buildMockWorkspaceDetails({
-          podMetadata: workspace?.podTemplate.podMetadata ?? { labels: {}, annotations: {} },
-          volumes: {
-            home: workspace?.podTemplate.volumes.home ?? {
-              pvcName: 'home-pvc',
-              mountPath: '/home/jovyan',
-              readOnly: false,
-            },
-            data: workspace?.podTemplate.volumes.data,
-            secrets: workspace?.podTemplate.volumes.secrets,
-          },
-        }),
-      };
-    },
+    getWorkspacePodTemplateDetails: async () => ({
+      data: buildMockWorkspaceDetails(),
+    }),
     updateWorkspacePauseState: async (_namespace, _workspaceName, body) => {
       await delay(1500);
       return {

--- a/workspaces/frontend/src/shared/utilities/WorkspaceUtils.ts
+++ b/workspaces/frontend/src/shared/utilities/WorkspaceUtils.ts
@@ -134,6 +134,13 @@ export const countGpusFromWorkspaces = (workspaces: WorkspacesWorkspaceListItem[
     return total + (gpuValue ?? 0);
   }, 0);
 
+export const hasWorkspacePendingUpdate = (
+  workspace: WorkspacesWorkspaceListItem | null | undefined,
+): boolean =>
+  !!workspace &&
+  ((workspace.podTemplate.options.podConfig.redirectChain ?? []).length > 0 ||
+    (workspace.podTemplate.options.imageConfig.redirectChain ?? []).length > 0);
+
 // For now, label keys will be showed as they are in the backend.
 export const formatLabelKey = (key: string): string => key;
 


### PR DESCRIPTION
Migrate the workspace details drawer to fetch volumes, labels, and annotations from the dedicated GET /workspaces/{ns}/{name}/podtemplate/details endpoint (PR #1119) instead of reading them from the list-item payload. This prepares the frontend for PR #1253, which removes pendingRestart, podTemplate.podMetadata, and podTemplate.volumes from the list response.

New hook — useWorkspaceDetails:
- Follows the established useFetchState pattern (useCallback → useFetchState)
- Fetches DetailsWorkspaceDetails on-demand when a workspace is selected
- Returns [data, loaded, error, refresh] matching the standard tuple

Overview tab — labels from details endpoint:
- WorkspaceDetailsOverview now receives details/detailsLoaded props
- Labels read from details?.podMetadata.labels instead of the list item
- Shows a Spinner while the details request is in-flight

Resources tab — volumes from details endpoint:
- WorkspaceResources now receives details/detailsLoaded props
- Home volume and data volumes read from details?.volumes instead of the list item, with Spinner placeholders during loading

Activity tab — pendingRestart computed from redirect chains:
- Removes direct use of workspace.pendingRestart (will be dropped by #1253)
- Derives the same boolean from redirectChain length on podConfig and imageConfig, which is semantically equivalent

Start/Stop modals — drop pendingRestart guard:
- workspacePendingUpdate condition simplified from `workspace?.pendingRestart && (redirectChain checks)` to `!!workspace && (redirectChain checks)`
- The !!workspace guard provides explicit null narrowing for TypeScript

Mock builders — backward-compatible refactoring:
- buildMockWorkspaceUpdateFromWorkspace accepts optional podMetadata and volumes args, falling back to list-item fields when not provided, so existing callers are unaffected
- New buildMockWorkspaceDetails builder for the details endpoint response
- mockNotebookApis details mock derives data from the workspace list item for consistency with other mock endpoints

Cypress tests — details endpoint intercepts:
- Add interceptApi type overload for the podtemplate/details route
- Add details endpoint intercepts in setupWorkspaceActionTest and the multi-workspace drawer switching test to prevent unhandled requests

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->