### PR TITLE
feat: expose activityRules in WorkspaceKind PUT endpoint

### DIFF
--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -1100,6 +1100,93 @@ metadata:
 			Expect(lastOption.Spec.Resources).NotTo(BeNil())
 		})
 
+		It("should add activityRules and persist the change", func() {
+			By("getting current data")
+			getData := getWorkspaceKindData(wskName)
+			Expect(getData.ActivityRules).To(BeEmpty())
+
+			By("adding activity rules")
+			getData.ActivityRules = []kubefloworgv1beta1.ActivityRule{
+				{
+					Config: kubefloworgv1beta1.ActivityRuleConfig{
+						SecondsSinceActive: 3600,
+					},
+					Effect: kubefloworgv1beta1.ActivityRuleEffect{
+						PauseWorkspace: new(true),
+					},
+				},
+			}
+
+			dataJSON, err := json.Marshal(getData)
+			Expect(err).NotTo(HaveOccurred())
+			updateBody := fmt.Sprintf(`{"data": %s}`, string(dataJSON))
+
+			By("executing update")
+			rr := doUpdate(wskName, updateBody)
+			Expect(rr.Result().StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("verifying the change persists via GET")
+			updatedData := getWorkspaceKindData(wskName)
+			Expect(updatedData.ActivityRules).To(HaveLen(1))
+			Expect(updatedData.ActivityRules[0].Config.SecondsSinceActive).To(Equal(int32(3600)))
+			Expect(updatedData.ActivityRules[0].Effect.PauseWorkspace).NotTo(BeNil())
+			Expect(*updatedData.ActivityRules[0].Effect.PauseWorkspace).To(BeTrue())
+
+			By("verifying the CRD was updated in Kubernetes")
+			wsk := &kubefloworgv1beta1.WorkspaceKind{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wskName}, wsk)).To(Succeed())
+			Expect(wsk.Spec.ActivityRules).To(HaveLen(1))
+			Expect(wsk.Spec.ActivityRules[0].Config.SecondsSinceActive).To(Equal(int32(3600)))
+		})
+
+		It("should edit existing activityRules and persist the change", func() {
+			By("getting current data (has 1 rule from previous test)")
+			getData := getWorkspaceKindData(wskName)
+			Expect(getData.ActivityRules).To(HaveLen(1))
+
+			By("modifying the existing rule's timeout")
+			getData.ActivityRules[0].Config.SecondsSinceActive = 7200
+
+			dataJSON, err := json.Marshal(getData)
+			Expect(err).NotTo(HaveOccurred())
+			updateBody := fmt.Sprintf(`{"data": %s}`, string(dataJSON))
+
+			By("executing update")
+			rr := doUpdate(wskName, updateBody)
+			Expect(rr.Result().StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("verifying the change persists via GET")
+			updatedData := getWorkspaceKindData(wskName)
+			Expect(updatedData.ActivityRules).To(HaveLen(1))
+			Expect(updatedData.ActivityRules[0].Config.SecondsSinceActive).To(Equal(int32(7200)))
+		})
+
+		It("should clear activityRules when omitted from update", func() {
+			By("getting current data (has 1 rule from previous test)")
+			getData := getWorkspaceKindData(wskName)
+			Expect(getData.ActivityRules).To(HaveLen(1))
+
+			By("setting activityRules to nil to simulate omission")
+			getData.ActivityRules = nil
+
+			dataJSON, err := json.Marshal(getData)
+			Expect(err).NotTo(HaveOccurred())
+			updateBody := fmt.Sprintf(`{"data": %s}`, string(dataJSON))
+
+			By("executing update")
+			rr := doUpdate(wskName, updateBody)
+			Expect(rr.Result().StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("verifying activityRules are cleared via GET")
+			updatedData := getWorkspaceKindData(wskName)
+			Expect(updatedData.ActivityRules).To(BeEmpty())
+
+			By("verifying the CRD was updated in Kubernetes")
+			wsk := &kubefloworgv1beta1.WorkspaceKind{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wskName}, wsk)).To(Succeed())
+			Expect(wsk.Spec.ActivityRules).To(BeEmpty())
+		})
+
 		It("should return 404 for a non-existent WorkspaceKind", func() {
 			missingName := "non-existent-wsk"
 			updateBody := `{

--- a/workspaces/backend/internal/models/workspacekinds/funcs_write.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_write.go
@@ -36,9 +36,10 @@ func NewWorkspaceKindCreateModelFromWorkspaceKind(wsk *kubefloworgv1beta1.Worksp
 // Used by GET (by name) and Update responses.
 func NewWorkspaceKindUpdateModelFromWorkspaceKind(wsk *kubefloworgv1beta1.WorkspaceKind) *WorkspaceKindUpdate {
 	return &WorkspaceKindUpdate{
-		Revision:    common.CalculateRevision(&wsk.ObjectMeta),
-		Spawner:     wsk.Spec.Spawner,
-		PodTemplate: wsk.Spec.PodTemplate,
+		Revision:      common.CalculateRevision(&wsk.ObjectMeta),
+		Spawner:       wsk.Spec.Spawner,
+		PodTemplate:   wsk.Spec.PodTemplate,
+		ActivityRules: wsk.Spec.ActivityRules,
 	}
 }
 
@@ -47,4 +48,5 @@ func NewWorkspaceKindUpdateModelFromWorkspaceKind(wsk *kubefloworgv1beta1.Worksp
 func ApplyWorkspaceKindUpdateModelToWorkspaceKind(update *WorkspaceKindUpdate, wsk *kubefloworgv1beta1.WorkspaceKind) {
 	wsk.Spec.Spawner = update.Spawner
 	wsk.Spec.PodTemplate = update.PodTemplate
+	wsk.Spec.ActivityRules = update.ActivityRules
 }

--- a/workspaces/backend/internal/models/workspacekinds/types_write.go
+++ b/workspaces/backend/internal/models/workspacekinds/types_write.go
@@ -39,8 +39,9 @@ type WorkspaceKindUpdate struct {
 	//     other than for equality, as the format is not guaranteed to be stable.
 	Revision common.RevisionString `json:"revision"`
 
-	Spawner     kubefloworgv1beta1.WorkspaceKindSpawner     `json:"spawner"`
-	PodTemplate kubefloworgv1beta1.WorkspaceKindPodTemplate `json:"podTemplate"`
+	Spawner       kubefloworgv1beta1.WorkspaceKindSpawner     `json:"spawner"`
+	PodTemplate   kubefloworgv1beta1.WorkspaceKindPodTemplate `json:"podTemplate"`
+	ActivityRules []kubefloworgv1beta1.ActivityRule           `json:"activityRules,omitempty"`
 }
 
 // Validate performs validation on the WorkspaceKindUpdate struct

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -6343,6 +6343,85 @@ const docTemplate = `{
                 }
             }
         },
