### PR TITLE
feat: Implement activity rules in backend API

### DIFF
--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -85,26 +85,28 @@ func buildActivityProbe(probe *kubefloworgv1beta1.ActivityProbe) *ActivityProbe 
 		return nil
 	}
 
-	res := &ActivityProbe{
-		MinProbeIntervalSeconds: ptr.Deref(probe.MinProbeIntervalSeconds, 300),
-		ProbeIntervalSeconds:    ptr.Deref(probe.ProbeIntervalSeconds, kubefloworgv1beta1.DefaultProbeIntervalSeconds),
-	}
-
+	var podExec *ActivityProbePodExec
 	if probe.PodExec != nil {
-		res.Exec = &ActivityProbeExec{
-			TimeoutSeconds: ptr.Deref(probe.PodExec.TimeoutSeconds, 60),
-			Script:         probe.PodExec.Script,
+		// NOTE: Script is excluded from ActivityProbePodExec in the WSK list for size reasons.
+		podExec = &ActivityProbePodExec{
+			TimeoutSeconds: ptr.Deref(probe.PodExec.TimeoutSeconds, kubefloworgv1beta1.DefaultPodExecTimeoutSeconds),
 		}
 	}
 
+	var jupyter *ActivityProbeJupyter
 	if probe.Jupyter != nil {
-		res.Jupyter = &ActivityProbeJupyter{
+		jupyter = &ActivityProbeJupyter{
 			LastActivity: probe.Jupyter.LastActivity,
 			PortId:       string(probe.Jupyter.PortId),
 		}
 	}
 
-	return res
+	return &ActivityProbe{
+		MinProbeIntervalSeconds: ptr.Deref(probe.MinProbeIntervalSeconds, kubefloworgv1beta1.DefaultMinProbeIntervalSeconds),
+		ProbeIntervalSeconds:    ptr.Deref(probe.ProbeIntervalSeconds, kubefloworgv1beta1.DefaultProbeIntervalSeconds),
+		PodExec:                 podExec,
+		Jupyter:                 jupyter,
+	}
 }
 
 func buildActivityRules(rules []kubefloworgv1beta1.ActivityRule) []ActivityRule {
@@ -113,32 +115,35 @@ func buildActivityRules(rules []kubefloworgv1beta1.ActivityRule) []ActivityRule 
 	}
 	res := make([]ActivityRule, len(rules))
 	for i, rule := range rules {
-		res[i] = ActivityRule{
-			Config: ActivityRuleConfig{
-				SecondsSinceActive: rule.Config.SecondsSinceActive,
-				MinRunningSeconds:  ptr.Deref(rule.Config.MinRunningSeconds, 0),
-			},
-			Effect: ActivityRuleEffect{
-				PauseWorkspace: ptr.Deref(rule.Effect.PauseWorkspace, false),
-			},
-		}
+		var match *ActivityRuleMatch
 		if rule.Match != nil {
 			var matchNs *MatchNamespace
 			if rule.Match.MatchNamespace != nil {
 				matchNs = &MatchNamespace{
-					Selector: rule.Match.MatchNamespace.Selector,
+					Selector: *rule.Match.MatchNamespace.Selector.DeepCopy(),
 				}
 			}
 			var matchPodConfig *MatchPodConfig
 			if rule.Match.MatchPodConfig != nil {
 				matchPodConfig = &MatchPodConfig{
-					Selector: rule.Match.MatchPodConfig.Selector,
+					Selector: *rule.Match.MatchPodConfig.Selector.DeepCopy(),
 				}
 			}
-			res[i].Match = &ActivityRuleMatch{
+			match = &ActivityRuleMatch{
 				MatchNamespace: matchNs,
 				MatchPodConfig: matchPodConfig,
 			}
+		}
+
+		res[i] = ActivityRule{
+			Config: ActivityRuleConfig{
+				SecondsSinceActive: rule.Config.SecondsSinceActive,
+				MinRunningSeconds:  ptr.Deref(rule.Config.MinRunningSeconds, 0),
+			},
+			Match: match,
+			Effect: ActivityRuleEffect{
+				PauseWorkspace: ptr.Deref(rule.Effect.PauseWorkspace, false),
+			},
 		}
 	}
 	return res

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -69,11 +69,77 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 			VolumeMounts: PodVolumeMounts{
 				Home: wsk.Spec.PodTemplate.VolumeMounts.Home,
 			},
-			Options: *podTemplateOptions,
+			ActivityProbe: buildActivityProbe(wsk.Spec.PodTemplate.ActivityProbe),
+			Options:       *podTemplateOptions,
 		},
+		ActivityRules: buildActivityRules(wsk.Spec.ActivityRules),
 		//
 		// TODO: replace this with the calculation of the actual restriction!
 		//
 		Restrictions: common.DefaultRestrictions(),
 	}
+}
+
+func buildActivityProbe(probe *kubefloworgv1beta1.ActivityProbe) *ActivityProbe {
+	if probe == nil {
+		return nil
+	}
+
+	res := &ActivityProbe{
+		MinProbeIntervalSeconds: ptr.Deref(probe.MinProbeIntervalSeconds, 300),
+		ProbeIntervalSeconds:    ptr.Deref(probe.ProbeIntervalSeconds, kubefloworgv1beta1.DefaultProbeIntervalSeconds),
+	}
+
+	if probe.PodExec != nil {
+		res.Exec = &ActivityProbeExec{
+			TimeoutSeconds: ptr.Deref(probe.PodExec.TimeoutSeconds, 60),
+			Script:         probe.PodExec.Script,
+		}
+	}
+
+	if probe.Jupyter != nil {
+		res.Jupyter = &ActivityProbeJupyter{
+			LastActivity: probe.Jupyter.LastActivity,
+			PortId:       string(probe.Jupyter.PortId),
+		}
+	}
+
+	return res
+}
+
+func buildActivityRules(rules []kubefloworgv1beta1.ActivityRule) []ActivityRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	res := make([]ActivityRule, len(rules))
+	for i, rule := range rules {
+		res[i] = ActivityRule{
+			Config: ActivityRuleConfig{
+				SecondsSinceActive: rule.Config.SecondsSinceActive,
+				MinRunningSeconds:  ptr.Deref(rule.Config.MinRunningSeconds, 0),
+			},
+			Effect: ActivityRuleEffect{
+				PauseWorkspace: ptr.Deref(rule.Effect.PauseWorkspace, false),
+			},
+		}
+		if rule.Match != nil {
+			var matchNs *MatchNamespace
+			if rule.Match.MatchNamespace != nil {
+				matchNs = &MatchNamespace{
+					Selector: rule.Match.MatchNamespace.Selector,
+				}
+			}
+			var matchPodConfig *MatchPodConfig
+			if rule.Match.MatchPodConfig != nil {
+				matchPodConfig = &MatchPodConfig{
+					Selector: rule.Match.MatchPodConfig.Selector,
+				}
+			}
+			res[i].Match = &ActivityRuleMatch{
+				MatchNamespace: matchNs,
+				MatchPodConfig: matchPodConfig,
+			}
+		}
+	}
+	return res
 }

