### PR TITLE
feat: grey out label filter values with no matching visible results

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaceForm.ts
@@ -282,6 +282,24 @@ class WorkspaceForm {
     return this.findExtraFilter(filterKey).find('input[type="checkbox"]').should('not.be.checked');
   }
 
+  assertLabelFilterDisabled(
+    labelKey: string,
+    labelValue: string,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy
+      .findByTestId(`label-filter-${labelKey}-${labelValue}`)
+      .should('have.attr', 'aria-disabled', 'true');
+  }
+
+  assertLabelFilterEnabled(
+    labelKey: string,
+    labelValue: string,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy
+      .findByTestId(`label-filter-${labelKey}-${labelValue}`)
+      .should('have.attr', 'aria-disabled', 'false');
+  }
+
   assertLabelCategoryExists(labelKey: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findLabelCategory(labelKey).should('exist');
   }

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterImagesByLabels.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/filterImagesByLabels.cy.ts
@@ -298,6 +298,40 @@ describe('Filter Images by Labels', () => {
       createWorkspace.clickExtraFilter('showHidden');
       createWorkspace.assertExtraFilterChecked('showHidden');
     });
+
+    it('should grey out label values that only exist on hidden images', () => {
+      createWorkspace.assertLabelFilterDisabled('gpu', '1');
+      createWorkspace.assertLabelFilterEnabled('cpu', '2');
+      createWorkspace.assertLabelFilterEnabled('framework', 'pytorch');
+    });
+
+    it('should enable label values when show hidden is toggled on', () => {
+      createWorkspace.assertLabelFilterDisabled('gpu', '1');
+
+      createWorkspace.clickExtraFilter('showHidden');
+
+      createWorkspace.assertLabelFilterEnabled('gpu', '1');
+    });
+
+    it('should re-disable label values when show hidden is toggled back off', () => {
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertLabelFilterEnabled('gpu', '1');
+
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertLabelFilterDisabled('gpu', '1');
+    });
+
+    it('should deselect label filter when it becomes disabled', () => {
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertLabelFilterEnabled('gpu', '1');
+
+      createWorkspace.clickLabelFilter('gpu', '1');
+      createWorkspace.assertLabelFilterChecked('gpu', '1');
+
+      createWorkspace.clickExtraFilter('showHidden');
+      createWorkspace.assertLabelFilterDisabled('gpu', '1');
+      createWorkspace.assertLabelFilterNotChecked('gpu', '1');
+    });
   });
 
   describe('UI state', () => {

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -55,6 +55,11 @@
   min-width: 200px;
 }
 
+.filter-label--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .workspace-form__info-icon {
   color: var(--pf-t--global--icon--color--status--info--default);
 }

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/labelFilter/FilterByLabels.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/labelFilter/FilterByLabels.tsx
@@ -28,6 +28,19 @@ type FilterByLabelsProps<T> = {
   filterControlRef?: React.Ref<FilterControlHandle>;
 };
 
+const buildLabelMap = <T,>(objects: LabelledObject<T>[]): Map<string, Set<string>> => {
+  const labelsMap = new Map<string, Set<string>>();
+  objects
+    .flatMap((obj) => obj.labels ?? [])
+    .forEach((label) => {
+      if (!labelsMap.has(label.key)) {
+        labelsMap.set(label.key, new Set<string>());
+      }
+      labelsMap.get(label.key)?.add(label.value);
+    });
+  return labelsMap;
+};
+
 export const FilterByLabels = <T,>(props: FilterByLabelsProps<T>): React.ReactElement => {
   const [selectedLabels, setSelectedLabels] = useState<Map<string, Set<string>>>(new Map());
   const [selectedExtraFilters, setSelectedExtraFilters] = useState<Map<string, ExtraFilter<T>>>(
@@ -38,18 +51,23 @@ export const FilterByLabels = <T,>(props: FilterByLabelsProps<T>): React.ReactEl
     },
   );
 
-  const filterMap = useMemo(() => {
-    const labelsMap = new Map<string, Set<string>>();
-    props.labelledObjects
-      .flatMap((labelledObject) => labelledObject.labels ?? [])
-      .forEach((label) => {
-        if (!labelsMap.has(label.key)) {
-          labelsMap.set(label.key, new Set<string>());
-        }
-        labelsMap.get(label.key)?.add(label.value);
-      });
-    return labelsMap;
-  }, [props.labelledObjects]);
+  const filterMap = useMemo(() => buildLabelMap(props.labelledObjects), [props.labelledObjects]);
+
+  const availableLabelValues = useMemo(
+    () =>
+      buildLabelMap(
+        props.labelledObjects.filter((obj) =>
+          [...selectedExtraFilters.values()].every((ef) => ef.matchesFilter(obj, ef.value)),
+        ),
+      ),
+    [props.labelledObjects, selectedExtraFilters],
+  );
+
+  const isLabelValueAvailable = useCallback(
+    (labelKey: string, labelValue: string) =>
+      availableLabelValues.get(labelKey)?.has(labelValue) ?? false,
+    [availableLabelValues],
+  );
 
   const isLabelChecked = useCallback(
     (label: string, labelValue: string) => selectedLabels.get(label)?.has(labelValue),
@@ -127,6 +145,32 @@ export const FilterByLabels = <T,>(props: FilterByLabelsProps<T>): React.ReactEl
   );
 
   useEffect(() => {
+    setSelectedLabels((prev) => {
+      const cleaned = new Map<string, Set<string>>();
+      let changed = false;
+      for (const [key, values] of prev) {
+        const available = availableLabelValues.get(key);
+        if (!available) {
+          changed = true;
+          continue;
+        }
+        const kept = new Set<string>();
+        for (const v of values) {
+          if (available.has(v)) {
+            kept.add(v);
+          } else {
+            changed = true;
+          }
+        }
+        if (kept.size > 0) {
+          cleaned.set(key, kept);
+        }
+      }
+      return changed ? cleaned : prev;
+    });
+  }, [availableLabelValues]);
+
+  useEffect(() => {
     updateLabelledObjects();
   }, [selectedLabels, selectedExtraFilters, updateLabelledObjects]);
 
@@ -172,16 +216,30 @@ export const FilterByLabels = <T,>(props: FilterByLabelsProps<T>): React.ReactEl
           data-testid={`label-category-${label}`}
           title={formatLabelKey(label)}
         >
-          {Array.from(filterMap.get(label)?.values() ?? []).map((labelValue) => (
-            <FilterSidePanelCategoryItem
-              key={`${label}|||${labelValue}`}
-              data-testid={`label-filter-${label}-${labelValue}`}
-              checked={isLabelChecked(label, labelValue)}
-              onClick={(e) => onChange(label, labelValue, e)}
-            >
-              {labelValue}
-            </FilterSidePanelCategoryItem>
-          ))}
+          {Array.from(filterMap.get(label)?.values() ?? [])
+            .sort((a, b) => {
+              const aAvail = isLabelValueAvailable(label, a);
+              const bAvail = isLabelValueAvailable(label, b);
+              if (aAvail === bAvail) {
+                return 0;
+              }
+              return aAvail ? -1 : 1;
+            })
+            .map((labelValue) => {
+              const available = isLabelValueAvailable(label, labelValue);
+              return (
+                <FilterSidePanelCategoryItem
+                  key={`${label}|||${labelValue}`}
+                  className={available ? '' : 'filter-label--disabled'}
+                  data-testid={`label-filter-${label}-${labelValue}`}
+                  checked={available && isLabelChecked(label, labelValue)}
+                  onClick={available ? (e) => onChange(label, labelValue, e) : undefined}
+                  aria-disabled={!available}
+                >
+                  {labelValue}
+                </FilterSidePanelCategoryItem>
+              );
+            })}
         </FilterSidePanelCategory>
       ))}
     </FilterSidePanel>


### PR DESCRIPTION
closes: #1103

### Grey out filter labels that result in no matched results
- Introduce availableLabelValues map with key --> label name and value --> matching results
- Introduce a cleanup useEffect to sync selectedLabels with availableLabelValues whenever the available set changes.
- If a user selects hidden and/or redirected filter, the available options should respect the user's selection
- Order filters so that have available results first
- Fix tests