+        "v1beta1.ActivityRule": {
+            "type": "object",
+            "required": [
+                "config",
+                "effect"
+            ],
+            "properties": {
+                "config": {
+                    "description": "the configuration for this rule",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.ActivityRuleConfig"
+                        }
+                    ]
+                },
+                "effect": {
+                    "description": "the action to take when the rule matches and its conditions are met",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.ActivityRuleEffect"
+                        }
+                    ]
+                },
+                "match": {
+                    "description": "the conditions under which this rule applies\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.ActivityRuleMatch"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.ActivityRuleConfig": {
+            "type": "object",
+            "required": [
+                "secondsSinceActive"
+            ],
+            "properties": {
+                "minRunningSeconds": {
+                    "description": "the minimum duration in seconds a Workspace must be running before it can be paused due to inactivity\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:default:=0\n+kubebuilder:validation:Optional",
+                    "type": "integer"
+                },
+                "secondsSinceActive": {
+                    "description": "the number of seconds of inactivity before a Workspace is eligible for this rule's effect\n - the minimum value is 16 (` + "`" + `secondsSinceActive` + "`" + ` \u003e 15) to prevent thrashing and culling\n   workspaces prematurely during startup or transient connection drops\n+kubebuilder:validation:Minimum:=16",
+                    "type": "integer"
+                }
+            }
+        },
+        "v1beta1.ActivityRuleEffect": {
+            "type": "object",
+            "properties": {
+                "pauseWorkspace": {
+                    "description": "determines if the Workspace should be paused\n - the webhook rejects rules with ` + "`" + `pauseWorkspace: true` + "`" + `\n   when no ` + "`" + `activityProbe` + "`" + ` is configured\n+kubebuilder:validation:Optional",
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1beta1.ActivityRuleMatch": {
+            "type": "object",
+            "properties": {
+                "matchNamespace": {
+                    "description": "filters Workspaces by namespace labels\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.NamespaceMatch"
+                        }
+                    ]
+                },
+                "matchPodConfig": {
+                    "description": "filters Workspaces by the PodConfig option they are using\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.PodConfigMatch"
+                        }
+                    ]
+                }
+            }
+        },
         "v1beta1.HTTPProxy": {
             "type": "object",
             "properties": {
@@ -6507,6 +6586,22 @@ const docTemplate = `{
                 }
             }
         },
+        "v1beta1.NamespaceMatch": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "description": "the standard Kubernetes label selector to match namespace labels",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.LabelSelector"
+                        }
+                    ]
+                }
+            }
+        },
         "v1beta1.OptionRedirect": {
             "type": "object",
             "required": [
@@ -6604,6 +6699,22 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/v1beta1.PodConfigValue"
                     }
+                }
+            }
+        },
+        "v1beta1.PodConfigMatch": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "description": "the standard Kubernetes label selector to match podConfig labels",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.LabelSelector"
+                        }
+                    ]
                 }
             }
         },
@@ -7338,6 +7449,12 @@ const docTemplate = `{
                 "spawner"
             ],
             "properties": {
+                "activityRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1beta1.ActivityRule"
+                    }
+                },
                 "podTemplate": {
                     "$ref": "#/definitions/v1beta1.WorkspaceKindPodTemplate"
                 },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -6341,6 +6341,85 @@
                 }
             }
         },
