### PR TITLE
chore: prepare frontend for npm v12's stricter install-script defaults

### DIFF
--- a/.github/workflows/ws-frontend-test.yml
+++ b/.github/workflows/ws-frontend-test.yml
@@ -32,6 +32,10 @@ jobs:
           node-version-file: workspaces/frontend/package.json
           cache-dependency-path: workspaces/frontend/package-lock.json
 
+      - name: Pin npm version
+        working-directory: workspaces/frontend
+        run: npm install -g npm@"$(node -p "require('./package.json').engines.npm")"
+
       - name: Install dependencies
         working-directory: workspaces/frontend
         run: npm ci

--- a/workspaces/frontend/Dockerfile
+++ b/workspaces/frontend/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install the dependencies and build
-RUN npm cache clean --force \
+RUN npm install -g npm@"$(node -p "require('./package.json').engines.npm")" \
+  && npm cache clean --force \
   && npm ci
 
 # Copy source code

--- a/workspaces/frontend/Dockerfile.dev
+++ b/workspaces/frontend/Dockerfile.dev
@@ -9,6 +9,12 @@
 
 FROM node:24-slim
 
+# Pin npm to the version declared in package.json's `engines.npm`, as root, before
+# dropping to the non-root user below (global npm dirs aren't writable by uid 1000).
+COPY package.json /tmp/package.json
+RUN npm install -g npm@"$(node -p "require('/tmp/package.json').engines.npm")" \
+  && rm /tmp/package.json
+
 # Create app directory with correct ownership, then switch to non-root user
 RUN mkdir /app && chown 1000:1000 /app
 USER 1000:1000

--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -105,7 +105,7 @@
       },
       "engines": {
         "node": "^24",
-        "npm": "^11.10.0"
+        "npm": "^11.16.0"
       },
       "optionalDependencies": {
         "@babel/preset-env": "^7.26.9",

--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -104,7 +104,7 @@
       },
       "engines": {
         "node": "^24",
-        "npm": "^11.10.0"
+        "npm": "^11.16.0"
       },
       "optionalDependencies": {
         "@babel/preset-env": "^7.26.9",

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -16,7 +16,7 @@
     }
   },
   "engines": {
-    "npm": "^11.10.0",
+    "npm": "^11.16.0",
     "node": "^24"
   },
   "scripts": {
@@ -188,5 +188,14 @@
     "nyc": "^17.1.0",
     "serve": "^14.2.4",
     "ts-jest": "^29.4.9"
+  },
+  "allowScripts": {
+    "@swc/core@1.13.3": true,
+    "cypress@14.5.4": true,
+    "unrs-resolver@1.11.1": true,
+    "@parcel/watcher": false,
+    "core-js": false,
+    "core-js-pure": false,
+    "esbuild": false
   }
 }

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -16,7 +16,7 @@
     }
   },
   "engines": {
-    "npm": "^11.10.0",
+    "npm": "^11.16.0",
     "node": "^24"
   },
   "scripts": {
@@ -189,5 +189,14 @@
     "nyc": "^17.1.0",
     "serve": "^14.2.4",
     "ts-jest": "^29.4.9"
+  },
+  "allowScripts": {
+    "@swc/core": true,
+    "cypress": true,
+    "unrs-resolver": true,
+    "@parcel/watcher": false,
+    "core-js": false,
+    "core-js-pure": false,
+    "esbuild": false
   }
 }


### PR DESCRIPTION
npm v12 blocks preinstall/install/postinstall scripts from dependencies unless explicitly approved via `npm approve-scripts`.

Therefore we add a version-pinned `allowScripts` allowlist for the packages that genuinely need their install scripts, and explicitly deny the rest after verifying via clean install + full test/build suite that their scripts can be omitted here.

Also raise `engines.npm` to `^11.16.0`, the version where `allowScripts` support landed, and pin CI/Docker to that version explicitly since neither `actions/setup-node` nor the `node:24-slim` base image otherwise enforce it.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
