### PR TITLE
chore: remove serviceAccount.name from WorkspaceKind CRD

### DIFF
--- a/workspaces/backend/api/suite_test.go
+++ b/workspaces/backend/api/suite_test.go
@@ -224,9 +224,6 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 			},
 			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspaceKindPodMetadata{},
-				ServiceAccount: kubefloworgv1beta1.WorkspaceKindServiceAccount{
-					Name: "default-editor",
-				},
 				ActivityProbe: &kubefloworgv1beta1.ActivityProbe{
 					MinProbeIntervalSeconds: new(int32(300)),
 					ProbeIntervalSeconds:    new(int32(3600)),

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -356,8 +356,6 @@ spec:
     logo:
       url: "https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg"
   podTemplate:
-    serviceAccount:
-      name: "default-editor"
     volumeMounts:
       home: "/home/jovyan"
     ports:
@@ -990,7 +988,6 @@ metadata:
 			By("verifying immutable fields are unchanged in K8s")
 			wsk := &kubefloworgv1beta1.WorkspaceKind{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wskName}, wsk)).To(Succeed())
-			Expect(wsk.Spec.PodTemplate.ServiceAccount.Name).To(Equal("default-editor"))
 			Expect(wsk.Spec.PodTemplate.VolumeMounts.Home).To(Equal("/home/jovyan"))
 		})
 

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -6721,7 +6721,6 @@ const docTemplate = `{
             "required": [
                 "options",
                 "ports",
-                "serviceAccount",
                 "volumeMounts"
             ],
             "properties": {
@@ -6802,7 +6801,7 @@ const docTemplate = `{
                     ]
                 },
                 "serviceAccount": {
-                    "description": "service account configs for Workspace Pods",
+                    "description": "service account configs for Workspace Pods\n - currently has no fields, the ServiceAccount used by Workspace Pods is\n   hardcoded to \"default-editor\" in the controller\n - this ServiceAccount MUST already exist in the Namespace of the Workspace,\n   the controller will NOT create it\n+kubebuilder:validation:Optional",
                     "allOf": [
                         {
                             "$ref": "#/definitions/v1beta1.WorkspaceKindServiceAccount"
@@ -6883,16 +6882,7 @@ const docTemplate = `{
             }
         },
         "v1beta1.WorkspaceKindServiceAccount": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "description": "the name of the ServiceAccount (NOT MUTABLE)\n - this Service Account MUST already exist in the Namespace\n   of the Workspace, the controller will NOT create it\n - we will not show this WorkspaceKind in the Spawner UI\n   if the SA does not exist in the Namespace\n+kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"ServiceAccount 'name' is immutable\"\n+kubebuilder:example=\"default-editor\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                    "type": "string"
-                }
-            }
+            "type": "object"
         },
         "v1beta1.WorkspaceKindSpawner": {
             "type": "object",

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -6719,7 +6719,6 @@
             "required": [
                 "options",
                 "ports",
-                "serviceAccount",
                 "volumeMounts"
             ],
             "properties": {
@@ -6800,7 +6799,7 @@
                     ]
                 },
                 "serviceAccount": {
-                    "description": "service account configs for Workspace Pods",
+                    "description": "service account configs for Workspace Pods\n - currently has no fields, the ServiceAccount used by Workspace Pods is\n   hardcoded to \"default-editor\" in the controller\n - this ServiceAccount MUST already exist in the Namespace of the Workspace,\n   the controller will NOT create it\n+kubebuilder:validation:Optional",
                     "allOf": [
                         {
                             "$ref": "#/definitions/v1beta1.WorkspaceKindServiceAccount"
@@ -6881,16 +6880,7 @@
             }
         },
         "v1beta1.WorkspaceKindServiceAccount": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "description": "the name of the ServiceAccount (NOT MUTABLE)\n - this Service Account MUST already exist in the Namespace\n   of the Workspace, the controller will NOT create it\n - we will not show this WorkspaceKind in the Spawner UI\n   if the SA does not exist in the Namespace\n+kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"ServiceAccount 'name' is immutable\"\n+kubebuilder:example=\"default-editor\"\n+kubebuilder:validation:MinLength:=1\n+kubebuilder:validation:MaxLength:=253\n+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                    "type": "string"
-                }
-            }
+            "type": "object"
         },
         "v1beta1.WorkspaceKindSpawner": {
             "type": "object",

--- a/workspaces/controller/api/v1beta1/workspacekind_types.go
+++ b/workspaces/controller/api/v1beta1/workspacekind_types.go
@@ -230,7 +230,12 @@ type WorkspaceKindPodTemplate struct {
 	PodMetadata *WorkspaceKindPodMetadata `json:"podMetadata,omitempty"`
 
 	// service account configs for Workspace Pods
-	ServiceAccount WorkspaceKindServiceAccount `json:"serviceAccount"`
+	//  - currently has no fields, the ServiceAccount used by Workspace Pods is
+	//    hardcoded to "default-editor" in the controller
+	//  - this ServiceAccount MUST already exist in the Namespace of the Workspace,
+	//    the controller will NOT create it
+	// +kubebuilder:validation:Optional
+	ServiceAccount *WorkspaceKindServiceAccount `json:"serviceAccount,omitempty"`
 
 	// activityProbe configs to determine Workspace activity (MUTABLE)
 	// +kubebuilder:validation:Optional
@@ -318,18 +323,10 @@ type WorkspaceKindPodMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// WorkspaceKindServiceAccount is currently empty, fields will be added once
+// Workspaces get their own controller-managed ServiceAccounts.
+// See https://github.com/kubeflow/notebooks/issues/1257
 type WorkspaceKindServiceAccount struct {
-	// the name of the ServiceAccount (NOT MUTABLE)
-	//  - this Service Account MUST already exist in the Namespace
-	//    of the Workspace, the controller will NOT create it
-	//  - we will not show this WorkspaceKind in the Spawner UI
-	//    if the SA does not exist in the Namespace
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ServiceAccount 'name' is immutable"
-	// +kubebuilder:example="default-editor"
-	// +kubebuilder:validation:MinLength:=1
-	// +kubebuilder:validation:MaxLength:=253
-	// +kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-	Name string `json:"name"`
 }
 
 // ActivityProbe defines how to detect recent user activity in a Workspace

--- a/workspaces/controller/api/v1beta1/zz_generated.deepcopy.go
+++ b/workspaces/controller/api/v1beta1/zz_generated.deepcopy.go
@@ -1073,7 +1073,11 @@ func (in *WorkspaceKindPodTemplate) DeepCopyInto(out *WorkspaceKindPodTemplate) 
 		*out = new(WorkspaceKindPodMetadata)
 		(*in).DeepCopyInto(*out)
 	}
-	out.ServiceAccount = in.ServiceAccount
+	if in.ServiceAccount != nil {
+		in, out := &in.ServiceAccount, &out.ServiceAccount
+		*out = new(WorkspaceKindServiceAccount)
+		**out = **in
+	}
 	if in.ActivityProbe != nil {
 		in, out := &in.ActivityProbe, &out.ActivityProbe
 		*out = new(ActivityProbe)

--- a/workspaces/controller/internal/controller/suite_test.go
+++ b/workspaces/controller/internal/controller/suite_test.go
@@ -248,9 +248,6 @@ func NewExampleWorkspaceKind1(name string) *kubefloworgv1beta1.WorkspaceKind {
 			},
 			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspaceKindPodMetadata{},
-				ServiceAccount: kubefloworgv1beta1.WorkspaceKindServiceAccount{
-					Name: "default-editor",
-				},
 				ActivityProbe: &kubefloworgv1beta1.ActivityProbe{
 					MinProbeIntervalSeconds: new(int32(300)),
 					ProbeIntervalSeconds:    new(int32(3600)),

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -60,6 +60,12 @@ const (
 	// pod template constants
 	workspacePodTemplateContainerName = "main"
 
+	// the ServiceAccount used by all Workspace Pods, it MUST already exist in the
+	// Namespace of the Workspace, the controller will NOT create it
+	// TODO: replace with per-Workspace ServiceAccounts
+	//       https://github.com/kubeflow/notebooks/issues/1257
+	workspaceServiceAccountName = "default-editor"
+
 	// lengths for resource names
 	generateNameSuffixLength    = 6
 	maxServiceNameLength        = 63
@@ -909,7 +915,7 @@ func generateStatefulSet(workspace *kubefloworgv1beta1.Workspace, workspaceKind 
 					},
 					NodeSelector:       podConfigSpec.NodeSelector,
 					SecurityContext:    workspaceKind.Spec.PodTemplate.SecurityContext,
-					ServiceAccountName: workspaceKind.Spec.PodTemplate.ServiceAccount.Name,
+					ServiceAccountName: workspaceServiceAccountName,
 					Tolerations:        podConfigSpec.Tolerations,
 					Volumes:            volumes,
 				},

--- a/workspaces/controller/internal/controller/workspace_controller_test.go
+++ b/workspaces/controller/internal/controller/workspace_controller_test.go
@@ -175,8 +175,10 @@ var _ = Describe("Workspace Controller", func() {
 				return statefulSetList.Items, nil
 			}, timeout, interval).Should(HaveLen(1))
 
-			// TODO: use this to get the StatefulSet
-			// statefulSet := statefulSetList.Items[0]
+			statefulSet := statefulSetList.Items[0]
+
+			By("running the Workspace Pods as the hardcoded ServiceAccount")
+			Expect(statefulSet.Spec.Template.Spec.ServiceAccountName).To(Equal(workspaceServiceAccountName))
 
 			By("creating a Service")
 			serviceList := &corev1.ServiceList{}

--- a/workspaces/controller/internal/controller/workspacekind_controller_test.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller_test.go
@@ -100,13 +100,8 @@ var _ = Describe("WorkspaceKind Controller", func() {
 			Expect(k8sClient.Get(ctx, workspaceKindKey, workspaceKind)).To(Succeed())
 			patch := client.MergeFrom(workspaceKind.DeepCopy())
 
-			By("failing to update the `spec.podTemplate.serviceAccount.name` field")
-			newWorkspaceKind := workspaceKind.DeepCopy()
-			newWorkspaceKind.Spec.PodTemplate.ServiceAccount.Name = "new-editor"
-			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
-
 			By("failing to update the `spec.podTemplate.volumeMounts.home` field")
-			newWorkspaceKind = workspaceKind.DeepCopy()
+			newWorkspaceKind := workspaceKind.DeepCopy()
 			newWorkspaceKind.Spec.PodTemplate.VolumeMounts.Home = "/home/jovyan/new"
 			Expect(k8sClient.Patch(ctx, newWorkspaceKind, patch)).NotTo(Succeed())
 		})

--- a/workspaces/controller/internal/webhook/suite_test.go
+++ b/workspaces/controller/internal/webhook/suite_test.go
@@ -199,9 +199,6 @@ func NewExampleWorkspaceKind(name string) *kubefloworgv1beta1.WorkspaceKind {
 			},
 			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
 				PodMetadata: &kubefloworgv1beta1.WorkspaceKindPodMetadata{},
-				ServiceAccount: kubefloworgv1beta1.WorkspaceKindServiceAccount{
-					Name: "default-editor",
-				},
 				ActivityProbe: &kubefloworgv1beta1.ActivityProbe{
 					MinProbeIntervalSeconds: new(int32(300)),
 					ProbeIntervalSeconds:    new(int32(3600)),

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspacekinds.yaml
@@ -4874,25 +4874,12 @@ spec:
                         type: object
                     type: object
                   serviceAccount:
-                    description: service account configs for Workspace Pods
-                    properties:
-                      name:
-                        description: |-
-                          the name of the ServiceAccount (NOT MUTABLE)
-                           - this Service Account MUST already exist in the Namespace
-                             of the Workspace, the controller will NOT create it
-                           - we will not show this WorkspaceKind in the Spawner UI
-                             if the SA does not exist in the Namespace
-                        example: default-editor
-                        maxLength: 253
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                        x-kubernetes-validations:
-                        - message: ServiceAccount 'name' is immutable
-                          rule: self == oldSelf
-                    required:
-                    - name
+                    description: |-
+                      service account configs for Workspace Pods
+                       - currently has no fields, the ServiceAccount used by Workspace Pods is
+                         hardcoded to "default-editor" in the controller
+                       - this ServiceAccount MUST already exist in the Namespace of the Workspace,
+                         the controller will NOT create it
                     type: object
                   volumeMounts:
                     description: volume mount paths
@@ -4913,7 +4900,6 @@ spec:
                 required:
                 - options
                 - ports
-                - serviceAccount
                 - volumeMounts
                 type: object
               spawner:

--- a/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml
@@ -47,8 +47,6 @@ spec:
     podMetadata:
       labels: {}
       annotations: {}
-    serviceAccount:
-      name: "default-editor"
     activityProbe:
       minProbeIntervalSeconds: 300
       probeIntervalSeconds: 3600

--- a/workspaces/controller/manifests/kustomize/samples/common/workspace_service_account.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/common/workspace_service_account.yaml
@@ -1,3 +1,8 @@
+## the ServiceAccount used by all WorkspaceKinds
+##  - the name is hardcoded in the controller, so it MUST stay "default-editor"
+##  - the controller will NOT create it, one MUST exist in every Namespace
+##    where Workspaces are created
+##  - see https://github.com/kubeflow/notebooks/issues/1257
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml
@@ -106,17 +106,12 @@ spec:
       annotations:
         my-workspace-kind-annotation: "my-value"
 
-    ## service account configs for Workspace Pods
-    ##
-    serviceAccount:
-
-      ## the name of the ServiceAccount (NOT MUTABLE)
-      ##  - this Service Account MUST already exist in the Namespace
-      ##    of the Workspace, the controller will NOT create it
-      ##  - we will not show this WorkspaceKind in the Spawner UI
-      ##    if the SA does not exist in the Namespace
-      ##
-      name: "default-editor"
+    ## NOTE: Workspace Pods always run as the "default-editor" ServiceAccount,
+    ##       which is hardcoded in the controller and MUST already exist in the
+    ##       Namespace of the Workspace, the controller will NOT create it.
+    ##       Configuration will return under `serviceAccount` once Workspaces get
+    ##       their own controller-managed ServiceAccounts:
+    ##       https://github.com/kubeflow/notebooks/issues/1257
 
     ## activity probe configs (MUTABLE)
     ##  - determines how to detect activity in the Workspace

--- a/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml
+++ b/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml
@@ -48,8 +48,6 @@ spec:
     podMetadata:
       labels: {}
       annotations: {}
-    serviceAccount:
-      name: "default-editor"
     activityProbe:
       minProbeIntervalSeconds: 300
       probeIntervalSeconds: 3600


### PR DESCRIPTION
## Description

Removes `spec.podTemplate.serviceAccount.name` from the WorkspaceKind CRD and hardcodes the ServiceAccount name in the controller instead.

The implementation of per-Workspace ServiceAccounts (#1257) will have the controller create and own a unique ServiceAccount for every Workspace, and repurpose `spec.podTemplate.serviceAccount` to
carry `clusterRoles`. Given the new design a user-supplied `name` is meaningless therefore it would have to be deprecated, ignored, or removed from the CRD *after* the beta release, which would be backwards-incompatible CRD change at a point where we no longer want to make them.

Instead we'll break this now so that #1257 only has to *add* fields to `serviceAccount` later, which is purely additive and hence non-breaking.

## Changes

- drop `name` from `WorkspaceKindServiceAccount`, leaving the struct empty and the `serviceAccount`
  field optional; the immutability CEL rule and validation markers go with it
- add the `workspaceServiceAccountName` constant (`"default-editor"`) to the controller and use it
  when generating the Workspace StatefulSet pod spec
- assert the generated StatefulSet's `ServiceAccountName` in the Workspace controller tests
- drop the `serviceAccount` blocks from the 3 sample WorkspaceKinds, and document in
  `samples/common/workspace_service_account.yaml` that its name is fixed for the time being
- regenerate the CRD, DeepCopy methods, and the backend OpenAPI spec

## Breaking change

WorkspaceKinds that set `spec.podTemplate.serviceAccount.name` are now **rejected** by the API
server, the two lines have to be removed from them:

## Follow-up

The generated frontend client still declares the field. `workspaces/frontend/scripts/swagger.version` pins a merged commit hash, so it can only be bumped once this PR is on `notebooks-v2`.
A follow-up PR will need to bump it, run `npm run generate:api`, and drop `serviceAccount` from the two frontend mocks.
Nothing should break in the meantime since the frontend never had a form field for `serviceAccount`, and `Form/helpers.ts` never set it on the create path.

Relates to #1257

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
