### PR TITLE
feat: Implement filterRules evaluation for /listvalues API

### DIFF
--- a/workspaces/backend/api/workspacekind_podtemplate_options_handler_test.go
+++ b/workspaces/backend/api/workspacekind_podtemplate_options_handler_test.go
@@ -129,7 +129,7 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 				wsk := &kubefloworgv1beta1.WorkspaceKind{}
 				Expect(k8sClient.Get(ctx, workspaceKind1Key, wsk)).To(Succeed())
 				listValuesRequest := &models.ListValuesRequest{Context: listValuesContext}
-				wskModel, err := models.NewPodTemplateOptionsModelFromWorkspaceKind(wsk, listValuesRequest)
+				wskModel, err := models.NewPodTemplateOptionsModelFromWorkspaceKind(wsk, listValuesRequest, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return wskModel
 			}

--- a/workspaces/backend/api/workspacekind_podtemplate_options_handler_test.go
+++ b/workspaces/backend/api/workspacekind_podtemplate_options_handler_test.go
@@ -128,8 +128,18 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			getExpected := func(listValuesContext models.ListValuesContext) *models.PodTemplateOptions {
 				wsk := &kubefloworgv1beta1.WorkspaceKind{}
 				Expect(k8sClient.Get(ctx, workspaceKind1Key, wsk)).To(Succeed())
+
+				// resolve the namespace labels the same way the handler does, so the expected model
+				// reflects any matchNamespace rules rather than assuming an absent namespace context.
+				var namespaceLabels map[string]string
+				if listValuesContext.Namespace != nil {
+					ns := &corev1.Namespace{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: listValuesContext.Namespace.Name}, ns)).To(Succeed())
+					namespaceLabels = ns.Labels
+				}
+
 				listValuesRequest := &models.ListValuesRequest{Context: listValuesContext}
-				wskModel, err := models.NewPodTemplateOptionsModelFromWorkspaceKind(wsk, listValuesRequest, nil)
+				wskModel, err := models.NewPodTemplateOptionsModelFromWorkspaceKind(wsk, listValuesRequest, namespaceLabels)
 				Expect(err).NotTo(HaveOccurred())
 				return wskModel
 			}

