### PR TITLE
chore: upgrade Go to 1.26.5 in backend and controller

### DIFF
--- a/workspaces/backend/Dockerfile
+++ b/workspaces/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use the golang image to build the application
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/workspaces/backend/api/pvcs_handler_test.go
+++ b/workspaces/backend/api/pvcs_handler_test.go
@@ -624,7 +624,7 @@ var _ = Describe("PVCs Handler", func() {
 					Namespace: namespaceName1,
 				},
 				Spec: kubefloworgv1beta1.WorkspaceSpec{
-					Paused: ptr.To(false),
+					Paused: new(false),
 					Kind:   workspaceKindName1,
 					PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{
 						Volumes: kubefloworgv1beta1.WorkspacePodVolumes{

--- a/workspaces/backend/api/secrets_handler_test.go
+++ b/workspaces/backend/api/secrets_handler_test.go
@@ -32,7 +32,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	commonModels "github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
@@ -388,11 +387,11 @@ var _ = Describe("Secrets Handler", func() {
 					Namespace: namespaceName1,
 				},
 				Spec: kubefloworgv1beta1.WorkspaceSpec{
-					Paused: ptr.To(false),
+					Paused: new(false),
 					Kind:   workspaceKindName1,
 					PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{
 						Volumes: kubefloworgv1beta1.WorkspacePodVolumes{
-							Home: ptr.To("my-home-pvc"),
+							Home: new("my-home-pvc"),
 							Secrets: []kubefloworgv1beta1.PodSecretMount{
 								{
 									SecretName: secretName1,
@@ -556,8 +555,8 @@ var _ = Describe("Secrets Handler", func() {
 				Name: secretCreateName,
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"username": {Base64: ptr.To("dGVzdHVzZXI=")},
-					"password": {Base64: ptr.To("dGVzdHBhc3M=")},
+					"username": {Base64: new("dGVzdHVzZXI=")},
+					"password": {Base64: new("dGVzdHBhc3M=")},
 				},
 			}
 			bodyEnvelope := SecretCreateEnvelope{Data: &secretCreate}
@@ -626,7 +625,7 @@ var _ = Describe("Secrets Handler", func() {
 				Name: secretCreateName,
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"key": {Base64: ptr.To("dmFsdWU=")},
+					"key": {Base64: new("dmFsdWU=")},
 				},
 			}
 			bodyEnvelope := SecretCreateEnvelope{Data: &secretCreate}
@@ -658,7 +657,7 @@ var _ = Describe("Secrets Handler", func() {
 			secretCreate := models.SecretCreate{
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"key": {Base64: ptr.To("dmFsdWU=")},
+					"key": {Base64: new("dmFsdWU=")},
 				},
 			}
 			bodyEnvelope := SecretCreateEnvelope{Data: &secretCreate}
@@ -715,7 +714,7 @@ var _ = Describe("Secrets Handler", func() {
 				Name: "test-invalid-base64",
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"key": {Base64: ptr.To("not-valid-base64!!!")},
+					"key": {Base64: new("not-valid-base64!!!")},
 				},
 			}
 			bodyEnvelope := SecretCreateEnvelope{Data: &secretCreate}
@@ -851,9 +850,9 @@ var _ = Describe("Secrets Handler", func() {
 					// "username": preserve existing value (Base64 is nil)
 					"username": {},
 					// "password": update with new value
-					"password": {Base64: ptr.To("bmV3cGFzcw==")},
+					"password": {Base64: new("bmV3cGFzcw==")},
 					// "newkey": add new key
-					"newkey": {Base64: ptr.To("bmV3a2V5dmFsdWU=")},
+					"newkey": {Base64: new("bmV3a2V5dmFsdWU=")},
 					// "host": omitted from request, should be deleted
 				},
 			}
@@ -922,7 +921,7 @@ var _ = Describe("Secrets Handler", func() {
 			updateReq := models.SecretUpdate{
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"key": {Base64: ptr.To("dmFsdWU=")},
+					"key": {Base64: new("dmFsdWU=")},
 				},
 			}
 			bodyEnvelope := SecretEnvelope{Data: &updateReq}
@@ -956,7 +955,7 @@ var _ = Describe("Secrets Handler", func() {
 			updateReq := models.SecretUpdate{
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"key": {Base64: ptr.To("not-valid-base64!!!")},
+					"key": {Base64: new("not-valid-base64!!!")},
 				},
 			}
 			bodyEnvelope := SecretEnvelope{Data: &updateReq}
@@ -990,7 +989,7 @@ var _ = Describe("Secrets Handler", func() {
 			updateReq := models.SecretUpdate{
 				Type: corev1.SecretTypeOpaque,
 				Contents: models.SecretData{
-					"key": {Base64: ptr.To("dmFsdWU=")},
+					"key": {Base64: new("dmFsdWU=")},
 				},
 			}
 			bodyEnvelope := SecretEnvelope{Data: &updateReq}

--- a/workspaces/backend/api/suite_test.go
+++ b/workspaces/backend/api/suite_test.go
@@ -34,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -176,8 +175,8 @@ func NewExampleWorkspace(name string, namespace string, workspaceKind string) *k
 			Namespace: namespace,
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
-			Paused:      ptr.To(false),
-			DisplayName: ptr.To("Example Workspace"),
+			Paused:      new(false),
+			DisplayName: new("Example Workspace"),
 			Kind:        workspaceKind,
 			PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspacePodMetadata{
@@ -185,12 +184,12 @@ func NewExampleWorkspace(name string, namespace string, workspaceKind string) *k
 					Annotations: nil,
 				},
 				Volumes: kubefloworgv1beta1.WorkspacePodVolumes{
-					Home: ptr.To("my-home-pvc"),
+					Home: new("my-home-pvc"),
 					Data: []kubefloworgv1beta1.PodVolumeMount{
 						{
 							PVCName:   "my-repositories-pvc",
 							MountPath: "/repositories/my-repositories",
-							ReadOnly:  ptr.To(false),
+							ReadOnly:  new(false),
 						},
 					},
 				},
@@ -213,14 +212,14 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 			Spawner: kubefloworgv1beta1.WorkspaceKindSpawner{
 				DisplayName:        "JupyterLab Notebook",
 				Description:        "A Workspace which runs JupyterLab in a Pod",
-				Hidden:             ptr.To(false),
-				Deprecated:         ptr.To(false),
-				DeprecationMessage: ptr.To("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
+				Hidden:             new(false),
+				Deprecated:         new(false),
+				DeprecationMessage: new("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
 				Icon: kubefloworgv1beta1.WorkspaceKindAsset{
-					Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
+					Url: new("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
 				},
 				Logo: kubefloworgv1beta1.WorkspaceKindAsset{
-					Url: ptr.To("https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg"),
+					Url: new("https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg"),
 				},
 			},
 			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
@@ -229,8 +228,8 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 					Name: "default-editor",
 				},
 				ActivityProbe: &kubefloworgv1beta1.ActivityProbe{
-					MinProbeIntervalSeconds: ptr.To(int32(300)),
-					ProbeIntervalSeconds:    ptr.To(int32(3600)),
+					MinProbeIntervalSeconds: new(int32(300)),
+					ProbeIntervalSeconds:    new(int32(3600)),
 					Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
 						LastActivity: true,
 						PortId:       "jupyterlab",
@@ -246,7 +245,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 						DefaultDisplayName: "JupyterLab",
 						Protocol:           "HTTP",
 						HTTPProxy: &kubefloworgv1beta1.HTTPProxy{
-							RemovePathPrefix: ptr.To(false),
+							RemovePathPrefix: new(false),
 							RequestHeaders: &kubefloworgv1beta1.IstioHeaderOperations{
 								Set:    map[string]string{},
 								Add:    map[string]string{},
@@ -278,14 +277,14 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 					},
 				},
 				SecurityContext: &v1.PodSecurityContext{
-					FSGroup: ptr.To(int64(100)),
+					FSGroup: new(int64(100)),
 				},
 				ContainerSecurityContext: &v1.SecurityContext{
-					AllowPrivilegeEscalation: ptr.To(false),
+					AllowPrivilegeEscalation: new(false),
 					Capabilities: &v1.Capabilities{
 						Drop: []v1.Capability{"ALL"},
 					},
-					RunAsNonRoot: ptr.To(true),
+					RunAsNonRoot: new(true),
 				},
 				Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
 					ImageConfig: kubefloworgv1beta1.ImageConfig{
@@ -298,14 +297,14 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "jupyterlab_scipy_180",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "jupyter-scipy:v1.8.0",
-									Description: ptr.To("JupyterLab, with SciPy Packages"),
+									Description: new("JupyterLab, with SciPy Packages"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "python_version",
 											Value: "3.11",
 										},
 									},
-									Hidden: ptr.To(true),
+									Hidden: new(true),
 								},
 								Redirect: &kubefloworgv1beta1.OptionRedirect{
 									To: "jupyterlab_scipy_190",
@@ -319,7 +318,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 									Ports: []kubefloworgv1beta1.ImagePort{
 										{
 											Id:          "jupyterlab",
-											DisplayName: ptr.To("JupyterLab"),
+											DisplayName: new("JupyterLab"),
 											Port:        8888,
 										},
 									},
@@ -330,7 +329,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "jupyterlab_scipy_190",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "jupyter-scipy:v1.9.0",
-									Description: ptr.To("JupyterLab, with SciPy Packages"),
+									Description: new("JupyterLab, with SciPy Packages"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "python_version",
@@ -360,7 +359,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "tiny_cpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Tiny CPU",
-									Description: ptr.To("Pod with 0.1 CPU, 128 MB RAM"),
+									Description: new("Pod with 0.1 CPU, 128 MB RAM"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -386,7 +385,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "small_cpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Small CPU",
-									Description: ptr.To("Pod with 1 CPU, 2 GB RAM"),
+									Description: new("Pod with 1 CPU, 2 GB RAM"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -412,7 +411,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "big_gpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Big GPU",
-									Description: ptr.To("Pod with 4 CPU, 16 GB RAM, and 1 GPU"),
+									Description: new("Pod with 4 CPU, 16 GB RAM, and 1 GPU"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",

--- a/workspaces/backend/api/workspace_actions_handler_test.go
+++ b/workspaces/backend/api/workspace_actions_handler_test.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/actions"
@@ -151,7 +150,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace)).To(Succeed())
 
 			By("ensuring the workspace is paused")
-			Expect(workspace.Spec.Paused).To(Equal(ptr.To(true)))
+			Expect(workspace.Spec.Paused).To(Equal(new(true)))
 		})
 
 		It("should start a workspace successfully", func() {
@@ -209,7 +208,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace)).To(Succeed())
 
 			By("ensuring the workspace is not paused")
-			Expect(workspace.Spec.Paused).To(Equal(ptr.To(false)))
+			Expect(workspace.Spec.Paused).To(Equal(new(false)))
 		})
 
 		It("should return 404 for a non-existent workspace when starting", func() {
@@ -288,7 +287,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 			By("setting the workspace's status state to Unknown and spec.paused to false")
 			workspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace)).To(Succeed())
-			workspace.Spec.Paused = ptr.To(false)
+			workspace.Spec.Paused = new(false)
 			workspace.Status.State = kubefloworgv1beta1.WorkspaceStateUnknown
 			Expect(k8sClient.Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
@@ -330,7 +329,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 			By("setting the workspace's spec.paused to true")
 			workspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace)).To(Succeed())
-			workspace.Spec.Paused = ptr.To(true)
+			workspace.Spec.Paused = new(true)
 			Expect(k8sClient.Update(ctx, workspace)).To(Succeed())
 
 			By("creating the request body")
@@ -440,7 +439,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 			By("setting the workspace's spec.paused to true and status state to Paused")
 			workspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace)).To(Succeed())
-			workspace.Spec.Paused = ptr.To(true)
+			workspace.Spec.Paused = new(true)
 			Expect(k8sClient.Update(ctx, workspace)).To(Succeed())
 			workspace.Status.State = kubefloworgv1beta1.WorkspaceStatePaused
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
@@ -491,7 +490,7 @@ var _ = Describe("Workspace Actions Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKey1, workspace)).To(Succeed())
 
 			By("ensuring the workspace is not paused (empty data object results in false)")
-			Expect(workspace.Spec.Paused).To(Equal(ptr.To(false)))
+			Expect(workspace.Spec.Paused).To(Equal(new(false)))
 		})
 	})
 })

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	commonModels "github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
@@ -974,7 +973,7 @@ metadata:
 			Expect(getData.Spawner.Deprecated).NotTo(BeNil())
 
 			By("toggling deprecated to true")
-			getData.Spawner.Deprecated = ptr.To(true)
+			getData.Spawner.Deprecated = new(true)
 			dataJSON, err := json.Marshal(getData)
 			Expect(err).NotTo(HaveOccurred())
 			updateBody := fmt.Sprintf(`{"data": %s}`, string(dataJSON))
@@ -1001,7 +1000,7 @@ metadata:
 
 			By("setting hidden on the first imageConfig option")
 			Expect(getData.PodTemplate.Options.ImageConfig.Values).NotTo(BeEmpty())
-			getData.PodTemplate.Options.ImageConfig.Values[0].Spawner.Hidden = ptr.To(false)
+			getData.PodTemplate.Options.ImageConfig.Values[0].Spawner.Hidden = new(false)
 
 			dataJSON, err := json.Marshal(getData)
 			Expect(err).NotTo(HaveOccurred())
@@ -1028,7 +1027,7 @@ metadata:
 					Id: "new_image_option",
 					Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 						DisplayName: "new-image:v1.0.0",
-						Description: ptr.To("A new image option"),
+						Description: new("A new image option"),
 					},
 					Spec: kubefloworgv1beta1.ImageConfigSpec{
 						Image: "ghcr.io/kubeflow/new-image:v1.0.0",
@@ -1072,7 +1071,7 @@ metadata:
 					Id: "new_pod_option",
 					Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 						DisplayName: "New Pod Config",
-						Description: ptr.To("A new pod config option"),
+						Description: new("A new pod config option"),
 					},
 					Spec: kubefloworgv1beta1.PodConfigSpec{
 						Resources: &corev1.ResourceRequirements{

--- a/workspaces/backend/api/workspaces_handler_test.go
+++ b/workspaces/backend/api/workspaces_handler_test.go
@@ -906,7 +906,7 @@ var _ = Describe("Workspaces Handler", func() {
 
 			By("ensuring the created Workspace matches the expected Workspace")
 			Expect(createdWorkspace.ObjectMeta.Name).To(Equal(workspaceName))
-			Expect(createdWorkspace.Spec.DisplayName).To(Equal(ptr.To(workspaceCreate.DisplayName)))
+			Expect(createdWorkspace.Spec.DisplayName).To(Equal(new(workspaceCreate.DisplayName)))
 			Expect(createdWorkspace.Spec.Kind).To(Equal(workspaceKindName))
 			Expect(createdWorkspace.Spec.Paused).To(Equal(&workspaceCreate.Paused))
 			Expect(createdWorkspace.Spec.PodTemplate.PodMetadata.Labels).To(Equal(workspaceCreate.PodTemplate.PodMetadata.Labels))
@@ -1082,7 +1082,7 @@ var _ = Describe("Workspaces Handler", func() {
 						Annotations: map[string]string{},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 						Data: []models.PodVolumeMount{
 							{
 								PVCName:   "my-data-pvc",
@@ -1156,7 +1156,7 @@ var _ = Describe("Workspaces Handler", func() {
 						},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 						Data: []models.PodVolumeMount{
 							{
 								PVCName:   "my-data-pvc",
@@ -1193,7 +1193,7 @@ var _ = Describe("Workspaces Handler", func() {
 			By("verifying the created Workspace has the original display name")
 			createdWorkspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey, createdWorkspace)).To(Succeed())
-			Expect(createdWorkspace.Spec.DisplayName).To(Equal(ptr.To("Original Display Name")))
+			Expect(createdWorkspace.Spec.DisplayName).To(Equal(new("Original Display Name")))
 			originalRevision := commonModels.CalculateRevision(&createdWorkspace.ObjectMeta)
 
 			By("building a WorkspaceUpdate model with changed fields including displayName")
@@ -1212,7 +1212,7 @@ var _ = Describe("Workspaces Handler", func() {
 						},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 						Data: []models.PodVolumeMount{
 							{
 								PVCName:   "my-data-pvc",
@@ -1273,7 +1273,7 @@ var _ = Describe("Workspaces Handler", func() {
 			Expect(updatedWorkspace.Annotations[commonModels.AnnotationUpdatedAt]).NotTo(BeEmpty())
 
 			By("verifying all fields were applied")
-			Expect(updatedWorkspace.Spec.DisplayName).To(Equal(ptr.To("Updated Display Name")))
+			Expect(updatedWorkspace.Spec.DisplayName).To(Equal(new("Updated Display Name")))
 			Expect(ptr.Deref(updatedWorkspace.Spec.Paused, false)).To(BeTrue())
 			Expect(updatedWorkspace.Spec.PodTemplate.PodMetadata.Labels).To(Equal(workspaceUpdate.PodTemplate.PodMetadata.Labels))
 			Expect(updatedWorkspace.Spec.PodTemplate.PodMetadata.Annotations).To(Equal(workspaceUpdate.PodTemplate.PodMetadata.Annotations))
@@ -1282,7 +1282,7 @@ var _ = Describe("Workspaces Handler", func() {
 				{
 					PVCName:   "my-data-pvc",
 					MountPath: "/data/updated",
-					ReadOnly:  ptr.To(true),
+					ReadOnly:  new(true),
 				},
 			}))
 
@@ -1304,7 +1304,7 @@ var _ = Describe("Workspaces Handler", func() {
 						Annotations: map[string]string{},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 					},
 					Options: models.PodTemplateOptionsMutate{
 						ImageConfig: "jupyterlab_scipy_180",
@@ -1334,7 +1334,7 @@ var _ = Describe("Workspaces Handler", func() {
 			By("verifying the created Workspace has the display name set")
 			createdWorkspace := &kubefloworgv1beta1.Workspace{}
 			Expect(k8sClient.Get(ctx, workspaceKey, createdWorkspace)).To(Succeed())
-			Expect(createdWorkspace.Spec.DisplayName).To(Equal(ptr.To("Name To Clear")))
+			Expect(createdWorkspace.Spec.DisplayName).To(Equal(new("Name To Clear")))
 			originalRevision := commonModels.CalculateRevision(&createdWorkspace.ObjectMeta)
 
 			By("building a WorkspaceUpdate model with displayName omitted")
@@ -1347,7 +1347,7 @@ var _ = Describe("Workspaces Handler", func() {
 						Annotations: map[string]string{},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 					},
 					Options: models.PodTemplateOptionsMutate{
 						ImageConfig: "jupyterlab_scipy_180",
@@ -1403,7 +1403,7 @@ var _ = Describe("Workspaces Handler", func() {
 						Annotations: map[string]string{},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 						Data: []models.PodVolumeMount{
 							{
 								PVCName:   "my-data-pvc",
@@ -1456,7 +1456,7 @@ var _ = Describe("Workspaces Handler", func() {
 						Annotations: map[string]string{},
 					},
 					Volumes: models.PodVolumesMutate{
-						Home: ptr.To("my-home-pvc"),
+						Home: new("my-home-pvc"),
 						Data: []models.PodVolumeMount{
 							{
 								PVCName:   "my-data-pvc",

--- a/workspaces/backend/go.mod
+++ b/workspaces/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/workspaces/backend
 
-go 1.24.13
+go 1.26.5
 
 replace github.com/kubeflow/notebooks/workspaces/controller => ../controller
 

--- a/workspaces/backend/internal/models/common/assets/funcs_test.go
+++ b/workspaces/backend/internal/models/common/assets/funcs_test.go
@@ -55,28 +55,28 @@ var _ = Describe("configMapStatusToErrorCode", func() {
 			status: &kubefloworgv1beta1.WorkspaceKindAssetConfigMapStatus{
 				Error: ptr.To(kubefloworgv1beta1.ConfigMapErrorNotFound),
 			},
-			expected: ptr.To(ImageRefErrorCodeConfigMapMissing),
+			expected: new(ImageRefErrorCodeConfigMapMissing),
 		},
 		{
 			description: "should map KeyNotFound to CONFIGMAP_KEY_MISSING",
 			status: &kubefloworgv1beta1.WorkspaceKindAssetConfigMapStatus{
 				Error: ptr.To(kubefloworgv1beta1.ConfigMapErrorKeyNotFound),
 			},
-			expected: ptr.To(ImageRefErrorCodeConfigMapKeyMissing),
+			expected: new(ImageRefErrorCodeConfigMapKeyMissing),
 		},
 		{
 			description: "should map Other to CONFIGMAP_OTHER",
 			status: &kubefloworgv1beta1.WorkspaceKindAssetConfigMapStatus{
 				Error: ptr.To(kubefloworgv1beta1.ConfigMapErrorOther),
 			},
-			expected: ptr.To(ImageRefErrorCodeConfigMapOther),
+			expected: new(ImageRefErrorCodeConfigMapOther),
 		},
 		{
 			description: "should map unrecognized error to UNKNOWN",
 			status: &kubefloworgv1beta1.WorkspaceKindAssetConfigMapStatus{
 				Error: ptr.To(kubefloworgv1beta1.ConfigMapError("SomeFutureError")),
 			},
-			expected: ptr.To(ImageRefErrorCodeConfigMapUnknown),
+			expected: new(ImageRefErrorCodeConfigMapUnknown),
 		},
 	}
 
@@ -96,7 +96,7 @@ var _ = Describe("newImageRefFromWorkspaceKindAsset", func() {
 
 	It("should return URL directly for URL-based assets", func() {
 		asset := kubefloworgv1beta1.WorkspaceKindAsset{
-			Url: ptr.To("https://example.com/icon.png"),
+			Url: new("https://example.com/icon.png"),
 		}
 		ref := NewImageRefFromWorkspaceKindAssetIcon(nilCfg, asset, noStatus, wkName)
 		Expect(ref.URL).To(Equal("https://example.com/icon.png"))
@@ -171,7 +171,7 @@ var _ = Describe("newImageRefFromWorkspaceKindAsset", func() {
 
 	It("should not prepend URL prefix for URL-based assets", func() {
 		asset := kubefloworgv1beta1.WorkspaceKindAsset{
-			Url: ptr.To("https://example.com/icon.png"),
+			Url: new("https://example.com/icon.png"),
 		}
 		ref := NewImageRefFromWorkspaceKindAssetIcon(cfgWithPrefix, asset, noStatus, wkName)
 		Expect(ref.URL).To(Equal("https://example.com/icon.png"))

--- a/workspaces/backend/internal/models/workspaces/funcs_write.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_write.go
@@ -143,7 +143,7 @@ func validateAndUnpackVolumes(
 		dataVolumeMounts[i] = kubefloworgv1beta1.PodVolumeMount{
 			PVCName:   dataVolumeName,
 			MountPath: dataVolume.MountPath,
-			ReadOnly:  ptr.To(dataVolume.ReadOnly),
+			ReadOnly:  new(dataVolume.ReadOnly),
 		}
 	}
 
@@ -231,7 +231,7 @@ func ApplyWorkspaceUpdateModelToWorkspace(ctx context.Context, k8sClient client.
 	}
 
 	// apply model fields to workspace spec
-	workspace.Spec.Paused = ptr.To(workspaceUpdate.Paused)
+	workspace.Spec.Paused = new(workspaceUpdate.Paused)
 	workspace.Spec.DisplayName = displayNamePtr(workspaceUpdate.DisplayName)
 	workspace.Spec.PodTemplate = buildWorkspacePodTemplate(&workspaceUpdate.PodTemplate, workspaceUpdate.PodTemplate.Volumes.Home, dataVolumeMounts, secretMounts)
 
@@ -242,5 +242,5 @@ func displayNamePtr(displayName string) *string {
 	if displayName == "" {
 		return nil
 	}
-	return ptr.To(displayName)
+	return new(displayName)
 }

--- a/workspaces/controller/Dockerfile
+++ b/workspaces/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/workspaces/controller/go.mod
+++ b/workspaces/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/workspaces/controller
 
-go 1.24.13
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/workspaces/controller/internal/controller/suite_test.go
+++ b/workspaces/controller/internal/controller/suite_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -169,8 +168,8 @@ func NewExampleWorkspace1(name string, namespace string, workspaceKind string) *
 			Namespace: namespace,
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
-			Paused:      ptr.To(false),
-			DisplayName: ptr.To("Example Workspace"),
+			Paused:      new(false),
+			DisplayName: new("Example Workspace"),
 			Kind:        workspaceKind,
 			PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspacePodMetadata{
@@ -178,12 +177,12 @@ func NewExampleWorkspace1(name string, namespace string, workspaceKind string) *
 					Annotations: nil,
 				},
 				Volumes: kubefloworgv1beta1.WorkspacePodVolumes{
-					Home: ptr.To("my-home-pvc"),
+					Home: new("my-home-pvc"),
 					Data: []kubefloworgv1beta1.PodVolumeMount{
 						{
 							PVCName:   "my-data-pvc",
 							MountPath: "/data/my-data",
-							ReadOnly:  ptr.To(false),
+							ReadOnly:  new(false),
 						},
 					},
 				},
@@ -237,14 +236,14 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 			Spawner: kubefloworgv1beta1.WorkspaceKindSpawner{
 				DisplayName:        "JupyterLab Notebook",
 				Description:        "A Workspace which runs JupyterLab in a Pod",
-				Hidden:             ptr.To(false),
-				Deprecated:         ptr.To(false),
-				DeprecationMessage: ptr.To("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
+				Hidden:             new(false),
+				Deprecated:         new(false),
+				DeprecationMessage: new("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
 				Icon: kubefloworgv1beta1.WorkspaceKindAsset{
-					Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
+					Url: new("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
 				},
 				Logo: kubefloworgv1beta1.WorkspaceKindAsset{
-					Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
+					Url: new("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
 				},
 			},
 			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
@@ -253,8 +252,8 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 					Name: "default-editor",
 				},
 				ActivityProbe: &kubefloworgv1beta1.ActivityProbe{
-					MinProbeIntervalSeconds: ptr.To(int32(300)),
-					ProbeIntervalSeconds:    ptr.To(int32(3600)),
+					MinProbeIntervalSeconds: new(int32(300)),
+					ProbeIntervalSeconds:    new(int32(3600)),
 					Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
 						LastActivity: true,
 						PortId:       "jupyterlab",
@@ -270,7 +269,7 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 						DefaultDisplayName: "JupyterLab",
 						Protocol:           "HTTP",
 						HTTPProxy: &kubefloworgv1beta1.HTTPProxy{
-							RemovePathPrefix: ptr.To(false),
+							RemovePathPrefix: new(false),
 							RequestHeaders: &kubefloworgv1beta1.IstioHeaderOperations{
 								Set:    map[string]string{},
 								Add:    map[string]string{},
@@ -302,14 +301,14 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 					},
 				},
 				SecurityContext: &v1.PodSecurityContext{
-					FSGroup: ptr.To(int64(100)),
+					FSGroup: new(int64(100)),
 				},
 				ContainerSecurityContext: &v1.SecurityContext{
-					AllowPrivilegeEscalation: ptr.To(false),
+					AllowPrivilegeEscalation: new(false),
 					Capabilities: &v1.Capabilities{
 						Drop: []v1.Capability{"ALL"},
 					},
-					RunAsNonRoot: ptr.To(true),
+					RunAsNonRoot: new(true),
 				},
 				Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
 					ImageConfig: kubefloworgv1beta1.ImageConfig{
@@ -322,14 +321,14 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "jupyterlab_scipy_180",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "jupyter-scipy:v1.8.0",
-									Description: ptr.To("JupyterLab, with SciPy Packages"),
+									Description: new("JupyterLab, with SciPy Packages"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "python_version",
 											Value: "3.11",
 										},
 									},
-									Hidden: ptr.To(true),
+									Hidden: new(true),
 								},
 								Redirect: &kubefloworgv1beta1.OptionRedirect{
 									To: "jupyterlab_scipy_190",
@@ -343,7 +342,7 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 									Ports: []kubefloworgv1beta1.ImagePort{
 										{
 											Id:          "jupyterlab",
-											DisplayName: ptr.To("JupyterLab"),
+											DisplayName: new("JupyterLab"),
 											Port:        8888,
 										},
 									},
@@ -354,7 +353,7 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "jupyterlab_scipy_190",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "jupyter-scipy:v1.9.0",
-									Description: ptr.To("JupyterLab, with SciPy Packages"),
+									Description: new("JupyterLab, with SciPy Packages"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "python_version",
@@ -384,7 +383,7 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "tiny_cpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Tiny CPU",
-									Description: ptr.To("Pod with 0.1 CPU, 128 MB RAM"),
+									Description: new("Pod with 0.1 CPU, 128 MB RAM"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -410,7 +409,7 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "small_cpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Small CPU",
-									Description: ptr.To("Pod with 1 CPU, 2 GB RAM"),
+									Description: new("Pod with 1 CPU, 2 GB RAM"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -436,7 +435,7 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "big_gpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Big GPU",
-									Description: ptr.To("Pod with 4 CPU, 16 GB RAM, and 1 GPU"),
+									Description: new("Pod with 4 CPU, 16 GB RAM, and 1 GPU"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",

--- a/workspaces/controller/internal/controller/workspace_controller_test.go
+++ b/workspaces/controller/internal/controller/workspace_controller_test.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/utils/ptr"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -139,7 +137,7 @@ var _ = Describe("Workspace Controller", func() {
 			By("pausing the Workspace")
 			patch := client.MergeFrom(workspace.DeepCopy())
 			newWorkspace := workspace.DeepCopy()
-			newWorkspace.Spec.Paused = ptr.To(true)
+			newWorkspace.Spec.Paused = new(true)
 			Expect(k8sClient.Patch(ctx, newWorkspace, patch)).To(Succeed())
 
 			By("setting the Workspace `status.pauseTime` to the current time")
@@ -155,7 +153,7 @@ var _ = Describe("Workspace Controller", func() {
 			By("un-pausing the Workspace")
 			patch = client.MergeFrom(workspace.DeepCopy())
 			newWorkspace = workspace.DeepCopy()
-			newWorkspace.Spec.Paused = ptr.To(false)
+			newWorkspace.Spec.Paused = new(false)
 			Expect(k8sClient.Patch(ctx, newWorkspace, patch)).To(Succeed())
 
 			By("setting the Workspace `status.pauseTime` to 0")
@@ -270,7 +268,7 @@ var _ = Describe("Workspace Controller", func() {
 
 		It("should not rewrite the URI when `removePathPrefix` is false", func() {
 			By("generating the VirtualService")
-			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RemovePathPrefix = ptr.To(false)
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RemovePathPrefix = new(false)
 			virtualService, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -281,7 +279,7 @@ var _ = Describe("Workspace Controller", func() {
 
 		It("should rewrite the URI to '/' when `removePathPrefix` is true", func() {
 			By("generating the VirtualService")
-			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RemovePathPrefix = ptr.To(true)
+			workspaceKind.Spec.PodTemplate.Ports[0].HTTPProxy.RemovePathPrefix = new(true)
 			virtualService, err := reconciler.generateVirtualService(workspace, workspaceKind, service, imageConfigSpec)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/workspaces/controller/internal/controller/workspacekind_controller_test.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -121,7 +120,7 @@ var _ = Describe("WorkspaceKind Controller", func() {
 			By("only allowing one of `spec.spawner.icon.{url,configMap}` to be set")
 			newWorkspaceKind := workspaceKind.DeepCopy()
 			newWorkspaceKind.Spec.Spawner.Icon = kubefloworgv1beta1.WorkspaceKindAsset{
-				Url: ptr.To("https://example.com/icon.png"),
+				Url: new("https://example.com/icon.png"),
 				ConfigMap: &kubefloworgv1beta1.WorkspaceKindAssetConfigMap{
 					Name:      "my-logos",
 					Key:       "icon.svg",

--- a/workspaces/controller/internal/webhook/suite_test.go
+++ b/workspaces/controller/internal/webhook/suite_test.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -188,14 +187,14 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 			Spawner: kubefloworgv1beta1.WorkspaceKindSpawner{
 				DisplayName:        "JupyterLab Notebook",
 				Description:        "A Workspace which runs JupyterLab in a Pod",
-				Hidden:             ptr.To(false),
-				Deprecated:         ptr.To(false),
-				DeprecationMessage: ptr.To("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
+				Hidden:             new(false),
+				Deprecated:         new(false),
+				DeprecationMessage: new("This WorkspaceKind will be removed on 20XX-XX-XX, please use another WorkspaceKind."),
 				Icon: kubefloworgv1beta1.WorkspaceKindAsset{
-					Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
+					Url: new("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
 				},
 				Logo: kubefloworgv1beta1.WorkspaceKindAsset{
-					Url: ptr.To("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
+					Url: new("https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"),
 				},
 			},
 			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
@@ -204,8 +203,8 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 					Name: "default-editor",
 				},
 				ActivityProbe: &kubefloworgv1beta1.ActivityProbe{
-					MinProbeIntervalSeconds: ptr.To(int32(300)),
-					ProbeIntervalSeconds:    ptr.To(int32(3600)),
+					MinProbeIntervalSeconds: new(int32(300)),
+					ProbeIntervalSeconds:    new(int32(3600)),
 					Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
 						LastActivity: true,
 						PortId:       "jupyterlab",
@@ -221,7 +220,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 						DefaultDisplayName: "JupyterLab",
 						Protocol:           "HTTP",
 						HTTPProxy: &kubefloworgv1beta1.HTTPProxy{
-							RemovePathPrefix: ptr.To(false),
+							RemovePathPrefix: new(false),
 							RequestHeaders: &kubefloworgv1beta1.IstioHeaderOperations{
 								Set:    map[string]string{},
 								Add:    map[string]string{},
@@ -258,14 +257,14 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 					},
 				},
 				SecurityContext: &v1.PodSecurityContext{
-					FSGroup: ptr.To(int64(100)),
+					FSGroup: new(int64(100)),
 				},
 				ContainerSecurityContext: &v1.SecurityContext{
-					AllowPrivilegeEscalation: ptr.To(false),
+					AllowPrivilegeEscalation: new(false),
 					Capabilities: &v1.Capabilities{
 						Drop: []v1.Capability{"ALL"},
 					},
-					RunAsNonRoot: ptr.To(true),
+					RunAsNonRoot: new(true),
 				},
 				Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
 					ImageConfig: kubefloworgv1beta1.ImageConfig{
@@ -278,14 +277,14 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "jupyterlab_scipy_180",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "jupyter-scipy:v1.8.0",
-									Description: ptr.To("JupyterLab, with SciPy Packages"),
+									Description: new("JupyterLab, with SciPy Packages"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "python_version",
 											Value: "3.11",
 										},
 									},
-									Hidden: ptr.To(true),
+									Hidden: new(true),
 								},
 								Redirect: &kubefloworgv1beta1.OptionRedirect{
 									To: "jupyterlab_scipy_190",
@@ -299,7 +298,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 									Ports: []kubefloworgv1beta1.ImagePort{
 										{
 											Id:          "jupyterlab",
-											DisplayName: ptr.To("JupyterLab"),
+											DisplayName: new("JupyterLab"),
 											Port:        8888,
 										},
 									},
@@ -310,7 +309,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "jupyterlab_scipy_190",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "jupyter-scipy:v1.9.0",
-									Description: ptr.To("JupyterLab, with SciPy Packages"),
+									Description: new("JupyterLab, with SciPy Packages"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "python_version",
@@ -342,7 +341,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 									Ports: []kubefloworgv1beta1.ImagePort{
 										{
 											Id:          "my_port",
-											DisplayName: ptr.To("something"),
+											DisplayName: new("something"),
 											Port:        1234,
 										},
 									},
@@ -395,7 +394,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "tiny_cpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Tiny CPU",
-									Description: ptr.To("Pod with 0.1 CPU, 128 MB RAM"),
+									Description: new("Pod with 0.1 CPU, 128 MB RAM"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -421,7 +420,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "small_cpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Small CPU",
-									Description: ptr.To("Pod with 1 CPU, 2 GB RAM"),
+									Description: new("Pod with 1 CPU, 2 GB RAM"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -447,7 +446,7 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 								Id: "big_gpu",
 								Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 									DisplayName: "Big GPU",
-									Description: ptr.To("Pod with 4 CPU, 16 GB RAM, and 1 GPU"),
+									Description: new("Pod with 4 CPU, 16 GB RAM, and 1 GPU"),
 									Labels: []kubefloworgv1beta1.OptionSpawnerLabel{
 										{
 											Key:   "cpu",
@@ -610,12 +609,12 @@ func NewExampleWorkspaceKindWithDuplicatePorts(name string) *kubefloworgv1beta1.
 	workspaceKind.Spec.PodTemplate.Options.ImageConfig.Values[0].Spec.Ports = []kubefloworgv1beta1.ImagePort{
 		{
 			Id:          "jupyterlab",
-			DisplayName: ptr.To("JupyterLab"),
+			DisplayName: new("JupyterLab"),
 			Port:        8888,
 		},
 		{
 			Id:          "jupyterlab2",
-			DisplayName: ptr.To("JupyterLab2"),
+			DisplayName: new("JupyterLab2"),
 			Port:        8888,
 		},
 	}
@@ -727,8 +726,8 @@ func NewExampleWorkspaceKindWithBothProbeTypes(name string) *kubefloworgv1beta1.
 func NewExampleWorkspaceKindWithInvalidProbeIntervals(name string) *kubefloworgv1beta1.WorkspaceKind {
 	workspaceKind := NewExampleWorkspaceKind(name)
 	workspaceKind.Spec.PodTemplate.ActivityProbe = &kubefloworgv1beta1.ActivityProbe{
-		MinProbeIntervalSeconds: ptr.To(int32(100)),
-		ProbeIntervalSeconds:    ptr.To(int32(50)),
+		MinProbeIntervalSeconds: new(int32(100)),
+		ProbeIntervalSeconds:    new(int32(50)),
 		Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
 			LastActivity: true,
 			PortId:       "jupyterlab",
@@ -790,7 +789,7 @@ func NewExampleWorkspaceKindWithValidFilterRules(name string) *kubefloworgv1beta
 			Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
 			Effect: kubefloworgv1beta1.FilterRuleEffect{
 				API: &kubefloworgv1beta1.FilterRuleEffectAPI{
-					Deny:        ptr.To(true),
+					Deny:        new(true),
 					DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "this image is not available in your namespace"},
 				},
 			},
@@ -835,7 +834,7 @@ func NewExampleWorkspaceKindWithValidFilterRules(name string) *kubefloworgv1beta
 			// using a matchPodConfig condition, which is valid at IMAGE_CONFIG scope
 			Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
 			Effect: kubefloworgv1beta1.FilterRuleEffect{
-				API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)},
+				API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)},
 			},
 			Match: []kubefloworgv1beta1.FilterRuleMatch{
 				{
@@ -1033,7 +1032,7 @@ func NewExampleWorkspaceKindWithFilterRuleDenyMessageWithoutDeny(name string) *k
 			Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
 			Effect: kubefloworgv1beta1.FilterRuleEffect{
 				API: &kubefloworgv1beta1.FilterRuleEffectAPI{
-					Hide:        ptr.To(true),
+					Hide:        new(true),
 					DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "this image is not available"},
 				},
 			},
@@ -1088,7 +1087,7 @@ func NewExampleWorkspace(name, namespace, workspaceKindName string) *kubefloworg
 			Namespace: namespace,
 		},
 		Spec: kubefloworgv1beta1.WorkspaceSpec{
-			DisplayName: ptr.To("Example Workspace"),
+			DisplayName: new("Example Workspace"),
 			Kind:        workspaceKindName,
 			PodTemplate: kubefloworgv1beta1.WorkspacePodTemplate{Options: kubefloworgv1beta1.WorkspacePodOptions{
 				ImageConfig: "jupyterlab_scipy_180",

--- a/workspaces/controller/internal/webhook/workspacekind_webhook_test.go
+++ b/workspaces/controller/internal/webhook/workspacekind_webhook_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
@@ -242,7 +241,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 					{
 						Config: kubefloworgv1beta1.ActivityRuleConfig{
 							SecondsSinceActive: 3600,
-							MinRunningSeconds:  ptr.To(int32(300)),
+							MinRunningSeconds:  new(int32(300)),
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{
 							MatchNamespace: &kubefloworgv1beta1.NamespaceMatch{
@@ -252,7 +251,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							},
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 					{
@@ -261,7 +260,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{}, // empty match = catch-all
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -287,7 +286,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							},
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -308,7 +307,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							},
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(false), // override to no-op culling
+							PauseWorkspace: new(false), // override to no-op culling
 						},
 					},
 					{
@@ -317,7 +316,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{}, // catch-all
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -331,7 +330,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							SecondsSinceActive: 15,
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -343,10 +342,10 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 					{
 						Config: kubefloworgv1beta1.ActivityRuleConfig{
 							SecondsSinceActive: 3600,
-							MinRunningSeconds:  ptr.To(int32(-10)),
+							MinRunningSeconds:  new(int32(-10)),
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -361,7 +360,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 					{
@@ -370,7 +369,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -385,7 +384,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(false),
+							PauseWorkspace: new(false),
 						},
 					},
 					{
@@ -394,7 +393,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -409,7 +408,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 						Match: &kubefloworgv1beta1.ActivityRuleMatch{},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 					{
@@ -424,7 +423,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							},
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -439,7 +438,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 								SecondsSinceActive: 3600,
 							},
 							Effect: kubefloworgv1beta1.ActivityRuleEffect{
-								PauseWorkspace: ptr.To(true),
+								PauseWorkspace: new(true),
 							},
 						},
 					})
@@ -458,7 +457,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 								SecondsSinceActive: 3000,
 							},
 							Effect: kubefloworgv1beta1.ActivityRuleEffect{
-								PauseWorkspace: ptr.To(true),
+								PauseWorkspace: new(true),
 							},
 						},
 					})
@@ -497,7 +496,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							SecondsSinceActive: 3000,
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(true),
+							PauseWorkspace: new(true),
 						},
 					},
 				}),
@@ -511,7 +510,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 							SecondsSinceActive: 3000,
 						},
 						Effect: kubefloworgv1beta1.ActivityRuleEffect{
-							PauseWorkspace: ptr.To(false),
+							PauseWorkspace: new(false),
 						},
 					},
 				}),
@@ -566,7 +565,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 						},
 					},
 					Effect: kubefloworgv1beta1.ActivityRuleEffect{
-						PauseWorkspace: ptr.To(true),
+						PauseWorkspace: new(true),
 					},
 				},
 				{
@@ -575,7 +574,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 					},
 					Match: &kubefloworgv1beta1.ActivityRuleMatch{}, // catch-all
 					Effect: kubefloworgv1beta1.ActivityRuleEffect{
-						PauseWorkspace: ptr.To(true),
+						PauseWorkspace: new(true),
 					},
 				},
 				{
@@ -969,12 +968,12 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 					wsk.Spec.PodTemplate.Options.ImageConfig.Values[1].Spec.Ports = []kubefloworgv1beta1.ImagePort{
 						{
 							Id:          "jupyterlab",
-							DisplayName: ptr.To("JupyterLab"),
+							DisplayName: new("JupyterLab"),
 							Port:        duplicatePortNumber,
 						},
 						{
 							Id:          "jupyterlab2",
-							DisplayName: ptr.To("JupyterLab2"),
+							DisplayName: new("JupyterLab2"),
 							Port:        duplicatePortNumber,
 						},
 					}
@@ -1089,7 +1088,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 								SecondsSinceActive: 5, // invalid
 							},
 							Effect: kubefloworgv1beta1.ActivityRuleEffect{
-								PauseWorkspace: ptr.To(true),
+								PauseWorkspace: new(true),
 							},
 						},
 					}
@@ -1107,7 +1106,7 @@ var _ = Describe("WorkspaceKind Webhook", func() {
 								SecondsSinceActive: 3600,
 							},
 							Effect: kubefloworgv1beta1.ActivityRuleEffect{
-								PauseWorkspace: ptr.To(true),
+								PauseWorkspace: new(true),
 							},
 						},
 					}


### PR DESCRIPTION
Bumps the go directive in both go.mod files and the golang builder image tag in both Dockerfiles from 1.24 to 1.26.5.

Also applies the `golangci-lint` modernize fixes (`ptr.To(x)` -> `new(x)`) that the newer Go version unlocks.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
