### PR TITLE
fix: harden testing/ and developing scripts

### DIFF
--- a/.github/workflows/ws-e2e-test.yml
+++ b/.github/workflows/ws-e2e-test.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     paths:
       - workspaces/**
+      - testing/**
 
 jobs:
   e2e-test:

--- a/developing/scripts/setup-prometheus.sh
+++ b/developing/scripts/setup-prometheus.sh
@@ -59,7 +59,12 @@ kubectl wait --for=condition=established crd/servicemonitors.monitoring.coreos.c
 echo "Deploying Prometheus instance..."
 kubectl apply -k "${DEVELOPING_DIR}/manifests/prometheus"
 
-echo "Waiting for Prometheus to be ready..."
+echo "Waiting for Prometheus to be available..."
+kubectl wait --for=condition=Available prometheus/prometheus \
+  --namespace=monitoring \
+  --timeout=120s
+
+echo "Waiting for Prometheus pods to be ready..."
 kubectl wait --for=condition=ready pod \
   -l app.kubernetes.io/name=prometheus \
   --namespace=monitoring \

--- a/testing/scripts/sanity-check.sh
+++ b/testing/scripts/sanity-check.sh
@@ -172,4 +172,19 @@ check_gateway_route "backend via gateway" "/workspaces/api/v1/healthcheck"
 check_gateway_route "frontend via gateway" "/workspaces/"
 
 echo ""
+echo "=== Sanity Check: Sample WorkspaceKinds ==="
+
+SAMPLES_DIR="../workspaces/controller/manifests/kustomize/samples"
+
+for sample in "${SAMPLES_DIR}"/*_workspacekind.yaml; do
+  name=$(basename "${sample}")
+  echo "Validating sample ${name}..."
+  if ! kubectl create --dry-run=server -f "${sample}" 2>&1; then
+    echo "✗ ERROR: Sample ${name} failed server-side validation"
+    exit 1
+  fi
+  echo "✓ ${name} is valid"
+done
+
+echo ""
 echo "✓ All sanity checks passed"


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_

Ran into a couple minor annoyances during PR reviews that would be nice to fix.

(1) When enabling PROMETHEUS in `tilt` - I got an error (likely a race condition) that `kubectl wait ... pods` failed because the pods hadn't been created yet... waiting on Prometheus CR to be `Available` seems the obvious hardening choice here.

(2) In reviewing https://github.com/kubeflow/notebooks/pull/1263 - i had a typo in the PR "suggestion" I offered.. which lead to an extra whitespace and invalid YAML for our `codeserver` WSK that got carried into the author's fixes... and to make matters worse - all our GHA checks passed...  Added a small/idempotent/trivial addition to `sanity-check.sh` that will reasonably catch regressions in our sample files - which seems aligned with the purpose of `sanity-check.sh`