### PR TITLE
fix: filter hidden options and display restrictions popover

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/utils/testBuilders.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/utils/testBuilders.ts
@@ -182,3 +182,20 @@ export const interceptListValues = (
     })
     .as(`listValues-${kind.name}`);
 };
+
+export const buildMockImageWithRestrictions = (
+  id: string,
+  displayName: string,
+  deny: boolean,
+  denyMessageText?: string,
+): OptionsImageConfigValue => ({
+  id,
+  displayName,
+  description: `Image: ${displayName}`,
+  hidden: false,
+  redirect: undefined,
+  clusterMetrics: undefined,
+  restrictions: deny
+    ? { deny: true, denyMessage: { text: denyMessageText ?? '' } }
+    : { deny: false },
+});

--- a/workspaces/frontend/src/app/components/RestrictedIconWithPopover.tsx
+++ b/workspaces/frontend/src/app/components/RestrictedIconWithPopover.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Popover } from '@patternfly/react-core/dist/esm/components/Popover';
+import { BanIcon } from '@patternfly/react-icons/dist/esm/icons/ban-icon';
+
+interface RestrictedIconWithPopoverProps {
+  id: string;
+  message: string;
+}
+
+export const RestrictedIconWithPopover: React.FC<RestrictedIconWithPopoverProps> = ({
+  id,
+  message,
+}) => (
+  <Popover id={id} bodyContent={message} triggerAction="hover">
+    <BanIcon aria-label="Restricted option" className="workspace-option-card__restricted-icon" />
+  </Popover>
+);

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -119,6 +119,21 @@ const WorkspaceForm: React.FC = () => {
     // Store original values for diff comparison
     setOriginalData(initialFormData);
   }, [initialFormData, initialFormDataLoaded, mode, replaceData]);
+  function resolveUsableDefault<
+    T extends { id: string; hidden?: boolean; restrictions?: { deny?: boolean } },
+  >(values: T[] | undefined, defaultId: string | undefined): string | undefined {
+    if (!values) {
+      return undefined;
+    }
+    const defaultOption = values.find((v) => v.id === defaultId);
+    if (defaultOption && !defaultOption.restrictions?.deny) {
+      return defaultId;
+    }
+    const isUsable = (opt?: T) => !opt?.restrictions?.deny;
+    const fallback = values.find((v) => isUsable(v));
+
+    return fallback?.id;
+  }
 
   // Apply default imageConfig and podConfig from listValues when a kind is first selected.
   // Only sets defaults when the values are unset (undefined), so user selections are never overwritten.
@@ -127,10 +142,22 @@ const WorkspaceForm: React.FC = () => {
       return;
     }
     if (!data.imageConfig && allValuesData.imageConfig.default) {
-      setData('imageConfig', allValuesData.imageConfig.default);
+      const resolved = resolveUsableDefault(
+        allValuesData.imageConfig.values,
+        allValuesData.imageConfig.default,
+      );
+      if (resolved) {
+        setData('imageConfig', resolved);
+      }
     }
     if (!data.podConfig && allValuesData.podConfig.default) {
-      setData('podConfig', allValuesData.podConfig.default);
+      const resolved = resolveUsableDefault(
+        allValuesData.podConfig.values,
+        allValuesData.podConfig.default,
+      );
+      if (resolved) {
+        setData('podConfig', resolved);
+      }
     }
   }, [allValuesData, allValuesLoaded, data.kind, data.imageConfig, data.podConfig, setData]);
 
@@ -140,7 +167,9 @@ const WorkspaceForm: React.FC = () => {
       return;
     }
     const podConfigOptions = filteredValuesData.podConfig.values ?? [];
-    const isStillValid = podConfigOptions.some((pc) => pc.id === data.podConfig);
+    const current = podConfigOptions.find((pc) => pc.id === data.podConfig);
+    // denied-but-present is left alone on purpose; hidden options are cleared
+    const isStillValid = !!current;
     if (!isStillValid) {
       setData('podConfig', undefined);
     }

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/image/WorkspaceFormImageList.tsx
@@ -55,6 +55,9 @@ export const WorkspaceFormImageList: React.FunctionComponent<WorkspaceFormImageL
       const newSelectedWorkspaceImage = filteredWorkspaceImages.find(
         (image) => image.displayName === event.currentTarget.name,
       );
+      if (newSelectedWorkspaceImage?.restrictions.deny) {
+        return;
+      }
       onSelect(newSelectedWorkspaceImage);
     },
     [filteredWorkspaceImages, onSelect],