+        "v1beta1.ActivityRule": {
+            "type": "object",
+            "required": [
+                "config",
+                "effect"
+            ],
+            "properties": {
+                "config": {
+                    "description": "the configuration for this rule",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.ActivityRuleConfig"
+                        }
+                    ]
+                },
+                "effect": {
+                    "description": "the action to take when the rule matches and its conditions are met",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.ActivityRuleEffect"
+                        }
+                    ]
+                },
+                "match": {
+                    "description": "the conditions under which this rule applies\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.ActivityRuleMatch"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.ActivityRuleConfig": {
+            "type": "object",
+            "required": [
+                "secondsSinceActive"
+            ],
+            "properties": {
+                "minRunningSeconds": {
+                    "description": "the minimum duration in seconds a Workspace must be running before it can be paused due to inactivity\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:default:=0\n+kubebuilder:validation:Optional",
+                    "type": "integer"
+                },
+                "secondsSinceActive": {
+                    "description": "the number of seconds of inactivity before a Workspace is eligible for this rule's effect\n - the minimum value is 16 (`secondsSinceActive` \u003e 15) to prevent thrashing and culling\n   workspaces prematurely during startup or transient connection drops\n+kubebuilder:validation:Minimum:=16",
+                    "type": "integer"
+                }
+            }
+        },
+        "v1beta1.ActivityRuleEffect": {
+            "type": "object",
+            "properties": {
+                "pauseWorkspace": {
+                    "description": "determines if the Workspace should be paused\n - the webhook rejects rules with `pauseWorkspace: true`\n   when no `activityProbe` is configured\n+kubebuilder:validation:Optional",
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1beta1.ActivityRuleMatch": {
+            "type": "object",
+            "properties": {
+                "matchNamespace": {
+                    "description": "filters Workspaces by namespace labels\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.NamespaceMatch"
+                        }
+                    ]
+                },
+                "matchPodConfig": {
+                    "description": "filters Workspaces by the PodConfig option they are using\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.PodConfigMatch"
+                        }
+                    ]
+                }
+            }
+        },
         "v1beta1.HTTPProxy": {
             "type": "object",
             "properties": {
@@ -6505,6 +6584,22 @@
                 }
             }
         },
+        "v1beta1.NamespaceMatch": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "description": "the standard Kubernetes label selector to match namespace labels",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.LabelSelector"
+                        }
+                    ]
+                }
+            }
+        },
         "v1beta1.OptionRedirect": {
             "type": "object",
             "required": [
@@ -6602,6 +6697,22 @@
                     "items": {
                         "$ref": "#/definitions/v1beta1.PodConfigValue"
                     }
+                }
+            }
+        },
+        "v1beta1.PodConfigMatch": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "description": "the standard Kubernetes label selector to match podConfig labels",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.LabelSelector"
+                        }
+                    ]
                 }
             }
         },
@@ -7336,6 +7447,12 @@
                 "spawner"
             ],
             "properties": {
+                "activityRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1beta1.ActivityRule"
+                    }
+                },
                 "podTemplate": {
                     "$ref": "#/definitions/v1beta1.WorkspaceKindPodTemplate"
                 },


### PR DESCRIPTION
closes: #1318
related: #1283 

Add activityRules field to the WorkspaceKindUpdate model so activity rules can be added, edited, and cleared via the PUT endpoint, matching the full-replacement semantics already used for spawner and podTemplate.

Changes:

- Add ActivityRules to WorkspaceKindUpdate
- Update Swagger
- Add tests