--- a/workspaces/backend/internal/models/workspacekinds/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_test.go
@@ -25,6 +25,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	testPodExecTimeoutSeconds     int32 = 45
+	testMinProbeIntervalSeconds   int32 = 120
+	testProbeIntervalSeconds      int32 = 1800
+	testRuleSecondsSinceActive    int32 = 3600
+	testRuleMinRunningSeconds     int32 = 300
+	testRuleSecondsSinceActiveMax int32 = 86400
+)
+
 func TestWorkspaceKinds(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "WorkspaceKinds Models Suite")
@@ -38,24 +47,24 @@ var _ = Describe("buildActivityProbe", func() {
 	It("converts a PodExec probe with default intervals", func() {
 		crdProbe := &kubefloworgv1beta1.ActivityProbe{
 			PodExec: &kubefloworgv1beta1.ActivityProbePodExec{
-				TimeoutSeconds: new(int32(45)),
+				TimeoutSeconds: &testPodExecTimeoutSeconds,
 				Script:         "#!/bin/bash\necho active",
 			},
 		}
 
 		apiProbe := buildActivityProbe(crdProbe)
 		Expect(apiProbe).NotTo(BeNil())
-		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(int32(300)))
-		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(int32(3600)))
+		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(kubefloworgv1beta1.DefaultMinProbeIntervalSeconds))
+		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(kubefloworgv1beta1.DefaultProbeIntervalSeconds))
 		Expect(apiProbe.PodExec).NotTo(BeNil())
