### PR TITLE
chore: update clickable material button color

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles/styles.scss
@@ -71,6 +71,11 @@ $kubeflow-theme: mat.define-light-theme(
 // component that you are using.
 @include mat.all-component-themes($kubeflow-theme);
 
+.mat-raised-button.mat-primary {
+  background-color: $kubeflow-blue-hue-4;
+  color: $kubeflow-white;
+}
+
 .mat-headline {
   color: $kubeflow-black-1;
 }


### PR DESCRIPTION
 closes: https://github.com/kubeflow/notebooks/issues/1286

old:
<img width="215" height="75" alt="Screenshot 2026-07-30 at 13 13 37" src="https://github.com/user-attachments/assets/b68050d1-90e2-4406-87d3-4b6aea61a28b" />


new:
<img width="202" height="75" alt="Screenshot 2026-07-30 at 13 18 14" src="https://github.com/user-attachments/assets/625f4918-3889-4330-97f6-df53ad034427" />