@@ -62,12 +65,12 @@ export const WorkspaceFormImageList: React.FunctionComponent<WorkspaceFormImageL
 
   const handleCardClick = useCallback(
     (image: OptionsImageConfigValue) => {
-      if (image.id !== selectedImage?.id) {
+      if (image.restrictions.deny) {
         return;
       }
       onSelect(image);
     },
-    [selectedImage, onSelect],
+    [onSelect],
   );
 
   return (

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/podConfig/WorkspaceFormPodConfigList.tsx
@@ -58,12 +58,12 @@ export const WorkspaceFormPodConfigList: React.FunctionComponent<
 
   const handleCardClick = useCallback(
     (podConfig: OptionsPodConfigValue) => {
-      if (podConfig.id !== selectedPodConfig?.id) {
+      if (podConfig.restrictions.deny) {
         return;
       }
       onSelect(podConfig);
     },
-    [selectedPodConfig?.id, onSelect],
+    [onSelect],
   );
 
   return (

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/shared/WorkspaceFormOptionCard.tsx
@@ -7,8 +7,10 @@ import {
 } from '@patternfly/react-core/dist/esm/components/Card';
 import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { css } from '@patternfly/react-styles';
 import { HiddenIconWithPopover } from '~/app/components/HiddenIconWithPopover';
 import { RedirectIconWithPopover } from '~/app/components/RedirectIconWithPopover';
+import { RestrictedIconWithPopover } from '~/app/components/RestrictedIconWithPopover';
 import {
   OptionValue,
   resolveRedirectChain,
@@ -46,17 +48,23 @@ export const WorkspaceFormOptionCard: React.FC<
   const cardId = option.id.replace(/ /g, '-');
   const popoverIdHidden = `hidden-${cardId}`;
   const popoverIdRedirect = `redirect-${cardId}`;
+  const isDenied = option.restrictions.deny === true;
+  const popoverIdRestricted = `restricted-${cardId}`;
+  const isRedirect = option.redirect !== undefined;
 
-  const cardClasses = [
-    option.hidden ? 'workspace-option-card--hidden' : '',
-    option.redirect ? 'workspace-option-card--redirected' : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const cardClasses = css(
+    'workspace-option-card',
+    option.hidden && 'workspace-option-card--hidden',
+    isRedirect && 'workspace-option-card--redirected',
+    isDenied && 'workspace-option-card--restricted',
+  );
 
-  const handleCardClick = (e: React.MouseEvent) => {
+  const handleCardClick = (event: React.MouseEvent) => {
+    if (isDenied) {
+      return;
+    }
     // Check if click originated from an icon (hidden or redirect)
-    const target = e.target as HTMLElement;
+    const target = event.target as HTMLElement;
     const clickedIcon = target.closest(
       '[data-testid="hidden-icon"], [data-testid="redirect-icon"]',
     );
@@ -70,12 +78,12 @@ export const WorkspaceFormOptionCard: React.FC<
   return (
     <Card
       isCompact
-      isSelectable
-      key={option.id}
       id={cardId}
       isSelected={isSelected}
-      onClick={handleCardClick}
+      isSelectable={!isDenied}
+      isDisabled={isDenied}
       className={cardClasses}
+      onClick={handleCardClick}
     >
       <CardHeader
         selectableActions={{
@@ -106,6 +114,13 @@ export const WorkspaceFormOptionCard: React.FC<
         className="workspace-option-card__icons-container"
         data-testid={`option-card-icons-${cardId}`}
       >
+        {isDenied && (
+          <RestrictedIconWithPopover
+            id={popoverIdRestricted}
+            message={option.restrictions.denyMessage?.text ?? 'This option is restricted.'}
+          />
+        )}
+
         {isDefault && (
           <FlexItem>
             <Label color="blue" isCompact>


### PR DESCRIPTION
Fixes issue where restricted or hidden options were not properly evaluated or displayed in the Workspace creation/edit wizard.
This PR implements rule-based option filtering and restriction handling for both **Image Config** and **Pod Config** selection steps:
1. Filters out options where `hidden: true` from the available selection lists.
2. Renders options with `restrictions.deny: true` as disabled (`isDisabled`) and non-selectable, displaying a `BanIcon` with a hover popover containing the restriction message (`denyMessage.text`).
3. Resolves usable default options upon kind selection; if a default option is hidden or denied, the form pre-selects the next available usable option.
4. Preserves currently selected pod configs during context changes if they exist and are not hidden (even if denied), so users can see why their current selection is restricted.

**Key Changes:**
- **`WorkspaceFormOptionCard.tsx`**: Updated option card to check `restrictions.deny`, apply disabled styling (`workspace-option-card--restricted`), block card click interactions, and render `RestrictedIconWithPopover`.
- **`RestrictedIconWithPopover.tsx`**: Added PatternFly `Popover` wrapper with `BanIcon` to show restriction explanation text on hover.
- **`WorkspaceFormImageList.tsx` & `WorkspaceFormPodConfigList.tsx`**: Added defensive check in option click/change handlers to prevent selection of denied options.
- **`WorkspaceForm.tsx`**: Added `resolveUsableDefault` helper to resolve usable (non-hidden, non-denied) default options for `imageConfig` and `podConfig`. Updated podConfig re-validation effect to leave denied-but-present options selected for clear UI feedback.
- **`testBuilders.ts`**: Added `buildMockImageWithRestrictions` test helper for unit and Cypress tests.

**Screenshots / UI Verification:**

<img width="1617" height="882" alt="Screenshot 2026-08-13 235057" src="https://github.com/user-attachments/assets/935814dc-3da3-4bd4-9692-0aab6645599c" />

**How to Test:**
1. Run local dev server: `npm run start:dev`
2. Navigate to Create Workspace form -> Image & Pod Config steps.
3. Verify options with `hidden: true` do not appear.
4. Verify options with `restrictions.deny: true` are disabled and hovering over the icon displays the restriction text.
5. Run TypeScript check & unit tests:
   ```bash
   npm run test:type-check
   npm run test:unit

closes: #1209
related: #735