--- a/workspaces/backend/internal/filterrules/engine.go
+++ b/workspaces/backend/internal/filterrules/engine.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package filterrules implements the shared, firewall-style (first-match-wins)
+// evaluation engine for WorkspaceKind `spec.filterRules[]`. It is intentionally
+// dependency-light (pure in-memory label matching plus the CRD types) so it can
+// be reused by both the `/listvalues` (#846) and `/workspacekinds` (#847) APIs.
+package filterrules
+
+import (
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
+)
+
+// EvalTarget identifies the single value being evaluated and supplies its own labels.
+type EvalTarget struct {
+	// Scope is the type of value being evaluated (IMAGE_CONFIG, POD_CONFIG, or WORKSPACE_KIND).
+	Scope kubefloworgv1beta1.FilterRuleScope
+
+	// Labels are this value's own `spawner.labels`, used for same-scope match conditions.
+	Labels []kubefloworgv1beta1.OptionSpawnerLabel
+}
+
+// EvalContext holds the request-scoped inputs shared across all evaluations.
+//
+// A nil label map means the corresponding context was NOT provided in the request, so any
+// match condition that requires it is treated as non-matching (conservative: don't hide or
+// deny without full context). A non-nil but empty map means the context was provided but
+// carries no labels.
+type EvalContext struct {
+	// NamespaceLabels are the labels of the namespace the workspace would be created in.
+	// nil when `context.namespace.name` was absent from the request.
+	NamespaceLabels map[string]string
+
+	// ImageConfigLabels are the `spawner.labels` of the imageConfig value selected in the
+	// request. nil when `context.imageConfig.id` was absent. Used for cross-option matching
+	// on non-IMAGE_CONFIG scope rules.
+	ImageConfigLabels map[string]string
+
+	// PodConfigLabels are the `spawner.labels` of the podConfig value selected in the
+	// request. nil when `context.podConfig.id` was absent. Used for cross-option matching
+	// on non-POD_CONFIG scope rules.
+	PodConfigLabels map[string]string
+}
+
+// EvalResult is the outcome of evaluating the filter rules for a single value.
+type EvalResult struct {
+	// UIHide is the `effect.ui.hide` value from the first matching rule.
+	UIHide bool
+
+	// APIHide is the `effect.api.hide` value from the first matching rule.
+	// When true the value must be omitted from the API response entirely.
+	APIHide bool
+
+	// Restrictions holds `deny` and `denyMessage` from the first matching `api.deny` rule.
+	Restrictions common.Restrictions
+}
+
+// Evaluate runs the filter rules over the given target using first-match-wins,
+// firewall-style semantics.
+//
+// Rules are evaluated top-to-bottom. The first rule whose scope matches the target AND all
+// of whose match conditions are satisfied determines the result; no further rules are
+// considered. If no rule matches, the non-restrictive zero-value result is returned
+// (UIHide=false, APIHide=false, Restrictions.Deny=false).
+func Evaluate(rules []kubefloworgv1beta1.FilterRule, target EvalTarget, evalCtx EvalContext) EvalResult {
+	// resolve the target's own labels once for same-scope match conditions
+	targetLabels := spawnerLabelsToMap(target.Labels)
+
+	for i := range rules {
+		rule := &rules[i]
+
+		// skip rules whose scope does not match the value type being evaluated
+		if rule.Scope != target.Scope {
+			continue
+		}
+
+		// evaluate ALL match conditions with AND logic
+		if !allConditionsMatch(rule.Match, target.Scope, targetLabels, evalCtx) {
+			continue
+		}
+
+		// first matching rule wins: build the result from its effect and stop
+		return resultFromEffect(rule.Effect)
+	}
+
+	// no rules matched: non-restrictive default
+	return EvalResult{Restrictions: common.DefaultRestrictions()}
+}
+
+// BuildEvalContext resolves the request-scoped inputs shared across all filter rule evaluations.
+//
+// namespaceLabels are passed through as-is (nil when no namespace context was provided). The
+// imageConfig/podConfig labels are resolved from the `spawner.labels` of the value selected via
+// `context.imageConfig.id` / `context.podConfig.id`, enabling cross-option matching. They remain
+// nil when the corresponding context id is empty or does not match any value.
+func BuildEvalContext(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string, imageConfigID, podConfigID string) EvalContext {
+	evalCtx := EvalContext{
+		NamespaceLabels: namespaceLabels,
+	}
+
+	if imageConfigID != "" {
+		for i := range wsk.Spec.PodTemplate.Options.ImageConfig.Values {
+			value := &wsk.Spec.PodTemplate.Options.ImageConfig.Values[i]
+			if value.Id == imageConfigID {
+				evalCtx.ImageConfigLabels = spawnerLabelsToMap(value.Spawner.Labels)
+				break
+			}
+		}
+	}
+
+	if podConfigID != "" {
+		for i := range wsk.Spec.PodTemplate.Options.PodConfig.Values {
+			value := &wsk.Spec.PodTemplate.Options.PodConfig.Values[i]
+			if value.Id == podConfigID {
+				evalCtx.PodConfigLabels = spawnerLabelsToMap(value.Spawner.Labels)
+				break
+			}
+		}
+	}
+
+	return evalCtx
+}
+
+// allConditionsMatch returns true only if every match condition is satisfied (AND logic).
+func allConditionsMatch(match []kubefloworgv1beta1.FilterRuleMatch, targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) bool {
+	for i := range match {
+		if !conditionMatches(&match[i], targetScope, targetLabels, evalCtx) {
+			return false
+		}
+	}
+	return true
+}
+
+// conditionMatches evaluates a single match condition against the resolved label set.
+//
+// Exactly one of matchNamespace / matchImageConfig / matchPodConfig is set (enforced by the
+// CRD webhook). If the label set required by the condition is absent (nil), the condition is
+// treated as non-matching.
+func conditionMatches(match *kubefloworgv1beta1.FilterRuleMatch, targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) bool {
+	switch {
+	case match.MatchNamespace != nil:
+		return matchSelector(match.MatchNamespace.Selector, evalCtx.NamespaceLabels)
+	case match.MatchImageConfig != nil:
+		return matchSelector(match.MatchImageConfig.Selector, imageConfigLabels(targetScope, targetLabels, evalCtx))
+	case match.MatchPodConfig != nil:
+		return matchSelector(match.MatchPodConfig.Selector, podConfigLabels(targetScope, targetLabels, evalCtx))
+	default:
+		// no recognized condition set: treat as non-matching
+		return false
+	}
+}
+
+// imageConfigLabels resolves which labels a matchImageConfig condition evaluates against.
+// For IMAGE_CONFIG scope evaluation the labels come from the value being evaluated (target);
+// for any other scope they come from the request-selected imageConfig (cross-option matching).
+func imageConfigLabels(targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) map[string]string {
+	if targetScope == kubefloworgv1beta1.FilterRuleScopeImageConfig {
+		return targetLabels
+	}
+	return evalCtx.ImageConfigLabels
+}
+
+// podConfigLabels resolves which labels a matchPodConfig condition evaluates against.
+// For POD_CONFIG scope evaluation the labels come from the value being evaluated (target);
+// for any other scope they come from the request-selected podConfig (cross-option matching).
+func podConfigLabels(targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) map[string]string {
+	if targetScope == kubefloworgv1beta1.FilterRuleScopePodConfig {
+		return targetLabels
+	}
+	return evalCtx.PodConfigLabels
+}
+
+// matchSelector compiles the label selector and evaluates it against the given labels.
+//
+// When targetLabels is nil the required context is absent, so the condition is non-matching
+// regardless of the selector (conservative: don't hide or deny without full context). An
+// invalid selector (which the CRD webhook should already reject) is also non-matching.
+func matchSelector(labelSelector metav1.LabelSelector, targetLabels map[string]string) bool {
+	if targetLabels == nil {
+		return false
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return false
+	}
+
+	return selector.Matches(labels.Set(targetLabels))
+}
+
+// resultFromEffect converts a matched rule's effect into an EvalResult.
+func resultFromEffect(effect kubefloworgv1beta1.FilterRuleEffect) EvalResult {
+	result := EvalResult{Restrictions: common.DefaultRestrictions()}
+
+	if effect.UI != nil {
+		result.UIHide = effect.UI.Hide
+	}
+
+	if effect.API != nil {
+		if effect.API.Hide != nil {
+			result.APIHide = *effect.API.Hide
+		}
+		if effect.API.Deny != nil && *effect.API.Deny {
+			result.Restrictions.Deny = true
+			if effect.API.DenyMessage != nil {
+				result.Restrictions.DenyMessage = &common.DenyMessage{
+					Text: effect.API.DenyMessage.Text,
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// spawnerLabelsToMap converts a slice of CRD spawner labels into a label map suitable for
+// selector matching. It always returns a non-nil map so callers can distinguish "present
+// with no labels" (non-nil empty) from "absent" (nil).
+func spawnerLabelsToMap(spawnerLabels []kubefloworgv1beta1.OptionSpawnerLabel) map[string]string {
+	result := make(map[string]string, len(spawnerLabels))
+	for i := range spawnerLabels {
+		result[spawnerLabels[i].Key] = spawnerLabels[i].Value
+	}
+	return result
+}

--- a/workspaces/backend/internal/filterrules/engine.go
+++ b/workspaces/backend/internal/filterrules/engine.go
@@ -57,6 +57,23 @@ type EvalContext struct {
 	// request. nil when `context.podConfig.id` was absent. Used for cross-option matching
 	// on non-POD_CONFIG scope rules.
 	PodConfigLabels map[string]string
+
+	// compiledRules are the WorkspaceKind's `spec.filterRules[]` with each match condition's
+	// label selector compiled once, so evaluation over many option values does not recompile
+	// the same selectors repeatedly.
+	compiledRules []compiledRule
+}
+
+// compiledRule pairs a filter rule with its match conditions' pre-compiled selectors.
+type compiledRule struct {
+	rule    *kubefloworgv1beta1.FilterRule
+	matches []compiledMatch
+}
+
+// compiledMatch pairs a single match condition with its pre-compiled label selector.
+type compiledMatch struct {
+	match    *kubefloworgv1beta1.FilterRuleMatch
+	selector labels.Selector
 }
 
 // EvalResult is the outcome of evaluating the filter rules for a single value.
@@ -72,32 +89,30 @@ type EvalResult struct {
 	Restrictions common.Restrictions
 }
 
-// Evaluate runs the filter rules over the given target using first-match-wins,
-// firewall-style semantics.
+// Evaluate runs the pre-compiled filter rules over the given target using
+// first-match-wins, firewall-style semantics.
 //
 // Rules are evaluated top-to-bottom. The first rule whose scope matches the target AND all
 // of whose match conditions are satisfied determines the result; no further rules are
 // considered. If no rule matches, the non-restrictive zero-value result is returned
 // (UIHide=false, APIHide=false, Restrictions.Deny=false).
-func Evaluate(rules []kubefloworgv1beta1.FilterRule, target EvalTarget, evalCtx EvalContext) EvalResult {
+func Evaluate(target EvalTarget, evalCtx EvalContext) EvalResult {
 	// resolve the target's own labels once for same-scope match conditions
 	targetLabels := spawnerLabelsToMap(target.Labels)
 
-	for i := range rules {
-		rule := &rules[i]
-
+	for _, cr := range evalCtx.compiledRules {
 		// skip rules whose scope does not match the value type being evaluated
-		if rule.Scope != target.Scope {
+		if cr.rule.Scope != target.Scope {
 			continue
 		}
 
 		// evaluate ALL match conditions with AND logic
-		if !allConditionsMatch(rule.Match, target.Scope, targetLabels, evalCtx) {
+		if !allConditionsMatch(cr.matches, target.Scope, targetLabels, evalCtx) {
 			continue
 		}
 
 		// first matching rule wins: build the result from its effect and stop
-		return resultFromEffect(rule.Effect)
+		return resultFromEffect(cr.rule.Effect)
 	}
 
 	// no rules matched: non-restrictive default
@@ -113,6 +128,7 @@ func Evaluate(rules []kubefloworgv1beta1.FilterRule, target EvalTarget, evalCtx 
 func BuildEvalContext(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string, imageConfigID, podConfigID string) EvalContext {
 	evalCtx := EvalContext{
 		NamespaceLabels: namespaceLabels,
+		compiledRules:   compileRules(wsk.Spec.FilterRules),
 	}
 
 	if imageConfigID != "" {
@@ -138,29 +154,84 @@ func BuildEvalContext(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map
 	return evalCtx
 }
 
-// allConditionsMatch returns true only if every match condition is satisfied (AND logic).
-func allConditionsMatch(match []kubefloworgv1beta1.FilterRuleMatch, targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) bool {
-	for i := range match {
-		if !conditionMatches(&match[i], targetScope, targetLabels, evalCtx) {
+// compileRules pre-compiles the label selector of every match condition in the given rules,
+// so the (potentially many) per-value evaluations reuse the compiled selectors instead of
+// recompiling them each time. Conditions whose selector fails to compile are dropped, so an
+// invalid condition is ignored while the rule's remaining conditions still apply.
+func compileRules(rules []kubefloworgv1beta1.FilterRule) []compiledRule {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	compiled := make([]compiledRule, 0, len(rules))
+	for _, rule := range rules {
+		matches := make([]compiledMatch, 0, len(rule.Match))
+		for _, match := range rule.Match {
+			selector, valid := compileSelector(&match)
+			if !valid {
+				continue
+			}
+			matches = append(matches, compiledMatch{
+				match:    &match,
+				selector: selector,
+			})
+		}
+		if len(matches) == 0 {
+			continue
+		}
+		compiled = append(compiled, compiledRule{rule: &rule, matches: matches})
+	}
+	return compiled
+}
+
+// compileSelector compiles the label selector of the (single) set match condition.
+//
+// valid is false, signaling the caller to drop the condition, when the match has no recognized
+// selector set or when its selector fails to compile (both of which the CRD webhook should
+// already reject).
+func compileSelector(match *kubefloworgv1beta1.FilterRuleMatch) (selector labels.Selector, valid bool) {
+	var labelSelector *metav1.LabelSelector
+	switch {
+	case match.MatchNamespace != nil:
+		labelSelector = &match.MatchNamespace.Selector
+	case match.MatchImageConfig != nil:
+		labelSelector = &match.MatchImageConfig.Selector
+	case match.MatchPodConfig != nil:
+		labelSelector = &match.MatchPodConfig.Selector
+	default:
+		return nil, false
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, false
+	}
+	return selector, true
+}
+
+// allConditionsMatch returns true only if every (valid) match condition is satisfied (AND logic).
+func allConditionsMatch(matches []compiledMatch, targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) bool {
+	for i := range matches {
+		if !conditionMatches(&matches[i], targetScope, targetLabels, evalCtx) {
 			return false
 		}
 	}
 	return true
 }
 
-// conditionMatches evaluates a single match condition against the resolved label set.
+// conditionMatches evaluates a single (pre-compiled) match condition against the resolved label set.
 //
 // Exactly one of matchNamespace / matchImageConfig / matchPodConfig is set (enforced by the
 // CRD webhook). If the label set required by the condition is absent (nil), the condition is
 // treated as non-matching.
-func conditionMatches(match *kubefloworgv1beta1.FilterRuleMatch, targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) bool {
+func conditionMatches(cm *compiledMatch, targetScope kubefloworgv1beta1.FilterRuleScope, targetLabels map[string]string, evalCtx EvalContext) bool {
 	switch {
-	case match.MatchNamespace != nil:
-		return matchSelector(match.MatchNamespace.Selector, evalCtx.NamespaceLabels)
-	case match.MatchImageConfig != nil:
-		return matchSelector(match.MatchImageConfig.Selector, imageConfigLabels(targetScope, targetLabels, evalCtx))
-	case match.MatchPodConfig != nil:
-		return matchSelector(match.MatchPodConfig.Selector, podConfigLabels(targetScope, targetLabels, evalCtx))
+	case cm.match.MatchNamespace != nil:
+		return matchSelector(cm.selector, evalCtx.NamespaceLabels)
+	case cm.match.MatchImageConfig != nil:
+		return matchSelector(cm.selector, imageConfigLabels(targetScope, targetLabels, evalCtx))
+	case cm.match.MatchPodConfig != nil:
+		return matchSelector(cm.selector, podConfigLabels(targetScope, targetLabels, evalCtx))
 	default:
 		// no recognized condition set: treat as non-matching
 		return false
@@ -187,18 +258,12 @@ func podConfigLabels(targetScope kubefloworgv1beta1.FilterRuleScope, targetLabel
 	return evalCtx.PodConfigLabels
 }
 
-// matchSelector compiles the label selector and evaluates it against the given labels.
+// matchSelector evaluates a pre-compiled selector against the given labels.
 //
 // When targetLabels is nil the required context is absent, so the condition is non-matching
-// regardless of the selector (conservative: don't hide or deny without full context). An
-// invalid selector (which the CRD webhook should already reject) is also non-matching.
-func matchSelector(labelSelector metav1.LabelSelector, targetLabels map[string]string) bool {
+// regardless of the selector (conservative: don't hide or deny without full context).
+func matchSelector(selector labels.Selector, targetLabels map[string]string) bool {
 	if targetLabels == nil {
-		return false
-	}
-
-	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
-	if err != nil {
 		return false
 	}
 
@@ -207,27 +272,25 @@ func matchSelector(labelSelector metav1.LabelSelector, targetLabels map[string]s
 
 // resultFromEffect converts a matched rule's effect into an EvalResult.
 func resultFromEffect(effect kubefloworgv1beta1.FilterRuleEffect) EvalResult {
-	result := EvalResult{Restrictions: common.DefaultRestrictions()}
+	return EvalResult{
+		UIHide:       effect.UI != nil && effect.UI.Hide,
+		APIHide:      effect.API != nil && effect.API.Hide != nil && *effect.API.Hide,
+		Restrictions: resolveRestrictions(effect),
+	}
+}
 
-	if effect.UI != nil {
-		result.UIHide = effect.UI.Hide
+// resolveRestrictions returns the restrictions from an `api.deny` effect, or the
+// non-restrictive default when the effect does not deny.
+func resolveRestrictions(effect kubefloworgv1beta1.FilterRuleEffect) common.Restrictions {
+	if effect.API == nil || effect.API.Deny == nil || !*effect.API.Deny {
+		return common.DefaultRestrictions()
 	}
 
-	if effect.API != nil {
-		if effect.API.Hide != nil {
-			result.APIHide = *effect.API.Hide
-		}
-		if effect.API.Deny != nil && *effect.API.Deny {
-			result.Restrictions.Deny = true
-			if effect.API.DenyMessage != nil {
-				result.Restrictions.DenyMessage = &common.DenyMessage{
-					Text: effect.API.DenyMessage.Text,
-				}
-			}
-		}
+	restrictions := common.Restrictions{Deny: true}
+	if effect.API.DenyMessage != nil {
+		restrictions.DenyMessage = &common.DenyMessage{Text: effect.API.DenyMessage.Text}
 	}
-
-	return result
+	return restrictions
 }
 
 // spawnerLabelsToMap converts a slice of CRD spawner labels into a label map suitable for

--- a/workspaces/backend/internal/filterrules/engine_test.go
+++ b/workspaces/backend/internal/filterrules/engine_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 )
@@ -40,6 +40,13 @@ func spawnerLabels(m map[string]string) []kubefloworgv1beta1.OptionSpawnerLabel 
 		result = append(result, kubefloworgv1beta1.OptionSpawnerLabel{Key: k, Value: v})
 	}
 	return result
+}
+
+// evaluateRules compiles the given rules into the eval context and runs Evaluate, so the
+// tests can keep expressing cases as (rules, target, context).
+func evaluateRules(rules []kubefloworgv1beta1.FilterRule, target EvalTarget, evalCtx EvalContext) EvalResult {
+	evalCtx.compiledRules = compileRules(rules)
+	return Evaluate(target, evalCtx)
 }
 
 // matchLabelsRule builds a single-condition FilterRule with the given scope, match condition
@@ -78,14 +85,12 @@ var _ = Describe("spawnerLabelsToMap", func() {
 var _ = Describe("Evaluate", func() {
 	Context("when no rules are provided", func() {
 		It("returns the non-restrictive default", func() {
-			result := Evaluate(nil, EvalTarget{
+			result := evaluateRules(nil, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{})
 
-			Expect(result.UIHide).To(BeFalse())
-			Expect(result.APIHide).To(BeFalse())
-			Expect(result.Restrictions).To(Equal(common.DefaultRestrictions()))
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -107,12 +112,12 @@ var _ = Describe("Evaluate", func() {
 				},
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{})
 
-			Expect(result.UIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -125,14 +130,12 @@ var _ = Describe("Evaluate", func() {
 				),
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{})
 
-			Expect(result.UIHide).To(BeTrue())
-			Expect(result.APIHide).To(BeFalse())
-			Expect(result.Restrictions.Deny).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
 		})
 
 		It("does not match when labels differ", func() {
@@ -143,12 +146,12 @@ var _ = Describe("Evaluate", func() {
 				),
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "false"}),
 			}, EvalContext{})
 
-			Expect(result.UIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -157,16 +160,16 @@ var _ = Describe("Evaluate", func() {
 			rules := []kubefloworgv1beta1.FilterRule{
 				matchImageConfigRule(
 					map[string]string{"deprecated": "true"},
-					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)}},
+					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}},
 				),
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"deprecated": "true"}),
 			}, EvalContext{})
 
-			Expect(result.APIHide).To(BeTrue())
+			Expect(result).To(BeComparableTo(EvalResult{APIHide: true, Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -177,21 +180,24 @@ var _ = Describe("Evaluate", func() {
 					map[string]string{"eol": "true"},
 					kubefloworgv1beta1.FilterRuleEffect{
 						API: &kubefloworgv1beta1.FilterRuleEffectAPI{
-							Deny:        ptr.To(true),
+							Deny:        new(true),
 							DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "image is end-of-life"},
 						},
 					},
 				),
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"eol": "true"}),
 			}, EvalContext{})
 
-			Expect(result.Restrictions.Deny).To(BeTrue())
-			Expect(result.Restrictions.DenyMessage).NotTo(BeNil())
-			Expect(result.Restrictions.DenyMessage.Text).To(Equal("image is end-of-life"))
+			Expect(result).To(BeComparableTo(EvalResult{
+				Restrictions: common.Restrictions{
+					Deny:        true,
+					DenyMessage: &common.DenyMessage{Text: "image is end-of-life"},
+				},
+			}))
 		})
 
 		It("does not set a denyMessage when deny is false", func() {
@@ -199,18 +205,17 @@ var _ = Describe("Evaluate", func() {
 				matchImageConfigRule(
 					map[string]string{"eol": "true"},
 					kubefloworgv1beta1.FilterRuleEffect{
-						API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(false)},
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: new(false)},
 					},
 				),
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"eol": "true"}),
 			}, EvalContext{})
 
-			Expect(result.Restrictions.Deny).To(BeFalse())
-			Expect(result.Restrictions.DenyMessage).To(BeNil())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -236,18 +241,18 @@ var _ = Describe("Evaluate", func() {
 			}
 
 			By("matching when both conditions are satisfied")
-			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result := evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{NamespaceLabels: map[string]string{"tier": "prod"}})
-			Expect(result.UIHide).To(BeTrue())
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
 
 			By("not matching when only one condition is satisfied")
-			result = Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result = evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{NamespaceLabels: map[string]string{"tier": "dev"}})
-			Expect(result.UIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -267,12 +272,12 @@ var _ = Describe("Evaluate", func() {
 				},
 			}
 
-			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result := evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{NamespaceLabels: nil})
 
-			Expect(result.UIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -282,7 +287,7 @@ var _ = Describe("Evaluate", func() {
 			rule := kubefloworgv1beta1.FilterRule{
 				Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Effect: kubefloworgv1beta1.FilterRuleEffect{
-					API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)},
+					API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)},
 				},
 				Match: []kubefloworgv1beta1.FilterRuleMatch{
 					{
@@ -299,18 +304,18 @@ var _ = Describe("Evaluate", func() {
 			}
 
 			By("hiding the NVIDIA image when a non-GPU podConfig is selected")
-			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result := evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
 			}, EvalContext{PodConfigLabels: map[string]string{"gpu": "false"}})
-			Expect(result.APIHide).To(BeTrue())
+			Expect(result).To(BeComparableTo(EvalResult{APIHide: true, Restrictions: common.DefaultRestrictions()}))
 
 			By("not hiding the NVIDIA image when no podConfig context is present")
-			result = Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result = evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
 			}, EvalContext{PodConfigLabels: nil})
-			Expect(result.APIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -324,19 +329,18 @@ var _ = Describe("Evaluate", func() {
 				matchImageConfigRule(
 					map[string]string{"gpu": "true"},
 					kubefloworgv1beta1.FilterRuleEffect{
-						API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(true)},
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: new(true)},
 					},
 				),
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{})
 
 			// only the first rule (ui.hide) applies; the second (api.deny) is never reached
-			Expect(result.UIHide).To(BeTrue())
-			Expect(result.Restrictions.Deny).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -350,12 +354,12 @@ var _ = Describe("Evaluate", func() {
 			}
 
 			// even with a conflicting cross-option label in context, the same-scope target labels are used
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
 			}, EvalContext{ImageConfigLabels: map[string]string{"vendor": "other"}})
 
-			Expect(result.UIHide).To(BeTrue())
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -374,18 +378,18 @@ var _ = Describe("Evaluate", func() {
 			}
 
 			By("matching when the selected podConfig labels satisfy the selector")
-			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result := evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
 			}, EvalContext{PodConfigLabels: map[string]string{"gpu": "false"}})
-			Expect(result.UIHide).To(BeTrue())
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
 
 			By("not matching when no podConfig context is present")
-			result = Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result = evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
 			}, EvalContext{PodConfigLabels: nil})
-			Expect(result.UIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
@@ -408,17 +412,17 @@ var _ = Describe("Evaluate", func() {
 				},
 			}
 
-			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+			result := evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "false"}), // target's own labels (matchPodConfig)
 			}, EvalContext{ImageConfigLabels: map[string]string{"vendor": "nvidia"}}) // cross-option (matchImageConfig)
 
-			Expect(result.UIHide).To(BeTrue())
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
 	Context("empty match condition", func() {
-		It("treats a match with no selector set as non-matching", func() {
+		It("drops a match with no selector set, so a rule with only that condition never fires", func() {
 			rules := []kubefloworgv1beta1.FilterRule{
 				{
 					Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
@@ -427,45 +431,75 @@ var _ = Describe("Evaluate", func() {
 				},
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{})
 
-			Expect(result.UIHide).To(BeFalse())
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 
 	Context("invalid selector", func() {
-		It("treats a selector that fails to compile as non-matching", func() {
-			rules := []kubefloworgv1beta1.FilterRule{
-				{
-					Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
-					Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
-					Match: []kubefloworgv1beta1.FilterRuleMatch{
+		badMatchImageConfig := kubefloworgv1beta1.FilterRuleMatch{
+			MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+				Selector: metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
-								Selector: metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      "gpu",
-											Operator: metav1.LabelSelectorOperator("BadOperator"),
-											Values:   []string{"true"},
-										},
-									},
-								},
-							},
+							Key:      "gpu",
+							Operator: metav1.LabelSelectorOperator("BadOperator"),
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+		}
+
+		It("ignores the invalid condition but still evaluates the remaining conditions", func() {
+			rule := kubefloworgv1beta1.FilterRule{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					badMatchImageConfig,
+					{
+						MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "true"}},
 						},
 					},
 				},
 			}
 
-			result := Evaluate(rules, EvalTarget{
+			By("matching when the remaining valid condition is satisfied")
+			result := evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+			Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
+
+			By("not matching when the remaining valid condition is not satisfied")
+			result = evaluateRules([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "false"}),
+			}, EvalContext{})
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
+		})
+
+		It("drops the rule entirely when the invalid condition is its only condition", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				{
+					Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+					Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+					Match:  []kubefloworgv1beta1.FilterRuleMatch{badMatchImageConfig},
+				},
+			}
+
+			result := evaluateRules(rules, EvalTarget{
 				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
 			}, EvalContext{})
 
-			Expect(result.UIHide).To(BeFalse())
+			// the rule has no valid conditions left, so it is dropped and never fires
+			Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 		})
 	})
 })
@@ -474,6 +508,12 @@ var _ = Describe("BuildEvalContext", func() {
 	newWSK := func() *kubefloworgv1beta1.WorkspaceKind {
 		return &kubefloworgv1beta1.WorkspaceKind{
 			Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+				FilterRules: []kubefloworgv1beta1.FilterRule{
+					matchImageConfigRule(
+						map[string]string{"gpu": "true"},
+						kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+					),
+				},
 				PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
 					Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
 						ImageConfig: kubefloworgv1beta1.ImageConfig{
@@ -508,6 +548,26 @@ var _ = Describe("BuildEvalContext", func() {
 		Expect(evalCtx.NamespaceLabels).To(HaveKeyWithValue("tier", "prod"))
 		Expect(evalCtx.ImageConfigLabels).To(BeNil())
 		Expect(evalCtx.PodConfigLabels).To(BeNil())
+	})
+
+	It("compiles the WorkspaceKind's filterRules into the eval context", func() {
+		evalCtx := BuildEvalContext(newWSK(), nil, "", "")
+
+		Expect(evalCtx.compiledRules).To(HaveLen(1))
+		cr := evalCtx.compiledRules[0]
+		Expect(cr.rule.Scope).To(Equal(kubefloworgv1beta1.FilterRuleScopeImageConfig))
+		Expect(cr.matches).To(HaveLen(1))
+		Expect(cr.matches[0].selector).NotTo(BeNil())
+		Expect(cr.matches[0].selector.Matches(labels.Set{"gpu": "true"})).To(BeTrue())
+		Expect(cr.matches[0].selector.Matches(labels.Set{"gpu": "false"})).To(BeFalse())
+	})
+
+	It("leaves compiledRules empty when the WorkspaceKind has no filterRules", func() {
+		wsk := newWSK()
+		wsk.Spec.FilterRules = nil
+		evalCtx := BuildEvalContext(wsk, nil, "", "")
+
+		Expect(evalCtx.compiledRules).To(BeEmpty())
 	})
 
 	It("resolves imageConfig and podConfig labels from matching ids", func() {

--- a/workspaces/backend/internal/filterrules/engine_test.go
+++ b/workspaces/backend/internal/filterrules/engine_test.go
@@ -1,0 +1,526 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filterrules
+
+import (
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
+)
+
+func TestFilterRules(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FilterRules Engine Suite")
+}
+
+// spawnerLabels converts a map into the CRD spawner label slice used by EvalTarget.
+func spawnerLabels(m map[string]string) []kubefloworgv1beta1.OptionSpawnerLabel {
+	result := make([]kubefloworgv1beta1.OptionSpawnerLabel, 0, len(m))
+	for k, v := range m {
+		result = append(result, kubefloworgv1beta1.OptionSpawnerLabel{Key: k, Value: v})
+	}
+	return result
+}
+
+// matchLabelsRule builds a single-condition FilterRule with the given scope, match condition
+// (via the provided FilterRuleMatch), and effect.
+func matchImageConfigRule(selector map[string]string, effect kubefloworgv1beta1.FilterRuleEffect) kubefloworgv1beta1.FilterRule {
+	return kubefloworgv1beta1.FilterRule{
+		Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+		Effect: effect,
+		Match: []kubefloworgv1beta1.FilterRuleMatch{
+			{
+				MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+					Selector: metav1.LabelSelector{MatchLabels: selector},
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("spawnerLabelsToMap", func() {
+	It("returns a non-nil empty map for no labels", func() {
+		result := spawnerLabelsToMap(nil)
+		Expect(result).NotTo(BeNil())
+		Expect(result).To(BeEmpty())
+	})
+
+	It("converts a slice of spawner labels into a map", func() {
+		result := spawnerLabelsToMap([]kubefloworgv1beta1.OptionSpawnerLabel{
+			{Key: "gpu", Value: "true"},
+			{Key: "vendor", Value: "nvidia"},
+		})
+		Expect(result).To(HaveKeyWithValue("gpu", "true"))
+		Expect(result).To(HaveKeyWithValue("vendor", "nvidia"))
+	})
+})
+
+var _ = Describe("Evaluate", func() {
+	Context("when no rules are provided", func() {
+		It("returns the non-restrictive default", func() {
+			result := Evaluate(nil, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+
+			Expect(result.UIHide).To(BeFalse())
+			Expect(result.APIHide).To(BeFalse())
+			Expect(result.Restrictions).To(Equal(common.DefaultRestrictions()))
+		})
+	})
+
+	Context("scope filtering", func() {
+		It("ignores rules whose scope does not match the target", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				{
+					Scope: kubefloworgv1beta1.FilterRuleScopePodConfig,
+					Effect: kubefloworgv1beta1.FilterRuleEffect{
+						UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true},
+					},
+					Match: []kubefloworgv1beta1.FilterRuleMatch{
+						{
+							MatchPodConfig: &kubefloworgv1beta1.FilterRuleSelector{
+								Selector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "true"}},
+							},
+						},
+					},
+				},
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+
+	Context("ui.hide effect", func() {
+		It("sets UIHide when a same-scope rule matches", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"gpu": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				),
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+
+			Expect(result.UIHide).To(BeTrue())
+			Expect(result.APIHide).To(BeFalse())
+			Expect(result.Restrictions.Deny).To(BeFalse())
+		})
+
+		It("does not match when labels differ", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"gpu": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				),
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "false"}),
+			}, EvalContext{})
+
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+
+	Context("api.hide effect", func() {
+		It("sets APIHide when a matching rule has api.hide=true", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"deprecated": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)}},
+				),
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"deprecated": "true"}),
+			}, EvalContext{})
+
+			Expect(result.APIHide).To(BeTrue())
+		})
+	})
+
+	Context("api.deny effect", func() {
+		It("populates Restrictions with deny and denyMessage", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"eol": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{
+							Deny:        ptr.To(true),
+							DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "image is end-of-life"},
+						},
+					},
+				),
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"eol": "true"}),
+			}, EvalContext{})
+
+			Expect(result.Restrictions.Deny).To(BeTrue())
+			Expect(result.Restrictions.DenyMessage).NotTo(BeNil())
+			Expect(result.Restrictions.DenyMessage.Text).To(Equal("image is end-of-life"))
+		})
+
+		It("does not set a denyMessage when deny is false", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"eol": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(false)},
+					},
+				),
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"eol": "true"}),
+			}, EvalContext{})
+
+			Expect(result.Restrictions.Deny).To(BeFalse())
+			Expect(result.Restrictions.DenyMessage).To(BeNil())
+		})
+	})
+
+	Context("AND logic across multiple match conditions", func() {
+		It("matches only when ALL conditions are satisfied", func() {
+			rule := kubefloworgv1beta1.FilterRule{
+				Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{
+					UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true},
+				},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					{
+						MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "true"}},
+						},
+					},
+					{
+						MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"tier": "prod"}},
+						},
+					},
+				},
+			}
+
+			By("matching when both conditions are satisfied")
+			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{NamespaceLabels: map[string]string{"tier": "prod"}})
+			Expect(result.UIHide).To(BeTrue())
+
+			By("not matching when only one condition is satisfied")
+			result = Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{NamespaceLabels: map[string]string{"tier": "dev"}})
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+
+	Context("namespace matching", func() {
+		It("treats matchNamespace as non-matching when namespace labels are absent", func() {
+			rule := kubefloworgv1beta1.FilterRule{
+				Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{
+					UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true},
+				},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					{
+						MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"tier": "prod"}},
+						},
+					},
+				},
+			}
+
+			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{NamespaceLabels: nil})
+
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+
+	Context("cross-option matching", func() {
+		It("evaluates matchPodConfig against the request-selected podConfig for an IMAGE_CONFIG rule", func() {
+			// selecting a non-NVIDIA podConfig should deny an NVIDIA-only image
+			rule := kubefloworgv1beta1.FilterRule{
+				Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{
+					API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)},
+				},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					{
+						MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"vendor": "nvidia"}},
+						},
+					},
+					{
+						MatchPodConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "false"}},
+						},
+					},
+				},
+			}
+
+			By("hiding the NVIDIA image when a non-GPU podConfig is selected")
+			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
+			}, EvalContext{PodConfigLabels: map[string]string{"gpu": "false"}})
+			Expect(result.APIHide).To(BeTrue())
+
+			By("not hiding the NVIDIA image when no podConfig context is present")
+			result = Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
+			}, EvalContext{PodConfigLabels: nil})
+			Expect(result.APIHide).To(BeFalse())
+		})
+	})
+
+	Context("first-match-wins ordering", func() {
+		It("applies only the effect of the first matching rule", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"gpu": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				),
+				matchImageConfigRule(
+					map[string]string{"gpu": "true"},
+					kubefloworgv1beta1.FilterRuleEffect{
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(true)},
+					},
+				),
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+
+			// only the first rule (ui.hide) applies; the second (api.deny) is never reached
+			Expect(result.UIHide).To(BeTrue())
+			Expect(result.Restrictions.Deny).To(BeFalse())
+		})
+	})
+
+	Context("matchImageConfig on a same-scope IMAGE_CONFIG target", func() {
+		It("evaluates against the target's own labels", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				matchImageConfigRule(
+					map[string]string{"vendor": "nvidia"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				),
+			}
+
+			// even with a conflicting cross-option label in context, the same-scope target labels are used
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
+			}, EvalContext{ImageConfigLabels: map[string]string{"vendor": "other"}})
+
+			Expect(result.UIHide).To(BeTrue())
+		})
+	})
+
+	Context("matchPodConfig cross-option on an IMAGE_CONFIG target", func() {
+		It("evaluates against the request-selected podConfig labels", func() {
+			rule := kubefloworgv1beta1.FilterRule{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					{
+						MatchPodConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "false"}},
+						},
+					},
+				},
+			}
+
+			By("matching when the selected podConfig labels satisfy the selector")
+			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
+			}, EvalContext{PodConfigLabels: map[string]string{"gpu": "false"}})
+			Expect(result.UIHide).To(BeTrue())
+
+			By("not matching when no podConfig context is present")
+			result = Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"vendor": "nvidia"}),
+			}, EvalContext{PodConfigLabels: nil})
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+
+	Context("POD_CONFIG target with same-scope and cross-option conditions", func() {
+		It("uses target labels for matchPodConfig and context labels for matchImageConfig", func() {
+			rule := kubefloworgv1beta1.FilterRule{
+				Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					{
+						MatchPodConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "false"}},
+						},
+					},
+					{
+						MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"vendor": "nvidia"}},
+						},
+					},
+				},
+			}
+
+			result := Evaluate([]kubefloworgv1beta1.FilterRule{rule}, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "false"}), // target's own labels (matchPodConfig)
+			}, EvalContext{ImageConfigLabels: map[string]string{"vendor": "nvidia"}}) // cross-option (matchImageConfig)
+
+			Expect(result.UIHide).To(BeTrue())
+		})
+	})
+
+	Context("empty match condition", func() {
+		It("treats a match with no selector set as non-matching", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				{
+					Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+					Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+					Match:  []kubefloworgv1beta1.FilterRuleMatch{{}}, // none of the three selectors set
+				},
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+
+	Context("invalid selector", func() {
+		It("treats a selector that fails to compile as non-matching", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				{
+					Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+					Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+					Match: []kubefloworgv1beta1.FilterRuleMatch{
+						{
+							MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+								Selector: metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "gpu",
+											Operator: metav1.LabelSelectorOperator("BadOperator"),
+											Values:   []string{"true"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := Evaluate(rules, EvalTarget{
+				Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Labels: spawnerLabels(map[string]string{"gpu": "true"}),
+			}, EvalContext{})
+
+			Expect(result.UIHide).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("BuildEvalContext", func() {
+	newWSK := func() *kubefloworgv1beta1.WorkspaceKind {
+		return &kubefloworgv1beta1.WorkspaceKind{
+			Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+				PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
+					Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
+						ImageConfig: kubefloworgv1beta1.ImageConfig{
+							Values: []kubefloworgv1beta1.ImageConfigValue{
+								{
+									Id: "img1",
+									Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+										Labels: []kubefloworgv1beta1.OptionSpawnerLabel{{Key: "vendor", Value: "nvidia"}},
+									},
+								},
+							},
+						},
+						PodConfig: kubefloworgv1beta1.PodConfig{
+							Values: []kubefloworgv1beta1.PodConfigValue{
+								{
+									Id: "pod1",
+									Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+										Labels: []kubefloworgv1beta1.OptionSpawnerLabel{{Key: "gpu", Value: "true"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	It("passes through namespace labels and leaves config labels nil when no ids are given", func() {
+		evalCtx := BuildEvalContext(newWSK(), map[string]string{"tier": "prod"}, "", "")
+
+		Expect(evalCtx.NamespaceLabels).To(HaveKeyWithValue("tier", "prod"))
+		Expect(evalCtx.ImageConfigLabels).To(BeNil())
+		Expect(evalCtx.PodConfigLabels).To(BeNil())
+	})
+
+	It("resolves imageConfig and podConfig labels from matching ids", func() {
+		evalCtx := BuildEvalContext(newWSK(), nil, "img1", "pod1")
+
+		Expect(evalCtx.ImageConfigLabels).To(HaveKeyWithValue("vendor", "nvidia"))
+		Expect(evalCtx.PodConfigLabels).To(HaveKeyWithValue("gpu", "true"))
+	})
+
+	It("leaves labels nil when the ids do not match any value", func() {
+		evalCtx := BuildEvalContext(newWSK(), nil, "missing-img", "missing-pod")
+
+		Expect(evalCtx.ImageConfigLabels).To(BeNil())
+		Expect(evalCtx.PodConfigLabels).To(BeNil())
+	})
+})

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -43,7 +43,7 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 	// TODO: remove these once frontend migrates to the new listValues endpoint for both create/update and wsk admin views
 	//
 	listValuesRequest := &options.ListValuesRequest{}
-	podTemplateOptions, err := options.NewPodTemplateOptionsModelFromWorkspaceKind(wsk, listValuesRequest)
+	podTemplateOptions, err := options.NewPodTemplateOptionsModelFromWorkspaceKind(wsk, listValuesRequest, nil)
 	if err != nil {
 		panic("invalid call to NewPodTemplateOptionsModelFromWorkspaceKind: " + err.Error())
 	}

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
@@ -23,23 +23,32 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/filterrules"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
-	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 )
 
-func NewPodTemplateOptionsModelFromWorkspaceKind(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest) (*PodTemplateOptions, error) {
+// NewPodTemplateOptionsModelFromWorkspaceKind builds the PodTemplateOptions response, evaluating
+// the WorkspaceKind's `spec.filterRules[]` against each imageConfig and podConfig value.
+//
+// namespaceLabels are the labels of the namespace named in the request context (resolved by the
+// caller via the k8s API), or nil when `context.namespace.name` was not provided.
+func NewPodTemplateOptionsModelFromWorkspaceKind(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest, namespaceLabels map[string]string) (*PodTemplateOptions, error) {
 	var allValErrs field.ErrorList //nolint:prealloc
+
+	// resolve the request-scoped context shared across all rule evaluations
+	imageConfigID, podConfigID := request.ConfigIDs()
+	evalCtx := filterrules.BuildEvalContext(wsk, namespaceLabels, imageConfigID, podConfigID)
 
 	// calculate maps of "option id" -> "number of workspaces using that option in the cluster"
 	metricsMapImageConfig := calculateOptionMetricsMap(wsk.Status.PodTemplateOptions.ImageConfig)
 	metricsMapPodConfig := calculateOptionMetricsMap(wsk.Status.PodTemplateOptions.PodConfig)
 
 	// accumulate image config values
-	imageConfigValues, valErrs := buildImageConfigValues(wsk, request, metricsMapImageConfig)
+	imageConfigValues, valErrs := buildImageConfigValues(wsk, request, metricsMapImageConfig, evalCtx)
 	allValErrs = append(allValErrs, valErrs...)
 
 	// accumulate pod config values
-	podConfigValues, valErrs := buildPodConfigValues(wsk, request, metricsMapPodConfig)
+	podConfigValues, valErrs := buildPodConfigValues(wsk, request, metricsMapPodConfig, evalCtx)
 	allValErrs = append(allValErrs, valErrs...)
 
 	// if there are any validation errors, return an aggregated error
@@ -68,7 +77,7 @@ func calculateOptionMetricsMap(metrics []kubefloworgv1beta1.OptionMetric) map[st
 	return resultMap
 }
 
-func buildImageConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest, optionMetricsMap map[string]int32) ([]ImageConfigValue, field.ErrorList) {
+func buildImageConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest, optionMetricsMap map[string]int32, evalCtx filterrules.EvalContext) ([]ImageConfigValue, field.ErrorList) {
 	var valErrs field.ErrorList
 
 	// get the id of any IMAGE CONFIG value specified in the context
@@ -96,21 +105,28 @@ func buildImageConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *List
 				continue
 			}
 		}
+
+		// evaluate the filter rules for this value (first-match-wins)
+		result := filterrules.Evaluate(wsk.Spec.FilterRules, filterrules.EvalTarget{
+			Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+			Labels: value.Spawner.Labels,
+		}, evalCtx)
+
+		// `api.hide` omits the value from the response entirely
+		if result.APIHide {
+			continue
+		}
+
 		imageConfigValues = append(imageConfigValues, ImageConfigValue{
 			Id:          value.Id,
 			DisplayName: value.Spawner.DisplayName,
 			Description: ptr.Deref(value.Spawner.Description, ""),
 			Labels:      buildOptionLabels(value.Spawner.Labels),
-			//
-			// TODO: merge with effect of any matching rules that have `effect.ui.hide`, once WSK rules exist
-			//
-			Hidden:         ptr.Deref(value.Spawner.Hidden, false),
+			// `hidden` is the admin-set value OR the `ui.hide` effect of the first matching rule
+			Hidden:         ptr.Deref(value.Spawner.Hidden, false) || result.UIHide,
 			Redirect:       buildOptionRedirect(value.Redirect),
 			ClusterMetrics: buildClusterOptionMetrics(value.Id, optionMetricsMap),
-			//
-			// TODO: replace this with the calculation of the actual restriction!
-			//
-			Restrictions: common.DefaultRestrictions(),
+			Restrictions:   result.Restrictions,
 		})
 	}
 
@@ -124,7 +140,7 @@ func buildImageConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *List
 	return imageConfigValues, valErrs
 }
 
-func buildPodConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest, optionMetricsMap map[string]int32) ([]PodConfigValue, field.ErrorList) {
+func buildPodConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListValuesRequest, optionMetricsMap map[string]int32, evalCtx filterrules.EvalContext) ([]PodConfigValue, field.ErrorList) {
 	var valErrs field.ErrorList
 
 	// get the id of any POD CONFIG value specified in the context
@@ -152,21 +168,28 @@ func buildPodConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListVa
 				continue
 			}
 		}
+
+		// evaluate the filter rules for this value (first-match-wins)
+		result := filterrules.Evaluate(wsk.Spec.FilterRules, filterrules.EvalTarget{
+			Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
+			Labels: value.Spawner.Labels,
+		}, evalCtx)
+
+		// `api.hide` omits the value from the response entirely
+		if result.APIHide {
+			continue
+		}
+
 		podConfigValues = append(podConfigValues, PodConfigValue{
 			Id:          value.Id,
 			DisplayName: value.Spawner.DisplayName,
 			Description: ptr.Deref(value.Spawner.Description, ""),
 			Labels:      buildOptionLabels(value.Spawner.Labels),
-			//
-			// TODO: merge with effect of any matching rules that have `effect.ui.hide`, once WSK rules exist
-			//
-			Hidden:         ptr.Deref(value.Spawner.Hidden, false),
+			// `hidden` is the admin-set value OR the `ui.hide` effect of the first matching rule
+			Hidden:         ptr.Deref(value.Spawner.Hidden, false) || result.UIHide,
 			Redirect:       buildOptionRedirect(value.Redirect),
 			ClusterMetrics: buildClusterOptionMetrics(value.Id, optionMetricsMap),
-			//
-			// TODO: replace this with the calculation of the actual restriction!
-			//
-			Restrictions: common.DefaultRestrictions(),
+			Restrictions:   result.Restrictions,
 		})
 	}
 

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
@@ -36,7 +36,7 @@ func NewPodTemplateOptionsModelFromWorkspaceKind(wsk *kubefloworgv1beta1.Workspa
 	var allValErrs field.ErrorList //nolint:prealloc
 
 	// resolve the request-scoped context shared across all rule evaluations
-	imageConfigID, podConfigID := request.ConfigIDs()
+	imageConfigID, podConfigID := request.configIDs()
 	evalCtx := filterrules.BuildEvalContext(wsk, namespaceLabels, imageConfigID, podConfigID)
 
 	// calculate maps of "option id" -> "number of workspaces using that option in the cluster"
@@ -107,7 +107,7 @@ func buildImageConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *List
 		}
 
 		// evaluate the filter rules for this value (first-match-wins)
-		result := filterrules.Evaluate(wsk.Spec.FilterRules, filterrules.EvalTarget{
+		result := filterrules.Evaluate(filterrules.EvalTarget{
 			Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
 			Labels: value.Spawner.Labels,
 		}, evalCtx)
@@ -170,7 +170,7 @@ func buildPodConfigValues(wsk *kubefloworgv1beta1.WorkspaceKind, request *ListVa
 		}
 
 		// evaluate the filter rules for this value (first-match-wins)
-		result := filterrules.Evaluate(wsk.Spec.FilterRules, filterrules.EvalTarget{
+		result := filterrules.Evaluate(filterrules.EvalTarget{
 			Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
 			Labels: value.Spawner.Labels,
 		}, evalCtx)

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs_test.go
@@ -1,0 +1,431 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestOptions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PodTemplateOptions Models Suite")
+}
+
+// imageConfigValue builds a CRD imageConfig value with the given id, labels, and admin-set hidden flag.
+func imageConfigValue(id string, hidden bool, labels map[string]string) kubefloworgv1beta1.ImageConfigValue {
+	return kubefloworgv1beta1.ImageConfigValue{
+		Id: id,
+		Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+			DisplayName: id,
+			Hidden:      ptr.To(hidden),
+			Labels:      spawnerLabelSlice(labels),
+		},
+	}
+}
+
+// podConfigValue builds a CRD podConfig value with the given id, labels, and admin-set hidden flag.
+func podConfigValue(id string, hidden bool, labels map[string]string) kubefloworgv1beta1.PodConfigValue {
+	return kubefloworgv1beta1.PodConfigValue{
+		Id: id,
+		Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
+			DisplayName: id,
+			Hidden:      ptr.To(hidden),
+			Labels:      spawnerLabelSlice(labels),
+		},
+	}
+}
+
+func spawnerLabelSlice(m map[string]string) []kubefloworgv1beta1.OptionSpawnerLabel {
+	result := make([]kubefloworgv1beta1.OptionSpawnerLabel, 0, len(m))
+	for k, v := range m {
+		result = append(result, kubefloworgv1beta1.OptionSpawnerLabel{Key: k, Value: v})
+	}
+	return result
+}
+
+// newWorkspaceKind builds a minimal WorkspaceKind with the given image/pod config values and filter rules.
+func newWorkspaceKind(images []kubefloworgv1beta1.ImageConfigValue, pods []kubefloworgv1beta1.PodConfigValue, rules []kubefloworgv1beta1.FilterRule) *kubefloworgv1beta1.WorkspaceKind {
+	return &kubefloworgv1beta1.WorkspaceKind{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-wsk"},
+		Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+			PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
+				Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
+					ImageConfig: kubefloworgv1beta1.ImageConfig{
+						Spawner: kubefloworgv1beta1.OptionsSpawnerConfig{Default: "img1"},
+						Values:  images,
+					},
+					PodConfig: kubefloworgv1beta1.PodConfig{
+						Spawner: kubefloworgv1beta1.OptionsSpawnerConfig{Default: "pod1"},
+						Values:  pods,
+					},
+				},
+			},
+			FilterRules: rules,
+		},
+	}
+}
+
+// imageValueByID returns the response imageConfig value with the given id, or nil if omitted.
+func imageValueByID(opts *PodTemplateOptions, id string) *ImageConfigValue {
+	for i := range opts.ImageConfig.Values {
+		if opts.ImageConfig.Values[i].Id == id {
+			return &opts.ImageConfig.Values[i]
+		}
+	}
+	return nil
+}
+
+// podValueByID returns the response podConfig value with the given id, or nil if omitted.
+func podValueByID(opts *PodTemplateOptions, id string) *PodConfigValue {
+	for i := range opts.PodConfig.Values {
+		if opts.PodConfig.Values[i].Id == id {
+			return &opts.PodConfig.Values[i]
+		}
+	}
+	return nil
+}
+
+func uiHideRule(scope kubefloworgv1beta1.FilterRuleScope, match []kubefloworgv1beta1.FilterRuleMatch) kubefloworgv1beta1.FilterRule {
+	return kubefloworgv1beta1.FilterRule{
+		Scope:  scope,
+		Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+		Match:  match,
+	}
+}
+
+func matchImageConfig(labels map[string]string) kubefloworgv1beta1.FilterRuleMatch {
+	return kubefloworgv1beta1.FilterRuleMatch{
+		MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+			Selector: metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+}
+
+func matchPodConfig(labels map[string]string) kubefloworgv1beta1.FilterRuleMatch {
+	return kubefloworgv1beta1.FilterRuleMatch{
+		MatchPodConfig: &kubefloworgv1beta1.FilterRuleSelector{
+			Selector: metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+}
+
+func matchNamespace(labels map[string]string) kubefloworgv1beta1.FilterRuleMatch {
+	return kubefloworgv1beta1.FilterRuleMatch{
+		MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+			Selector: metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+}
+
+var _ = Describe("NewPodTemplateOptionsModelFromWorkspaceKind", func() {
+
+	Context("no-rules default", func() {
+		It("returns all values with admin-set hidden and non-restrictive restrictions", func() {
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{
+					imageConfigValue("img1", false, nil),
+					imageConfigValue("img2", true, nil),
+				},
+				[]kubefloworgv1beta1.PodConfigValue{podConfigValue("pod1", false, nil)},
+				nil,
+			)
+
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.ImageConfig.Values).To(HaveLen(2))
+
+			img1 := imageValueByID(opts, "img1")
+			Expect(img1).NotTo(BeNil())
+			Expect(img1.Hidden).To(BeFalse())
+			Expect(img1.Restrictions.Deny).To(BeFalse())
+
+			// admin-set hidden is preserved when no rule matches
+			img2 := imageValueByID(opts, "img2")
+			Expect(img2).NotTo(BeNil())
+			Expect(img2.Hidden).To(BeTrue())
+			Expect(img2.Restrictions.Deny).To(BeFalse())
+
+			Expect(opts.PodConfig.Values).To(HaveLen(1))
+			pod1 := podValueByID(opts, "pod1")
+			Expect(pod1).NotTo(BeNil())
+			Expect(pod1.Hidden).To(BeFalse())
+			Expect(pod1.Restrictions.Deny).To(BeFalse())
+		})
+	})
+
+	Context("hidden merging", func() {
+		It("merges admin-set hidden with the ui.hide effect (logical OR)", func() {
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{
+					imageConfigValue("img1", false, map[string]string{"img-deprecated": "true"}),
+					imageConfigValue("img2", true, nil),  // admin-hidden, no rule
+					imageConfigValue("img3", false, nil), // neither
+				},
+				[]kubefloworgv1beta1.PodConfigValue{
+					podConfigValue("pod1", false, map[string]string{"pod-deprecated": "true"}),
+					podConfigValue("pod2", true, nil),  // admin-hidden, no rule
+					podConfigValue("pod3", false, nil), // neither
+				},
+				[]kubefloworgv1beta1.FilterRule{
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopeImageConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchImageConfig(map[string]string{"img-deprecated": "true"}),
+					}),
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopePodConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchPodConfig(map[string]string{"pod-deprecated": "true"}),
+					}),
+				},
+			)
+
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(imageValueByID(opts, "img1").Hidden).To(BeTrue()) // via ui.hide
+			Expect(imageValueByID(opts, "img2").Hidden).To(BeTrue()) // via admin-set
+			Expect(imageValueByID(opts, "img3").Hidden).To(BeFalse())
+
+			Expect(podValueByID(opts, "pod1").Hidden).To(BeTrue()) // via ui.hide
+			Expect(podValueByID(opts, "pod2").Hidden).To(BeTrue()) // via admin-set
+			Expect(podValueByID(opts, "pod3").Hidden).To(BeFalse())
+		})
+	})
+
+	Context("api.hide omission", func() {
+		It("omits values whose matching rule has api.hide=true", func() {
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{
+					imageConfigValue("img1", false, map[string]string{"img-eol": "true"}),
+					imageConfigValue("img2", false, nil),
+				},
+				[]kubefloworgv1beta1.PodConfigValue{
+					podConfigValue("pod1", false, map[string]string{"pod-eol": "true"}),
+					podConfigValue("pod2", false, nil),
+				},
+				[]kubefloworgv1beta1.FilterRule{
+					{
+						Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)}},
+						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchImageConfig(map[string]string{"img-eol": "true"})},
+					},
+					{
+						Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)}},
+						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchPodConfig(map[string]string{"pod-eol": "true"})},
+					},
+				},
+			)
+
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(opts.ImageConfig.Values).To(HaveLen(1))
+			Expect(imageValueByID(opts, "img1")).To(BeNil())
+			Expect(imageValueByID(opts, "img2")).NotTo(BeNil())
+
+			Expect(opts.PodConfig.Values).To(HaveLen(1))
+			Expect(podValueByID(opts, "pod1")).To(BeNil())
+			Expect(podValueByID(opts, "pod2")).NotTo(BeNil())
+		})
+	})
+
+	Context("api.deny + denyMessage", func() {
+		It("returns the value with restrictions populated from the api.deny effect", func() {
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{
+					imageConfigValue("img1", false, map[string]string{"img-eol": "true"}),
+					imageConfigValue("img2", false, nil), // does not match the deny rule
+				},
+				[]kubefloworgv1beta1.PodConfigValue{
+					podConfigValue("pod1", false, map[string]string{"pod-eol": "true"}),
+					podConfigValue("pod2", false, nil), // does not match the deny rule
+				},
+				[]kubefloworgv1beta1.FilterRule{
+					{
+						Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
+						Effect: kubefloworgv1beta1.FilterRuleEffect{
+							API: &kubefloworgv1beta1.FilterRuleEffectAPI{
+								Deny:        ptr.To(true),
+								DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "image is end-of-life"},
+							},
+						},
+						Match: []kubefloworgv1beta1.FilterRuleMatch{matchImageConfig(map[string]string{"img-eol": "true"})},
+					},
+					{
+						Scope: kubefloworgv1beta1.FilterRuleScopePodConfig,
+						Effect: kubefloworgv1beta1.FilterRuleEffect{
+							API: &kubefloworgv1beta1.FilterRuleEffectAPI{
+								Deny:        ptr.To(true),
+								DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "pod config is end-of-life"},
+							},
+						},
+						Match: []kubefloworgv1beta1.FilterRuleMatch{matchPodConfig(map[string]string{"pod-eol": "true"})},
+					},
+				},
+			)
+
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			img1 := imageValueByID(opts, "img1")
+			Expect(img1).NotTo(BeNil()) // deny keeps the value in the response
+			Expect(img1.Restrictions.Deny).To(BeTrue())
+			Expect(img1.Restrictions.DenyMessage).NotTo(BeNil())
+			Expect(img1.Restrictions.DenyMessage.Text).To(Equal("image is end-of-life"))
+
+			// non-matching image is returned without restrictions
+			img2 := imageValueByID(opts, "img2")
+			Expect(img2).NotTo(BeNil())
+			Expect(img2.Restrictions.Deny).To(BeFalse())
+			Expect(img2.Restrictions.DenyMessage).To(BeNil())
+
+			pod1 := podValueByID(opts, "pod1")
+			Expect(pod1).NotTo(BeNil()) // deny keeps the value in the response
+			Expect(pod1.Restrictions.Deny).To(BeTrue())
+			Expect(pod1.Restrictions.DenyMessage).NotTo(BeNil())
+			Expect(pod1.Restrictions.DenyMessage.Text).To(Equal("pod config is end-of-life"))
+
+			// non-matching pod config is returned without restrictions
+			pod2 := podValueByID(opts, "pod2")
+			Expect(pod2).NotTo(BeNil())
+			Expect(pod2.Restrictions.Deny).To(BeFalse())
+			Expect(pod2.Restrictions.DenyMessage).To(BeNil())
+		})
+	})
+
+	Context("namespace matching", func() {
+		It("applies a matchNamespace rule only when namespace labels satisfy the selector", func() {
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{imageConfigValue("img1", false, nil)},
+				[]kubefloworgv1beta1.PodConfigValue{podConfigValue("pod1", false, nil)},
+				[]kubefloworgv1beta1.FilterRule{
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopeImageConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchNamespace(map[string]string{"tier": "prod"}),
+					}),
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopePodConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchNamespace(map[string]string{"tier": "prod"}),
+					}),
+				},
+			)
+
+			By("hiding when the namespace labels match")
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, map[string]string{"tier": "prod"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(imageValueByID(opts, "img1").Hidden).To(BeTrue())
+			Expect(podValueByID(opts, "pod1").Hidden).To(BeTrue())
+
+			By("not hiding when the namespace labels do not match")
+			opts, err = NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, map[string]string{"tier": "dev"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(imageValueByID(opts, "img1").Hidden).To(BeFalse())
+			Expect(podValueByID(opts, "pod1").Hidden).To(BeFalse())
+
+			By("not hiding when no namespace context is provided (nil labels)")
+			opts, err = NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(imageValueByID(opts, "img1").Hidden).To(BeFalse())
+			Expect(podValueByID(opts, "pod1").Hidden).To(BeFalse())
+		})
+	})
+
+	Context("cross-option matching", func() {
+		It("hides a podConfig based on the imageConfig selected in the request context", func() {
+			// rule: hide any non-GPU podConfig when an NVIDIA image is selected
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{
+					imageConfigValue("nvidia-img", false, map[string]string{"vendor": "nvidia"}),
+				},
+				[]kubefloworgv1beta1.PodConfigValue{
+					podConfigValue("cpu-pod", false, map[string]string{"gpu": "false"}),
+					podConfigValue("gpu-pod", false, map[string]string{"gpu": "true"}),
+				},
+				[]kubefloworgv1beta1.FilterRule{
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopePodConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchImageConfig(map[string]string{"vendor": "nvidia"}),
+						matchPodConfig(map[string]string{"gpu": "false"}),
+					}),
+				},
+			)
+
+			By("hiding the cpu podConfig when the nvidia image is selected in context")
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{
+				Context: ListValuesContext{ImageConfig: &ContextImageConfig{Id: "nvidia-img"}},
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podValueByID(opts, "cpu-pod").Hidden).To(BeTrue())
+			Expect(podValueByID(opts, "gpu-pod").Hidden).To(BeFalse())
+
+			By("not hiding any podConfig when no imageConfig context is provided")
+			opts, err = NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podValueByID(opts, "cpu-pod").Hidden).To(BeFalse())
+			Expect(podValueByID(opts, "gpu-pod").Hidden).To(BeFalse())
+		})
+	})
+
+	Context("first-match-wins ordering", func() {
+		It("applies only the first matching rule's effect per value", func() {
+			wsk := newWorkspaceKind(
+				[]kubefloworgv1beta1.ImageConfigValue{
+					imageConfigValue("img1", false, map[string]string{"img-gpu": "true"}),
+				},
+				[]kubefloworgv1beta1.PodConfigValue{
+					podConfigValue("pod1", false, map[string]string{"pod-gpu": "true"}),
+				},
+				[]kubefloworgv1beta1.FilterRule{
+					// first image rule: ui.hide
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopeImageConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchImageConfig(map[string]string{"img-gpu": "true"}),
+					}),
+					// second image rule (never reached): api.deny
+					{
+						Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(true)}},
+						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchImageConfig(map[string]string{"img-gpu": "true"})},
+					},
+					// first pod rule: ui.hide
+					uiHideRule(kubefloworgv1beta1.FilterRuleScopePodConfig, []kubefloworgv1beta1.FilterRuleMatch{
+						matchPodConfig(map[string]string{"pod-gpu": "true"}),
+					}),
+					// second pod rule (never reached): api.deny
+					{
+						Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(true)}},
+						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchPodConfig(map[string]string{"pod-gpu": "true"})},
+					},
+				},
+			)
+
+			opts, err := NewPodTemplateOptionsModelFromWorkspaceKind(wsk, &ListValuesRequest{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			img1 := imageValueByID(opts, "img1")
+			Expect(img1).NotTo(BeNil())
+			Expect(img1.Hidden).To(BeTrue())             // first rule applied
+			Expect(img1.Restrictions.Deny).To(BeFalse()) // second rule never reached
+
+			pod1 := podValueByID(opts, "pod1")
+			Expect(pod1).NotTo(BeNil())
+			Expect(pod1.Hidden).To(BeTrue())             // first rule applied
+			Expect(pod1.Restrictions.Deny).To(BeFalse()) // second rule never reached
+		})
+	})
+})

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestOptions(t *testing.T) {
@@ -37,7 +36,7 @@ func imageConfigValue(id string, hidden bool, labels map[string]string) kubeflow
 		Id: id,
 		Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 			DisplayName: id,
-			Hidden:      ptr.To(hidden),
+			Hidden:      new(hidden),
 			Labels:      spawnerLabelSlice(labels),
 		},
 	}