-		Expect(apiProbe.PodExec.TimeoutSeconds).To(Equal(int32(45)))
+		Expect(apiProbe.PodExec.TimeoutSeconds).To(Equal(testPodExecTimeoutSeconds))
 		Expect(apiProbe.Jupyter).To(BeNil())
 	})
 
 	It("converts a Jupyter probe with custom intervals", func() {
 		crdProbe := &kubefloworgv1beta1.ActivityProbe{
-			MinProbeIntervalSeconds: new(int32(120)),
-			ProbeIntervalSeconds:    new(int32(1800)),
+			MinProbeIntervalSeconds: &testMinProbeIntervalSeconds,
+			ProbeIntervalSeconds:    &testProbeIntervalSeconds,
 			Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
 				LastActivity: true,
 				PortId:       "jupyterlab",
@@ -64,8 +73,8 @@ var _ = Describe("buildActivityProbe", func() {
 
 		apiProbe := buildActivityProbe(crdProbe)
 		Expect(apiProbe).NotTo(BeNil())
-		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(int32(120)))
-		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(int32(1800)))
+		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(testMinProbeIntervalSeconds))
+		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(testProbeIntervalSeconds))
 		Expect(apiProbe.Jupyter).NotTo(BeNil())
 		Expect(apiProbe.Jupyter.LastActivity).To(BeTrue())
 		Expect(apiProbe.Jupyter.PortId).To(Equal("jupyterlab"))
@@ -83,8 +92,8 @@ var _ = Describe("buildActivityRules", func() {
 		crdRules := []kubefloworgv1beta1.ActivityRule{
 			{
 				Config: kubefloworgv1beta1.ActivityRuleConfig{
-					SecondsSinceActive: 3600,
-					MinRunningSeconds:  new(int32(300)),
+					SecondsSinceActive: testRuleSecondsSinceActive,
+					MinRunningSeconds:  &testRuleMinRunningSeconds,
 				},
 				Match: &kubefloworgv1beta1.ActivityRuleMatch{
 					MatchNamespace: &kubefloworgv1beta1.NamespaceMatch{
@@ -104,7 +113,7 @@ var _ = Describe("buildActivityRules", func() {
 			},
 			{
 				Config: kubefloworgv1beta1.ActivityRuleConfig{
-					SecondsSinceActive: 86400,
+					SecondsSinceActive: testRuleSecondsSinceActiveMax,
 				},
 				Effect: kubefloworgv1beta1.ActivityRuleEffect{
 					PauseWorkspace: new(true),
@@ -115,8 +124,8 @@ var _ = Describe("buildActivityRules", func() {
 		apiRules := buildActivityRules(crdRules)
 		Expect(apiRules).To(HaveLen(2))
 
-		Expect(apiRules[0].Config.SecondsSinceActive).To(Equal(int32(3600)))
-		Expect(apiRules[0].Config.MinRunningSeconds).To(Equal(int32(300)))
+		Expect(apiRules[0].Config.SecondsSinceActive).To(Equal(testRuleSecondsSinceActive))
+		Expect(apiRules[0].Config.MinRunningSeconds).To(Equal(testRuleMinRunningSeconds))
 		Expect(apiRules[0].Match).NotTo(BeNil())
 		Expect(apiRules[0].Match.MatchNamespace).NotTo(BeNil())
 		Expect(apiRules[0].Match.MatchNamespace.Selector.MatchLabels).To(HaveKeyWithValue("tier", "dev"))
@@ -130,7 +139,7 @@ var _ = Describe("buildActivityRules", func() {
 		apiRules[0].Match.MatchPodConfig.Selector.MatchLabels["gpu"] = "false"
 		Expect(crdRules[0].Match.MatchPodConfig.Selector.MatchLabels["gpu"]).To(Equal("true"))
 
-		Expect(apiRules[1].Config.SecondsSinceActive).To(Equal(int32(86400)))
+		Expect(apiRules[1].Config.SecondsSinceActive).To(Equal(testRuleSecondsSinceActiveMax))
 		Expect(apiRules[1].Config.MinRunningSeconds).To(Equal(int32(0)))
 		Expect(apiRules[1].Match).To(BeNil())
 		Expect(apiRules[1].Effect.PauseWorkspace).To(BeTrue())

--- a/workspaces/backend/internal/models/workspacekinds/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestWorkspaceKinds(t *testing.T) {
@@ -39,7 +38,7 @@ var _ = Describe("buildActivityProbe", func() {
 	It("converts a PodExec probe with default intervals", func() {
 		crdProbe := &kubefloworgv1beta1.ActivityProbe{
 			PodExec: &kubefloworgv1beta1.ActivityProbePodExec{
-				TimeoutSeconds: ptr.To(int32(45)),
+				TimeoutSeconds: new(int32(45)),
 				Script:         "#!/bin/bash\necho active",
 			},
 		}
@@ -48,16 +47,15 @@ var _ = Describe("buildActivityProbe", func() {
 		Expect(apiProbe).NotTo(BeNil())
 		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(int32(300)))
 		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(int32(3600)))
-		Expect(apiProbe.Exec).NotTo(BeNil())
-		Expect(apiProbe.Exec.TimeoutSeconds).To(Equal(int32(45)))
-		Expect(apiProbe.Exec.Script).To(Equal("#!/bin/bash\necho active"))
+		Expect(apiProbe.PodExec).NotTo(BeNil())
+		Expect(apiProbe.PodExec.TimeoutSeconds).To(Equal(int32(45)))
 		Expect(apiProbe.Jupyter).To(BeNil())
 	})
 
 	It("converts a Jupyter probe with custom intervals", func() {
 		crdProbe := &kubefloworgv1beta1.ActivityProbe{
-			MinProbeIntervalSeconds: ptr.To(int32(120)),
-			ProbeIntervalSeconds:    ptr.To(int32(1800)),
+			MinProbeIntervalSeconds: new(int32(120)),
+			ProbeIntervalSeconds:    new(int32(1800)),
 			Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
 				LastActivity: true,
 				PortId:       "jupyterlab",
@@ -71,7 +69,7 @@ var _ = Describe("buildActivityProbe", func() {
 		Expect(apiProbe.Jupyter).NotTo(BeNil())
 		Expect(apiProbe.Jupyter.LastActivity).To(BeTrue())
 		Expect(apiProbe.Jupyter.PortId).To(Equal("jupyterlab"))
-		Expect(apiProbe.Exec).To(BeNil())
+		Expect(apiProbe.PodExec).To(BeNil())
 	})
 })
 
@@ -86,7 +84,7 @@ var _ = Describe("buildActivityRules", func() {
 			{
 				Config: kubefloworgv1beta1.ActivityRuleConfig{
 					SecondsSinceActive: 3600,
-					MinRunningSeconds:  ptr.To(int32(300)),
+					MinRunningSeconds:  new(int32(300)),
 				},
 				Match: &kubefloworgv1beta1.ActivityRuleMatch{
 					MatchNamespace: &kubefloworgv1beta1.NamespaceMatch{
@@ -94,9 +92,14 @@ var _ = Describe("buildActivityRules", func() {
 							MatchLabels: map[string]string{"tier": "dev"},
 						},
 					},
+					MatchPodConfig: &kubefloworgv1beta1.PodConfigMatch{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"gpu": "true"},
+						},
+					},
 				},
 				Effect: kubefloworgv1beta1.ActivityRuleEffect{
-					PauseWorkspace: ptr.To(true),
+					PauseWorkspace: new(true),
 				},
 			},
 			{
@@ -104,7 +107,7 @@ var _ = Describe("buildActivityRules", func() {
 					SecondsSinceActive: 86400,
 				},
 				Effect: kubefloworgv1beta1.ActivityRuleEffect{
-					PauseWorkspace: ptr.To(true),
+					PauseWorkspace: new(true),
 				},
 			},
 		}
@@ -117,7 +120,15 @@ var _ = Describe("buildActivityRules", func() {
 		Expect(apiRules[0].Match).NotTo(BeNil())
 		Expect(apiRules[0].Match.MatchNamespace).NotTo(BeNil())
 		Expect(apiRules[0].Match.MatchNamespace.Selector.MatchLabels).To(HaveKeyWithValue("tier", "dev"))
+		Expect(apiRules[0].Match.MatchPodConfig).NotTo(BeNil())
+		Expect(apiRules[0].Match.MatchPodConfig.Selector.MatchLabels).To(HaveKeyWithValue("gpu", "true"))
 		Expect(apiRules[0].Effect.PauseWorkspace).To(BeTrue())
+
+		// Verify deep copy of label selector maps
+		apiRules[0].Match.MatchNamespace.Selector.MatchLabels["tier"] = "mutated"
+		Expect(crdRules[0].Match.MatchNamespace.Selector.MatchLabels["tier"]).To(Equal("dev"))
+		apiRules[0].Match.MatchPodConfig.Selector.MatchLabels["gpu"] = "false"
+		Expect(crdRules[0].Match.MatchPodConfig.Selector.MatchLabels["gpu"]).To(Equal("true"))
 
 		Expect(apiRules[1].Config.SecondsSinceActive).To(Equal(int32(86400)))
 		Expect(apiRules[1].Config.MinRunningSeconds).To(Equal(int32(0)))

--- a/workspaces/backend/internal/models/workspacekinds/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspacekinds
+
+import (
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestWorkspaceKinds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "WorkspaceKinds Models Suite")
+}
+
+var _ = Describe("buildActivityProbe", func() {
+	It("returns nil when probe is nil", func() {
+		Expect(buildActivityProbe(nil)).To(BeNil())
+	})
+
+	It("converts a PodExec probe with default intervals", func() {
+		crdProbe := &kubefloworgv1beta1.ActivityProbe{
+			PodExec: &kubefloworgv1beta1.ActivityProbePodExec{
+				TimeoutSeconds: ptr.To(int32(45)),
+				Script:         "#!/bin/bash\necho active",
+			},
+		}
+
+		apiProbe := buildActivityProbe(crdProbe)
+		Expect(apiProbe).NotTo(BeNil())
+		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(int32(300)))
+		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(int32(3600)))
+		Expect(apiProbe.Exec).NotTo(BeNil())
+		Expect(apiProbe.Exec.TimeoutSeconds).To(Equal(int32(45)))
+		Expect(apiProbe.Exec.Script).To(Equal("#!/bin/bash\necho active"))
+		Expect(apiProbe.Jupyter).To(BeNil())
+	})
+
+	It("converts a Jupyter probe with custom intervals", func() {
+		crdProbe := &kubefloworgv1beta1.ActivityProbe{
+			MinProbeIntervalSeconds: ptr.To(int32(120)),
+			ProbeIntervalSeconds:    ptr.To(int32(1800)),
+			Jupyter: &kubefloworgv1beta1.ActivityProbeJupyter{
+				LastActivity: true,
+				PortId:       "jupyterlab",
+			},
+		}
+
+		apiProbe := buildActivityProbe(crdProbe)
+		Expect(apiProbe).NotTo(BeNil())
+		Expect(apiProbe.MinProbeIntervalSeconds).To(Equal(int32(120)))
+		Expect(apiProbe.ProbeIntervalSeconds).To(Equal(int32(1800)))
+		Expect(apiProbe.Jupyter).NotTo(BeNil())
+		Expect(apiProbe.Jupyter.LastActivity).To(BeTrue())
+		Expect(apiProbe.Jupyter.PortId).To(Equal("jupyterlab"))
+		Expect(apiProbe.Exec).To(BeNil())
+	})
+})
+
+var _ = Describe("buildActivityRules", func() {
+	It("returns nil when rules are empty", func() {
+		Expect(buildActivityRules(nil)).To(BeNil())
+		Expect(buildActivityRules([]kubefloworgv1beta1.ActivityRule{})).To(BeNil())
+	})
+
+	It("converts activity rules correctly", func() {
+		crdRules := []kubefloworgv1beta1.ActivityRule{
+			{
+				Config: kubefloworgv1beta1.ActivityRuleConfig{
+					SecondsSinceActive: 3600,
+					MinRunningSeconds:  ptr.To(int32(300)),
+				},
+				Match: &kubefloworgv1beta1.ActivityRuleMatch{
+					MatchNamespace: &kubefloworgv1beta1.NamespaceMatch{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"tier": "dev"},
+						},
+					},
+				},
+				Effect: kubefloworgv1beta1.ActivityRuleEffect{
+					PauseWorkspace: ptr.To(true),
+				},
+			},
+			{
+				Config: kubefloworgv1beta1.ActivityRuleConfig{
+					SecondsSinceActive: 86400,
+				},
+				Effect: kubefloworgv1beta1.ActivityRuleEffect{
+					PauseWorkspace: ptr.To(true),
+				},
+			},
+		}
+
+		apiRules := buildActivityRules(crdRules)
+		Expect(apiRules).To(HaveLen(2))
+
+		Expect(apiRules[0].Config.SecondsSinceActive).To(Equal(int32(3600)))
+		Expect(apiRules[0].Config.MinRunningSeconds).To(Equal(int32(300)))
+		Expect(apiRules[0].Match).NotTo(BeNil())
+		Expect(apiRules[0].Match.MatchNamespace).NotTo(BeNil())
+		Expect(apiRules[0].Match.MatchNamespace.Selector.MatchLabels).To(HaveKeyWithValue("tier", "dev"))
+		Expect(apiRules[0].Effect.PauseWorkspace).To(BeTrue())
+
+		Expect(apiRules[1].Config.SecondsSinceActive).To(Equal(int32(86400)))
+		Expect(apiRules[1].Config.MinRunningSeconds).To(Equal(int32(0)))
+		Expect(apiRules[1].Match).To(BeNil())
+		Expect(apiRules[1].Effect.PauseWorkspace).To(BeTrue())
+	})
+})

--- a/workspaces/backend/internal/models/workspacekinds/types.go
+++ b/workspaces/backend/internal/models/workspacekinds/types.go
@@ -66,13 +66,13 @@ type PodVolumeMounts struct {
 type ActivityProbe struct {
 	MinProbeIntervalSeconds int32                 `json:"minProbeIntervalSeconds"`
 	ProbeIntervalSeconds    int32                 `json:"probeIntervalSeconds"`
-	Exec                    *ActivityProbeExec    `json:"exec,omitempty"`
+	PodExec                 *ActivityProbePodExec `json:"podExec,omitempty"`
 	Jupyter                 *ActivityProbeJupyter `json:"jupyter,omitempty"`
 }
 
-type ActivityProbeExec struct {
-	TimeoutSeconds int32  `json:"timeoutSeconds"`
-	Script         string `json:"script"`
+type ActivityProbePodExec struct {
+	TimeoutSeconds int32 `json:"timeoutSeconds"`
+	// NOTE: Script is excluded from the WorkspaceKindListItem model for size reasons.
 }
 
 type ActivityProbeJupyter struct {

--- a/workspaces/backend/internal/models/workspacekinds/types.go
+++ b/workspaces/backend/internal/models/workspacekinds/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package workspacekinds
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common/assets"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds/podtemplate/options"
@@ -33,6 +35,7 @@ type WorkspaceKindListItem struct {
 	Logo               assets.ImageRef     `json:"logo"`
 	ClusterMetrics     ClusterKindMetrics  `json:"clusterMetrics"`
 	PodTemplate        PodTemplate         `json:"podTemplate"`
+	ActivityRules      []ActivityRule      `json:"activityRules,omitempty"`
 	Restrictions       common.Restrictions `json:"restrictions"`
 }
 
@@ -41,8 +44,9 @@ type ClusterKindMetrics struct {
 }
 
 type PodTemplate struct {
-	PodMetadata  PodMetadata     `json:"podMetadata"`
-	VolumeMounts PodVolumeMounts `json:"volumeMounts"`
+	PodMetadata   PodMetadata     `json:"podMetadata"`
+	VolumeMounts  PodVolumeMounts `json:"volumeMounts"`
+	ActivityProbe *ActivityProbe  `json:"activityProbe,omitempty"`
 
 	//
 	// TODO: remove once frontend migrates to the new listValues endpoint for both create/update and wsk admin views
@@ -57,4 +61,49 @@ type PodMetadata struct {
 
 type PodVolumeMounts struct {
 	Home string `json:"home"`
+}
+
+type ActivityProbe struct {
+	MinProbeIntervalSeconds int32                 `json:"minProbeIntervalSeconds"`
+	ProbeIntervalSeconds    int32                 `json:"probeIntervalSeconds"`
+	Exec                    *ActivityProbeExec    `json:"exec,omitempty"`
+	Jupyter                 *ActivityProbeJupyter `json:"jupyter,omitempty"`
+}
+
+type ActivityProbeExec struct {
+	TimeoutSeconds int32  `json:"timeoutSeconds"`
+	Script         string `json:"script"`
+}
+
+type ActivityProbeJupyter struct {
+	LastActivity bool   `json:"lastActivity"`
+	PortId       string `json:"portId"`
+}
+
+type ActivityRule struct {
+	Config ActivityRuleConfig `json:"config"`
+	Match  *ActivityRuleMatch `json:"match,omitempty"`
+	Effect ActivityRuleEffect `json:"effect"`
+}
+
+type ActivityRuleConfig struct {
+	SecondsSinceActive int32 `json:"secondsSinceActive"`
+	MinRunningSeconds  int32 `json:"minRunningSeconds,omitempty"`
+}
+
+type ActivityRuleMatch struct {
+	MatchNamespace *MatchNamespace `json:"matchNamespace,omitempty"`
+	MatchPodConfig *MatchPodConfig `json:"matchPodConfig,omitempty"`
+}
+
+type MatchNamespace struct {
+	Selector metav1.LabelSelector `json:"selector"`
+}
+
+type MatchPodConfig struct {
+	Selector metav1.LabelSelector `json:"selector"`
+}
+
+type ActivityRuleEffect struct {
+	PauseWorkspace bool `json:"pauseWorkspace"`
 }

--- a/workspaces/backend/internal/models/workspaces/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/funcs.go
@@ -59,10 +59,11 @@ func NewWorkspaceListItemFromWorkspace(cfg *config.EnvConfig, ws *kubefloworgv1b
 			Icon:    buildIconImageRef(cfg, ws, wsk),
 			Logo:    buildLogoImageRef(cfg, ws, wsk),
 		},
-		Paused:       ptr.Deref(ws.Spec.Paused, false),
-		PausedTime:   ws.Status.PauseTime,
-		State:        ws.Status.State,
-		StateMessage: ws.Status.StateMessage,
+		Paused:          ptr.Deref(ws.Spec.Paused, false),
+		PausedTime:      ws.Status.PauseTime,
+		LastRunningTime: ws.Status.LastRunningTime,
+		State:           ws.Status.State,
+		StateMessage:    ws.Status.StateMessage,
 		PodTemplate: PodTemplate{
 			Options: PodTemplateOptions{
 				ImageConfig: imageConfigModel,
@@ -295,10 +296,21 @@ func buildLastProbeInfo(probe *kubefloworgv1beta1.WorkspaceActivityLastProbe) *L
 	if probe == nil {
 		return nil
 	}
+
+	result := ProbeResult(probe.Result)
+	switch probe.Result {
+	case kubefloworgv1beta1.WorkspaceProbeResultSuccess:
+		result = ProbeResultSuccess
+	case kubefloworgv1beta1.WorkspaceProbeResultFailure:
+		result = ProbeResultFailure
+	case kubefloworgv1beta1.WorkspaceProbeResultTimeout:
+		result = ProbeResultTimeout
+	}
+
 	return &LastProbeInfo{
 		StartTime: probe.StartTime,
 		EndTime:   probe.EndTime,
-		Result:    ProbeResult(probe.Result),
+		Result:    result,
 		Message:   probe.Message,
 	}
 }

--- a/workspaces/backend/internal/models/workspaces/funcs.go
+++ b/workspaces/backend/internal/models/workspaces/funcs.go
@@ -72,9 +72,8 @@ func NewWorkspaceListItemFromWorkspace(cfg *config.EnvConfig, ws *kubefloworgv1b
 		Activity: Activity{
 			LastActivity: ws.Status.Activity.LastActivity,
 			LastUpdate:   ws.Status.Activity.LastUpdate,
-			// TODO: populate LastProbe when culling is implemented:
-			//       https://github.com/kubeflow/notebooks/issues/38
-			LastProbe: nil,
+			LastProbe:    buildLastProbeInfo(ws.Status.Activity.LastProbe),
+			Rules:        buildActivityRules(&ws.Status.Activity),
 		},
 		Services: buildServices(ws, wskPodTemplatePorts, imageConfigValue),
 		Audit:    commonCore.NewAuditFromObjectMeta(&ws.ObjectMeta),
@@ -290,4 +289,34 @@ func buildLogoImageRef(cfg *config.EnvConfig, ws *kubefloworgv1beta1.Workspace, 
 		return commonAssets.ImageRef{URL: UnknownLogoURL}
 	}
 	return commonAssets.NewImageRefFromWorkspaceKindAssetLogo(cfg, wsk.Spec.Spawner.Logo, wsk.Status.SpawnerLogo, ws.Spec.Kind)
+}
+
+func buildLastProbeInfo(probe *kubefloworgv1beta1.WorkspaceActivityLastProbe) *LastProbeInfo {
+	if probe == nil {
+		return nil
+	}
+	return &LastProbeInfo{
+		StartTime: probe.StartTime,
+		EndTime:   probe.EndTime,
+		Result:    ProbeResult(probe.Result),
+		Message:   probe.Message,
+	}
+}
+
+func buildActivityRules(activity *kubefloworgv1beta1.WorkspaceActivity) *ActivityRules {
+	if activity == nil || activity.Rules == nil {
+		return nil
+	}
+	var pauseRule *ActivityPauseRule
+	if activity.Rules.PauseWorkspace != nil {
+		pauseRule = &ActivityPauseRule{
+			EligibleAfter: activity.Rules.PauseWorkspace.EligibleAfter,
+		}
+	}
+	if pauseRule == nil {
+		return nil
+	}
+	return &ActivityRules{
+		PauseWorkspace: pauseRule,
+	}
 }

--- a/workspaces/backend/internal/models/workspaces/funcs_test.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_test.go
@@ -18,10 +18,17 @@ package workspaces
 
 import (
 	"testing"
+	"time"
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+)
+
+var (
+	testStartTime     = time.Date(2024, time.March, 14, 16, 55, 3, 0, time.UTC).UnixMilli()
+	testEndTime       = time.Date(2024, time.March, 14, 16, 55, 5, 0, time.UTC).UnixMilli()
+	testEligibleAfter = time.Date(2024, time.February, 12, 0, 0, 0, 0, time.UTC).UnixMilli()
 )
 
 func TestWorkspaces(t *testing.T) {
@@ -36,16 +43,16 @@ var _ = Describe("buildLastProbeInfo", func() {
 
 	It("converts a WorkspaceActivityLastProbe correctly", func() {
 		crdProbe := &kubefloworgv1beta1.WorkspaceActivityLastProbe{
-			StartTime: 1710435303000,
-			EndTime:   1710435305000,
+			StartTime: testStartTime,
+			EndTime:   testEndTime,
 			Result:    kubefloworgv1beta1.WorkspaceProbeResultSuccess,
 			Message:   "Jupyter probe succeeded",
 		}
 
 		apiProbe := buildLastProbeInfo(crdProbe)
 		Expect(apiProbe).NotTo(BeNil())
-		Expect(apiProbe.StartTime).To(Equal(int64(1710435303000)))
-		Expect(apiProbe.EndTime).To(Equal(int64(1710435305000)))
+		Expect(apiProbe.StartTime).To(Equal(testStartTime))
+		Expect(apiProbe.EndTime).To(Equal(testEndTime))
 		Expect(apiProbe.Result).To(Equal(ProbeResultSuccess))
 		Expect(apiProbe.Message).To(Equal("Jupyter probe succeeded"))
 	})
@@ -64,7 +71,7 @@ var _ = Describe("buildActivityRules", func() {
 		activity := &kubefloworgv1beta1.WorkspaceActivity{
 			Rules: &kubefloworgv1beta1.WorkspaceActivityRules{
 				PauseWorkspace: &kubefloworgv1beta1.WorkspaceActivityPauseRule{
-					EligibleAfter: 1707667200000,
+					EligibleAfter: testEligibleAfter,
 				},
 			},
 		}
@@ -72,6 +79,6 @@ var _ = Describe("buildActivityRules", func() {
 		rules := buildActivityRules(activity)
 		Expect(rules).NotTo(BeNil())
 		Expect(rules.PauseWorkspace).NotTo(BeNil())
-		Expect(rules.PauseWorkspace.EligibleAfter).To(Equal(int64(1707667200000)))
+		Expect(rules.PauseWorkspace.EligibleAfter).To(Equal(testEligibleAfter))
 	})
 })

--- a/workspaces/backend/internal/models/workspaces/funcs_test.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_test.go
@@ -56,6 +56,22 @@ var _ = Describe("buildLastProbeInfo", func() {
 		Expect(apiProbe.Result).To(Equal(ProbeResultSuccess))
 		Expect(apiProbe.Message).To(Equal("Jupyter probe succeeded"))
 	})
+
+	It("converts a failed WorkspaceActivityLastProbe correctly", func() {
+		crdProbe := &kubefloworgv1beta1.WorkspaceActivityLastProbe{
+			StartTime: testStartTime,
+			EndTime:   testEndTime,
+			Result:    kubefloworgv1beta1.WorkspaceProbeResultFailure,
+			Message:   "Jupyter probe failed",
+		}
+
+		apiProbe := buildLastProbeInfo(crdProbe)
+		Expect(apiProbe).NotTo(BeNil())
+		Expect(apiProbe.StartTime).To(Equal(testStartTime))
+		Expect(apiProbe.EndTime).To(Equal(testEndTime))
+		Expect(apiProbe.Result).To(Equal(ProbeResultFailure))
+		Expect(apiProbe.Message).To(Equal("Jupyter probe failed"))
+	})
 })
 
 var _ = Describe("buildActivityRules", func() {

--- a/workspaces/backend/internal/models/workspaces/funcs_test.go
+++ b/workspaces/backend/internal/models/workspaces/funcs_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaces
+
+import (
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorkspaces(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workspaces Models Suite")
+}
+
+var _ = Describe("buildLastProbeInfo", func() {
+	It("returns nil when probe is nil", func() {
+		Expect(buildLastProbeInfo(nil)).To(BeNil())
+	})
+
+	It("converts a WorkspaceActivityLastProbe correctly", func() {
+		crdProbe := &kubefloworgv1beta1.WorkspaceActivityLastProbe{
+			StartTime: 1710435303000,
+			EndTime:   1710435305000,
+			Result:    kubefloworgv1beta1.WorkspaceProbeResultSuccess,
+			Message:   "Jupyter probe succeeded",
+		}
+
+		apiProbe := buildLastProbeInfo(crdProbe)
+		Expect(apiProbe).NotTo(BeNil())
+		Expect(apiProbe.StartTime).To(Equal(int64(1710435303000)))
+		Expect(apiProbe.EndTime).To(Equal(int64(1710435305000)))
+		Expect(apiProbe.Result).To(Equal(ProbeResultSuccess))
+		Expect(apiProbe.Message).To(Equal("Jupyter probe succeeded"))
+	})
+})
+
+var _ = Describe("buildActivityRules", func() {
+	It("returns nil when activity or pause rule is nil", func() {
+		Expect(buildActivityRules(nil)).To(BeNil())
+		Expect(buildActivityRules(&kubefloworgv1beta1.WorkspaceActivity{})).To(BeNil())
+		Expect(buildActivityRules(&kubefloworgv1beta1.WorkspaceActivity{
+			Rules: &kubefloworgv1beta1.WorkspaceActivityRules{},
+		})).To(BeNil())
+	})
+
+	It("returns converted ActivityRules with pauseWorkspace rule", func() {
+		activity := &kubefloworgv1beta1.WorkspaceActivity{
+			Rules: &kubefloworgv1beta1.WorkspaceActivityRules{
+				PauseWorkspace: &kubefloworgv1beta1.WorkspaceActivityPauseRule{
+					EligibleAfter: 1707667200000,
+				},
+			},
+		}
+
+		rules := buildActivityRules(activity)
+		Expect(rules).NotTo(BeNil())
+		Expect(rules.PauseWorkspace).NotTo(BeNil())
+		Expect(rules.PauseWorkspace.EligibleAfter).To(Equal(int64(1707667200000)))
+	})
+})

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -104,6 +104,7 @@ type Activity struct {
 	LastActivity int64          `json:"lastActivity"` // Unix Epoch time
 	LastUpdate   int64          `json:"lastUpdate"`   // Unix Epoch time
 	LastProbe    *LastProbeInfo `json:"lastProbe,omitempty"`
+	Rules        *ActivityRules `json:"rules,omitempty"`
 }
 
 type LastProbeInfo struct {
@@ -120,6 +121,14 @@ const (
 	ProbeResultFailure ProbeResult = "Failure"
 	ProbeResultTimeout ProbeResult = "Timeout"
 )
+
+type ActivityRules struct {
+	PauseWorkspace *ActivityPauseRule `json:"pauseWorkspace,omitempty"`
+}
+
+type ActivityPauseRule struct {
+	EligibleAfter int64 `json:"eligibleAfter"`
+}
 
 type Service struct {
 	HttpService *HttpService `json:"httpService,omitempty"`

--- a/workspaces/backend/internal/models/workspaces/types.go
+++ b/workspaces/backend/internal/models/workspaces/types.go
@@ -30,17 +30,18 @@ import (
 type WorkspaceListItem struct {
 	Name string `json:"name"`
 	// DisplayName is an optional human-readable name for the workspace.
-	DisplayName   string                            `json:"displayName,omitempty"`
-	Namespace     string                            `json:"namespace"`
-	WorkspaceKind WorkspaceKindInfo                 `json:"workspaceKind"`
-	Paused        bool                              `json:"paused"`
-	PausedTime    int64                             `json:"pausedTime"`
-	State         kubefloworgv1beta1.WorkspaceState `json:"state"`
-	StateMessage  string                            `json:"stateMessage"`
-	PodTemplate   PodTemplate                       `json:"podTemplate"`
-	Activity      Activity                          `json:"activity"`
-	Services      []Service                         `json:"services"`
-	Audit         commonCore.Audit                  `json:"audit"`
+	DisplayName     string                            `json:"displayName,omitempty"`
+	Namespace       string                            `json:"namespace"`
+	WorkspaceKind   WorkspaceKindInfo                 `json:"workspaceKind"`
+	Paused          bool                              `json:"paused"`
+	PausedTime      int64                             `json:"pausedTime"`      // Unix Epoch time in milliseconds
+	LastRunningTime int64                             `json:"lastRunningTime"` // Unix Epoch time in milliseconds
+	State           kubefloworgv1beta1.WorkspaceState `json:"state"`
+	StateMessage    string                            `json:"stateMessage"`
+	PodTemplate     PodTemplate                       `json:"podTemplate"`
+	Activity        Activity                          `json:"activity"`
+	Services        []Service                         `json:"services"`
+	Audit           commonCore.Audit                  `json:"audit"`
 }
 
 type WorkspaceKindInfo struct {
@@ -101,8 +102,8 @@ const (
 )
 
 type Activity struct {
-	LastActivity int64          `json:"lastActivity"` // Unix Epoch time
-	LastUpdate   int64          `json:"lastUpdate"`   // Unix Epoch time
+	LastActivity int64          `json:"lastActivity"` // Unix Epoch time in milliseconds
+	LastUpdate   int64          `json:"lastUpdate"`   // Unix Epoch time in milliseconds
 	LastProbe    *LastProbeInfo `json:"lastProbe,omitempty"`
 	Rules        *ActivityRules `json:"rules,omitempty"`
 }
@@ -127,7 +128,7 @@ type ActivityRules struct {
 }
 
 type ActivityPauseRule struct {
-	EligibleAfter int64 `json:"eligibleAfter"`
+	EligibleAfter int64 `json:"eligibleAfter"` // Unix Epoch time in milliseconds
 }
 
 type Service struct {

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -6972,6 +6972,111 @@ const docTemplate = `{
                 "WorkspaceStateUnknown"
             ]
         },
+        "workspacekinds.ActivityProbe": {
+            "type": "object",
+            "required": [
+                "minProbeIntervalSeconds",
+                "probeIntervalSeconds"
+            ],
+            "properties": {
+                "exec": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbeExec"
+                },
+                "jupyter": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbeJupyter"
+                },
+                "minProbeIntervalSeconds": {
+                    "type": "integer"
+                },
+                "probeIntervalSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.ActivityProbeExec": {
+            "type": "object",
+            "required": [
+                "script",
+                "timeoutSeconds"
+            ],
+            "properties": {
+                "script": {
+                    "type": "string"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.ActivityProbeJupyter": {
+            "type": "object",
+            "required": [
+                "lastActivity",
+                "portId"
+            ],
+            "properties": {
+                "lastActivity": {
+                    "type": "boolean"
+                },
+                "portId": {
+                    "type": "string"
+                }
+            }
+        },
+        "workspacekinds.ActivityRule": {
+            "type": "object",
+            "required": [
+                "config",
+                "effect"
+            ],
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/workspacekinds.ActivityRuleConfig"
+                },
+                "effect": {
+                    "$ref": "#/definitions/workspacekinds.ActivityRuleEffect"
+                },
+                "match": {
+                    "$ref": "#/definitions/workspacekinds.ActivityRuleMatch"
+                }
+            }
+        },
+        "workspacekinds.ActivityRuleConfig": {
+            "type": "object",
+            "required": [
+                "secondsSinceActive"
+            ],
+            "properties": {
+                "minRunningSeconds": {
+                    "type": "integer"
+                },
+                "secondsSinceActive": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.ActivityRuleEffect": {
+            "type": "object",
+            "required": [
+                "pauseWorkspace"
+            ],
+            "properties": {
+                "pauseWorkspace": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "workspacekinds.ActivityRuleMatch": {
+            "type": "object",
+            "properties": {
+                "matchNamespace": {
+                    "$ref": "#/definitions/workspacekinds.MatchNamespace"
+                },
+                "matchPodConfig": {
+                    "$ref": "#/definitions/workspacekinds.MatchPodConfig"
+                }
+            }
+        },
         "workspacekinds.ClusterKindMetrics": {
             "type": "object",
             "required": [
@@ -6980,6 +7085,28 @@ const docTemplate = `{
             "properties": {
                 "workspacesCount": {
                     "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.MatchNamespace": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "$ref": "#/definitions/v1.LabelSelector"
+                }
+            }
+        },
+        "workspacekinds.MatchPodConfig": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "$ref": "#/definitions/v1.LabelSelector"
                 }
             }
         },
@@ -7012,6 +7139,9 @@ const docTemplate = `{
                 "volumeMounts"
             ],
             "properties": {
+                "activityProbe": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbe"
+                },
                 "options": {
                     "description": "TODO: remove once frontend migrates to the new listValues endpoint for both create/update and wsk admin views",
                     "allOf": [
@@ -7074,6 +7204,12 @@ const docTemplate = `{
                 "restrictions"
             ],
             "properties": {
+                "activityRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspacekinds.ActivityRule"
+                    }
+                },
                 "clusterMetrics": {
                     "$ref": "#/definitions/workspacekinds.ClusterKindMetrics"
                 },
@@ -7146,6 +7282,28 @@ const docTemplate = `{
                 "lastUpdate": {
                     "description": "Unix Epoch time",
                     "type": "integer"
+                },
+                "rules": {
+                    "$ref": "#/definitions/workspaces.ActivityRules"
+                }
+            }
+        },
+        "workspaces.ActivityPauseRule": {
+            "type": "object",
+            "required": [
+                "eligibleAfter"
+            ],
+            "properties": {
+                "eligibleAfter": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspaces.ActivityRules": {
+            "type": "object",
+            "properties": {
+                "pauseWorkspace": {
+                    "$ref": "#/definitions/workspaces.ActivityPauseRule"
                 }
             }
         },

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -6979,31 +6979,16 @@ const docTemplate = `{
                 "probeIntervalSeconds"
             ],
             "properties": {
-                "exec": {
-                    "$ref": "#/definitions/workspacekinds.ActivityProbeExec"
-                },
                 "jupyter": {
                     "$ref": "#/definitions/workspacekinds.ActivityProbeJupyter"
                 },
                 "minProbeIntervalSeconds": {
                     "type": "integer"
                 },
-                "probeIntervalSeconds": {
-                    "type": "integer"
-                }
-            }
-        },
-        "workspacekinds.ActivityProbeExec": {
-            "type": "object",
-            "required": [
-                "script",
-                "timeoutSeconds"
-            ],
-            "properties": {
-                "script": {
-                    "type": "string"
+                "podExec": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbePodExec"
                 },
-                "timeoutSeconds": {
+                "probeIntervalSeconds": {
                     "type": "integer"
                 }
             }
@@ -7020,6 +7005,17 @@ const docTemplate = `{
                 },
                 "portId": {
                     "type": "string"
+                }
+            }
+        },
+        "workspacekinds.ActivityProbePodExec": {
+            "type": "object",
+            "required": [
+                "timeoutSeconds"
+            ],
+            "properties": {
+                "timeoutSeconds": {
+                    "type": "integer"
                 }
             }
         },
@@ -7273,14 +7269,14 @@ const docTemplate = `{
             ],
             "properties": {
                 "lastActivity": {
-                    "description": "Unix Epoch time",
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 },
                 "lastProbe": {
                     "$ref": "#/definitions/workspaces.LastProbeInfo"
                 },
                 "lastUpdate": {
-                    "description": "Unix Epoch time",
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 },
                 "rules": {
@@ -7295,6 +7291,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "eligibleAfter": {
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 }
             }
@@ -7684,6 +7681,7 @@ const docTemplate = `{
             "required": [
                 "activity",
                 "audit",
+                "lastRunningTime",
                 "name",
                 "namespace",
                 "paused",
@@ -7705,6 +7703,10 @@ const docTemplate = `{
                     "description": "DisplayName is an optional human-readable name for the workspace.",
                     "type": "string"
                 },
+                "lastRunningTime": {
+                    "description": "Unix Epoch time in milliseconds",
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -7715,6 +7717,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "pausedTime": {
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 },
                 "podTemplate": {

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -6977,31 +6977,16 @@
                 "probeIntervalSeconds"
             ],
             "properties": {
-                "exec": {
-                    "$ref": "#/definitions/workspacekinds.ActivityProbeExec"
-                },
                 "jupyter": {
                     "$ref": "#/definitions/workspacekinds.ActivityProbeJupyter"
                 },
                 "minProbeIntervalSeconds": {
                     "type": "integer"
                 },
-                "probeIntervalSeconds": {
-                    "type": "integer"
-                }
-            }
-        },
-        "workspacekinds.ActivityProbeExec": {
-            "type": "object",
-            "required": [
-                "script",
-                "timeoutSeconds"
-            ],
-            "properties": {
-                "script": {
-                    "type": "string"
+                "podExec": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbePodExec"
                 },
-                "timeoutSeconds": {
+                "probeIntervalSeconds": {
                     "type": "integer"
                 }
             }
@@ -7018,6 +7003,17 @@
                 },
                 "portId": {
                     "type": "string"
+                }
+            }
+        },
+        "workspacekinds.ActivityProbePodExec": {
+            "type": "object",
+            "required": [
+                "timeoutSeconds"
+            ],
+            "properties": {
+                "timeoutSeconds": {
+                    "type": "integer"
                 }
             }
         },
@@ -7271,14 +7267,14 @@
             ],
             "properties": {
                 "lastActivity": {
-                    "description": "Unix Epoch time",
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 },
                 "lastProbe": {
                     "$ref": "#/definitions/workspaces.LastProbeInfo"
                 },
                 "lastUpdate": {
-                    "description": "Unix Epoch time",
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 },
                 "rules": {
@@ -7293,6 +7289,7 @@
             ],
             "properties": {
                 "eligibleAfter": {
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 }
             }
@@ -7682,6 +7679,7 @@
             "required": [
                 "activity",
                 "audit",
+                "lastRunningTime",
                 "name",
                 "namespace",
                 "paused",
@@ -7703,6 +7701,10 @@
                     "description": "DisplayName is an optional human-readable name for the workspace.",
                     "type": "string"
                 },
+                "lastRunningTime": {
+                    "description": "Unix Epoch time in milliseconds",
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -7713,6 +7715,7 @@
                     "type": "boolean"
                 },
                 "pausedTime": {
+                    "description": "Unix Epoch time in milliseconds",
                     "type": "integer"
                 },
                 "podTemplate": {

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -6970,6 +6970,111 @@
                 "WorkspaceStateUnknown"
             ]
         },
+        "workspacekinds.ActivityProbe": {
+            "type": "object",
+            "required": [
+                "minProbeIntervalSeconds",
+                "probeIntervalSeconds"
+            ],
+            "properties": {
+                "exec": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbeExec"
+                },
+                "jupyter": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbeJupyter"
+                },
+                "minProbeIntervalSeconds": {
+                    "type": "integer"
+                },
+                "probeIntervalSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.ActivityProbeExec": {
+            "type": "object",
+            "required": [
+                "script",
+                "timeoutSeconds"
+            ],
+            "properties": {
+                "script": {
+                    "type": "string"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.ActivityProbeJupyter": {
+            "type": "object",
+            "required": [
+                "lastActivity",
+                "portId"
+            ],
+            "properties": {
+                "lastActivity": {
+                    "type": "boolean"
+                },
+                "portId": {
+                    "type": "string"
+                }
+            }
+        },
+        "workspacekinds.ActivityRule": {
+            "type": "object",
+            "required": [
+                "config",
+                "effect"
+            ],
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/workspacekinds.ActivityRuleConfig"
+                },
+                "effect": {
+                    "$ref": "#/definitions/workspacekinds.ActivityRuleEffect"
+                },
+                "match": {
+                    "$ref": "#/definitions/workspacekinds.ActivityRuleMatch"
+                }
+            }
+        },
+        "workspacekinds.ActivityRuleConfig": {
+            "type": "object",
+            "required": [
+                "secondsSinceActive"
+            ],
+            "properties": {
+                "minRunningSeconds": {
+                    "type": "integer"
+                },
+                "secondsSinceActive": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.ActivityRuleEffect": {
+            "type": "object",
+            "required": [
+                "pauseWorkspace"
+            ],
+            "properties": {
+                "pauseWorkspace": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "workspacekinds.ActivityRuleMatch": {
+            "type": "object",
+            "properties": {
+                "matchNamespace": {
+                    "$ref": "#/definitions/workspacekinds.MatchNamespace"
+                },
+                "matchPodConfig": {
+                    "$ref": "#/definitions/workspacekinds.MatchPodConfig"
+                }
+            }
+        },
         "workspacekinds.ClusterKindMetrics": {
             "type": "object",
             "required": [
@@ -6978,6 +7083,28 @@
             "properties": {
                 "workspacesCount": {
                     "type": "integer"
+                }
+            }
+        },
+        "workspacekinds.MatchNamespace": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "$ref": "#/definitions/v1.LabelSelector"
+                }
+            }
+        },
+        "workspacekinds.MatchPodConfig": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "$ref": "#/definitions/v1.LabelSelector"
                 }
             }
         },
@@ -7010,6 +7137,9 @@
                 "volumeMounts"
             ],
             "properties": {
+                "activityProbe": {
+                    "$ref": "#/definitions/workspacekinds.ActivityProbe"
+                },
                 "options": {
                     "description": "TODO: remove once frontend migrates to the new listValues endpoint for both create/update and wsk admin views",
                     "allOf": [
@@ -7072,6 +7202,12 @@
                 "restrictions"
             ],
             "properties": {
+                "activityRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspacekinds.ActivityRule"
+                    }
+                },
                 "clusterMetrics": {
                     "$ref": "#/definitions/workspacekinds.ClusterKindMetrics"
                 },
@@ -7144,6 +7280,28 @@
                 "lastUpdate": {
                     "description": "Unix Epoch time",
                     "type": "integer"
+                },
+                "rules": {
+                    "$ref": "#/definitions/workspaces.ActivityRules"
+                }
+            }
+        },
+        "workspaces.ActivityPauseRule": {
+            "type": "object",
+            "required": [
+                "eligibleAfter"
+            ],
+            "properties": {
+                "eligibleAfter": {
+                    "type": "integer"
+                }
+            }
+        },
+        "workspaces.ActivityRules": {
+            "type": "object",
+            "properties": {
+                "pauseWorkspace": {
+                    "$ref": "#/definitions/workspaces.ActivityPauseRule"
                 }
             }
         },

--- a/workspaces/controller/api/v1beta1/workspacekind_types.go
+++ b/workspaces/controller/api/v1beta1/workspacekind_types.go
@@ -23,10 +23,19 @@ import (
 
 // Important: Run "make" to regenerate code after modifying this file
 
-// DefaultProbeIntervalSeconds is the fallback probe interval used when no activityProbe
-// is configured. This must stay in sync with the +kubebuilder:default marker on
-// ActivityProbe.ProbeIntervalSeconds.
-const DefaultProbeIntervalSeconds int32 = 3600
+// Default values for ActivityProbe fields. These MUST stay in sync with the
+// corresponding +kubebuilder:default markers on the ActivityProbe types, so that
+// the controller and the API server agree on the effective value when a field is unset.
+const (
+	// DefaultProbeIntervalSeconds is the fallback for ActivityProbe.ProbeIntervalSeconds.
+	DefaultProbeIntervalSeconds int32 = 3600
+
+	// DefaultMinProbeIntervalSeconds is the fallback for ActivityProbe.MinProbeIntervalSeconds.
+	DefaultMinProbeIntervalSeconds int32 = 300
+
+	// DefaultPodExecTimeoutSeconds is the fallback for ActivityProbePodExec.TimeoutSeconds.
+	DefaultPodExecTimeoutSeconds int32 = 60
+)
 
 /*
 ===============================================================================


### PR DESCRIPTION
 closes: #868

Implemented the following:
1. Update API models to include activity rules configuration from WorkspaceKind and enhanced activity
status from Workspace
1. Implement conversion logic to transform controller CRD types to API response models
1. Regenerate OpenAPI documentation for updated endpoints

Did not include the following because the schema has changed, and these are not mentioned in the [design doc](https://github.com/kubeflow/notebooks/issues/839#issuecomment-4270494091):
1. Expose frontend-consumable fields such as idle duration, time until culling, and warning thresholds