@@ -49,7 +48,7 @@ func podConfigValue(id string, hidden bool, labels map[string]string) kubeflowor
 		Id: id,
 		Spawner: kubefloworgv1beta1.OptionSpawnerInfo{
 			DisplayName: id,
-			Hidden:      ptr.To(hidden),
+			Hidden:      new(hidden),
 			Labels:      spawnerLabelSlice(labels),
 		},
 	}
@@ -223,12 +222,12 @@ var _ = Describe("NewPodTemplateOptionsModelFromWorkspaceKind", func() {
 				[]kubefloworgv1beta1.FilterRule{
 					{
 						Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
-						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)}},
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}},
 						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchImageConfig(map[string]string{"img-eol": "true"})},
 					},
 					{
 						Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
-						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: ptr.To(true)}},
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}},
 						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchPodConfig(map[string]string{"pod-eol": "true"})},
 					},
 				},
@@ -263,7 +262,7 @@ var _ = Describe("NewPodTemplateOptionsModelFromWorkspaceKind", func() {
 						Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
 						Effect: kubefloworgv1beta1.FilterRuleEffect{
 							API: &kubefloworgv1beta1.FilterRuleEffectAPI{
-								Deny:        ptr.To(true),
+								Deny:        new(true),
 								DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "image is end-of-life"},
 							},
 						},
@@ -273,7 +272,7 @@ var _ = Describe("NewPodTemplateOptionsModelFromWorkspaceKind", func() {
 						Scope: kubefloworgv1beta1.FilterRuleScopePodConfig,
 						Effect: kubefloworgv1beta1.FilterRuleEffect{
 							API: &kubefloworgv1beta1.FilterRuleEffectAPI{
-								Deny:        ptr.To(true),
+								Deny:        new(true),
 								DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "pod config is end-of-life"},
 							},
 						},
@@ -398,7 +397,7 @@ var _ = Describe("NewPodTemplateOptionsModelFromWorkspaceKind", func() {
 					// second image rule (never reached): api.deny
 					{
 						Scope:  kubefloworgv1beta1.FilterRuleScopeImageConfig,
-						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(true)}},
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: new(true)}},
 						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchImageConfig(map[string]string{"img-gpu": "true"})},
 					},
 					// first pod rule: ui.hide
@@ -408,7 +407,7 @@ var _ = Describe("NewPodTemplateOptionsModelFromWorkspaceKind", func() {
 					// second pod rule (never reached): api.deny
 					{
 						Scope:  kubefloworgv1beta1.FilterRuleScopePodConfig,
-						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: ptr.To(true)}},
+						Effect: kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: new(true)}},
 						Match:  []kubefloworgv1beta1.FilterRuleMatch{matchPodConfig(map[string]string{"pod-gpu": "true"})},
 					},
 				},

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types_write.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types_write.go
@@ -37,6 +37,18 @@ func (d *ListValuesRequest) Validate(prefix *field.Path) []*field.Error {
 	return errs
 }
 
+// ConfigIDs returns the imageConfig and podConfig ids from the request context,
+// each empty when the corresponding context is absent.
+func (d *ListValuesRequest) ConfigIDs() (imageConfigID, podConfigID string) {
+	if d.Context.ImageConfig != nil {
+		imageConfigID = d.Context.ImageConfig.Id
+	}
+	if d.Context.PodConfig != nil {
+		podConfigID = d.Context.PodConfig.Id
+	}
+	return imageConfigID, podConfigID
+}
+
 type ListValuesContext struct {
 	Namespace   *ContextNamespace   `json:"namespace,omitempty"`
 	PodConfig   *ContextPodConfig   `json:"podConfig,omitempty"`

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types_write.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/types_write.go
@@ -37,9 +37,9 @@ func (d *ListValuesRequest) Validate(prefix *field.Path) []*field.Error {
 	return errs
 }
 
-// ConfigIDs returns the imageConfig and podConfig ids from the request context,
+// configIDs returns the imageConfig and podConfig ids from the request context,
 // each empty when the corresponding context is absent.
-func (d *ListValuesRequest) ConfigIDs() (imageConfigID, podConfigID string) {
+func (d *ListValuesRequest) configIDs() (imageConfigID, podConfigID string) {
 	if d.Context.ImageConfig != nil {
 		imageConfigID = d.Context.ImageConfig.Id
 	}

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
@@ -220,11 +221,11 @@ func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, li
 		return nil, err
 	}
 
-	// always return a non-nil map so matchNamespace conditions are evaluated (namespace present)
-	if namespace.Labels == nil {
-		return map[string]string{}, nil
-	}
-	return namespace.Labels, nil
+	// copy the labels into a map we own; also ensures a non-nil map so matchNamespace conditions
+	// are evaluated (namespace present) even when the namespace has no labels.
+	labels := make(map[string]string, len(namespace.Labels))
+	maps.Copy(labels, namespace.Labels)
+	return labels, nil
 }
 
 // GetWorkspaceKindAssetBytesIcon retrieves the content of a WorkspaceKind icon as bytes, along with its media type.

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -188,13 +188,43 @@ func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Conte
 		return nil, err
 	}
 
+	// resolve the labels of the namespace named in the request context (used by matchNamespace rules).
+	// nil when no namespace context was provided, so those conditions are treated as non-matching.
+	namespaceLabels, err := r.resolveNamespaceLabels(ctx, listValuesRequest)
+	if err != nil {
+		return nil, err
+	}
+
 	// convert the WorkspaceKind and ListValuesRequest to PodTemplateOptions model
-	listValuesResponse, err := modelsPodTemplateOptions.NewPodTemplateOptionsModelFromWorkspaceKind(workspaceKind, listValuesRequest)
+	listValuesResponse, err := modelsPodTemplateOptions.NewPodTemplateOptionsModelFromWorkspaceKind(workspaceKind, listValuesRequest, namespaceLabels)
 	if err != nil {
 		return nil, err
 	}
 
 	return listValuesResponse, nil
+}
+
+// resolveNamespaceLabels fetches the labels of the namespace named in the request context.
+// It returns nil (and no error) when no namespace context was provided, or when the namespace
+// does not exist, so that matchNamespace conditions are conservatively treated as non-matching.
+func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, listValuesRequest *modelsPodTemplateOptions.ListValuesRequest) (map[string]string, error) {
+	if listValuesRequest.Context.Namespace == nil || listValuesRequest.Context.Namespace.Name == "" {
+		return nil, nil
+	}
+
+	namespace := &corev1.Namespace{}
+	if err := r.client.Get(ctx, client.ObjectKey{Name: listValuesRequest.Context.Namespace.Name}, namespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// always return a non-nil map so matchNamespace conditions are evaluated (namespace present)
+	if namespace.Labels == nil {
+		return map[string]string{}, nil
+	}
+	return namespace.Labels, nil
 }
 
 // GetWorkspaceKindAssetBytesIcon retrieves the content of a WorkspaceKind icon as bytes, along with its media type.


### PR DESCRIPTION
closes: #846

Evolves the stub `POST /listvalues` endpoint into a full implementation that evaluates `spec.filterRules[]` from the WorkspaceKind CRD to compute `hidden` and `restrictions` for each imageConfig and podConfig value in the response. This is the core of the Compatibility Selectors feature — the firewall-style (first-match-wins) rule evaluation engine.

Implemented the following:

1. Add a standalone `filterrules` package with a shared, dependency-light `Evaluate` engine (first-match-wins semantics), so it can be reused by the upcoming `/workspacekinds` API (#847).
2. Rule evaluation per option value:
   - `hidden` merging — final `hidden` = admin-set value **OR** `ui.hide` from the first matching rule.
   - `restrictions` computation — `deny` + `denyMessage` from the first matching `api.deny` rule.
   - `api.hide` filtering — omit items from the response when an `api.hide: true` effect matches.
3. Match condition evaluation (AND logic) using standard Kubernetes label selectors (`metav1.LabelSelectorAsSelector`):
   - `matchNamespace.selector` — against namespace labels fetched once per request from the k8s API.
   - `matchImageConfig.selector` / `matchPodConfig.selector` — against the option value's `spawner.labels`.
4. Cross-option matching — when `context.imageConfig.id` / `context.podConfig.id` is provided, the selected option's labels are resolved and used to evaluate cross-scope conditions (e.g. selecting an NVIDIA image hides non-GPU podConfigs).
5. Conservative semantics for absent context — when the required labels are not available (e.g. no `context.namespace.name`), the condition is treated as non-matching, so nothing is hidden/denied without full context.
6. Unit tests covering all rule evaluation scenarios: namespace matching, cross-option matching, `api.hide` omission, `api.deny` + `denyMessage`, `hidden` merging, first-match-wins ordering, and the no-rules default (100% statement coverage of the engine).

Notes:

- The response schema already included the `restrictions` attribute (added in a prior PR), so no swagger regeneration was required.
- `WORKSPACE_KIND`-scoped rules are intentionally not evaluated here — they belong to the `/workspacekinds` endpoint (#847). The engine is generic and already supports that scope.