### PR TITLE
feat: Add pauseWorkspace activity rule info to workspace table and details

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
@@ -71,6 +71,22 @@ class Workspaces {
       .should('have.text', lastActivity);
   }
 
+  hoverWorkspaceRowLastActivity(index: number) {
+    cy.findByTestId(`workspace-row-${index}`)
+      .findByTestId('workspace-lastActivity')
+      .find('span')
+      .first()
+      .trigger('mouseenter');
+  }
+
+  assertTooltipContainsText(text: string) {
+    cy.findByTestId('workspace-lastActivity-tooltip').should('contain.text', text);
+  }
+
+  assertTooltipNotExists() {
+    cy.get('.pf-v6-c-tooltip').should('not.exist');
+  }
+
   applyFilter(args: { key: string; value: string; name: string }) {
     cy.findByTestId('filter-workspaces-dropdown').click();
     cy.findByTestId(`filter-workspaces-dropdown-${args.key}`).click();
@@ -405,6 +421,10 @@ class WorkspaceDetailsDrawer {
 
   assertActivityTabContentContainsText(text: string) {
     this.findActivityTabContent().should('contain.text', text);
+  }
+
+  assertActivityTabContentNotContainsText(text: string) {
+    this.findActivityTabContent().should('not.contain.text', text);
   }
 
   assertOverviewTabAriaSelected(selected: boolean) {

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaces.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/workspaces.cy.ts
@@ -993,8 +993,94 @@ describe('Workspaces', () => {
         workspaceDetailsDrawer.assertActivityTabContentVisible();
         workspaceDetailsDrawer.assertActivityTabContentContainsText('Last activity');
         workspaceDetailsDrawer.assertActivityTabContentContainsText('Last update');
-        workspaceDetailsDrawer.assertActivityTabContentContainsText('Pause time');
+        workspaceDetailsDrawer.assertActivityTabContentContainsText('Pauses after');
+        workspaceDetailsDrawer.assertActivityTabContentContainsText('Paused since');
         workspaceDetailsDrawer.assertActivityTabContentContainsText('Pending restart');
+      });
+
+      it('should hide Pauses after row when pauseWorkspace rule is absent', () => {
+        const mockNamespace = buildMockNamespace({ name: DEFAULT_NAMESPACE });
+        const mockWorkspaces = [
+          buildMockWorkspace({
+            name: TEST_WORKSPACE_NAME,
+            state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+            activity: {
+              lastActivity: new Date(2025, 5, 1).getTime(),
+              lastUpdate: new Date(2025, 4, 1).getTime(),
+            },
+          }),
+        ];
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/namespaces',
+          { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+          mockModArchResponse([mockNamespace]),
+        ).as('getNamespaces');
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/workspaces/:namespace',
+          { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
+          mockModArchResponse(mockWorkspaces),
+        ).as('getWorkspaces');
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/workspaces/:namespace/:workspaceName/podtemplate/details',
+          {
+            path: {
+              apiVersion: NOTEBOOKS_API_VERSION,
+              namespace: mockNamespace.name,
+              workspaceName: TEST_WORKSPACE_NAME,
+            },
+          },
+          mockModArchResponse(buildMockWorkspaceDetails()),
+        ).as('getWorkspaceDetails');
+
+        navigateToNamespace(mockNamespace.name);
+
+        workspaces
+          .findAction({ action: 'viewDetails', workspaceName: TEST_WORKSPACE_NAME })
+          .click();
+        workspaceDetailsDrawer.findActivityTab().click();
+
+        workspaceDetailsDrawer.assertActivityTabContentContainsText('Last activity');
+        workspaceDetailsDrawer.assertActivityTabContentContainsText('Paused since');
+        workspaceDetailsDrawer.assertActivityTabContentNotContainsText('Pauses after');
+      });
+
+      it('should show pause tooltip on last activity hover when pause rule exists', () => {
+        workspaces.hoverWorkspaceRowLastActivity(0);
+        workspaces.assertTooltipContainsText('Workspace will be paused in');
+      });
+
+      it('should not show pause tooltip when pause rule is absent', () => {
+        const mockNamespace = buildMockNamespace({ name: DEFAULT_NAMESPACE });
+        const mockWorkspaces = [
+          buildMockWorkspace({
+            name: TEST_WORKSPACE_NAME,
+            state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+            activity: {
+              lastActivity: new Date(2025, 5, 1).getTime(),
+              lastUpdate: new Date(2025, 4, 1).getTime(),
+            },
+          }),
+        ];
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/namespaces',
+          { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+          mockModArchResponse([mockNamespace]),
+        ).as('getNamespaces');
+
+        cy.interceptApi(
+          'GET /api/:apiVersion/workspaces/:namespace',
+          { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: mockNamespace.name } },
+          mockModArchResponse(mockWorkspaces),
+        ).as('getWorkspaces');
+
+        navigateToNamespace(mockNamespace.name);
+
+        workspaces.hoverWorkspaceRowLastActivity(0);
+        workspaces.assertTooltipNotExists();
       });
 
       it('should navigate back to Overview tab from Activity tab', () => {

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -6,10 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  TimestampTooltipVariant,
-  Timestamp,
-} from '@patternfly/react-core/dist/esm/components/Timestamp';
+import { Timestamp } from '@patternfly/react-core/dist/esm/components/Timestamp';
 import { Label } from '@patternfly/react-core/dist/esm/components/Label';
 import {
   PaginationVariant,
@@ -49,7 +46,11 @@ import {
   WORKSPACE_STATE_COLORS,
 } from '~/shared/utilities/WorkspaceUtils';
 import CustomEmptyState from '~/shared/components/CustomEmptyState';
-import { WorkspacesWorkspaceListItem, V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import {
+  WorkspacesActivity,
+  WorkspacesWorkspaceListItem,
+  V1Beta1WorkspaceState,
+} from '~/generated/data-contracts';
 import { RedirectIconWithPopover } from '~/app/components/RedirectIconWithPopover';
 import { POLL_INTERVAL } from '~/shared/utilities/const';
 import { RefreshCounter } from '~/app/components/RefreshCounter';
@@ -114,6 +115,32 @@ type WorkspaceFilterKey = keyof typeof filterConfig;
 
 // Defines which filters should appear in the dropdown
 const visibleFilterKeys: readonly WorkspaceFilterKey[] = ['name', 'kind', 'image', 'state'];
+
+const LastActivityCell: React.FC<{ activity: WorkspacesActivity }> = ({ activity }) => {
+  if (activity.lastActivity === 0) {
+    return <span className="pf-v6-c-timestamp pf-m-help-text">unknown</span>;
+  }
+
+  const timestamp = (
+    <Timestamp date={new Date(activity.lastActivity)}>
+      {formatDistanceToNow(new Date(activity.lastActivity), { addSuffix: true })}
+    </Timestamp>
+  );
+
+  const pauseRule = activity.rules?.pauseWorkspace;
+  if (!pauseRule) {
+    return timestamp;
+  }
+
+  return (
+    <Tooltip
+      data-testid="workspace-lastActivity-tooltip"
+      content={`Workspace will be paused in ${formatDistanceToNow(new Date(pauseRule.eligibleAfter))}`}
+    >
+      <span>{timestamp}</span>
+    </Tooltip>
+  );
+};
 
 export interface WorkspaceTableRef {
   clearAllFilters: () => void;
@@ -497,22 +524,9 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               )}
                               {columnKey === 'gpu' && formatResourceFromWorkspace(workspace, 'gpu')}
                               {columnKey === 'idleGpu' && formatWorkspaceIdleState(workspace)}
-                              {columnKey === 'lastActivity' &&
-                                (workspace.activity.lastActivity === 0 ? (
-                                  <span className="pf-v6-c-timestamp pf-m-help-text">unknown</span>
-                                ) : (
-                                  <Timestamp
-                                    date={new Date(workspace.activity.lastActivity)}
-                                    tooltip={{ variant: TimestampTooltipVariant.default }}
-                                  >
-                                    {formatDistanceToNow(
-                                      new Date(workspace.activity.lastActivity),
-                                      {
-                                        addSuffix: true,
-                                      },
-                                    )}
-                                  </Timestamp>
-                                ))}
+                              {columnKey === 'lastActivity' && (
+                                <LastActivityCell activity={workspace.activity} />
+                              )}
                             </Td>
                           );
                         })}

--- a/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Details/WorkspaceDetailsActivity.tsx
@@ -38,8 +38,19 @@ export const WorkspaceDetailsActivity: React.FunctionComponent<WorkspaceDetailsA
         </DescriptionListDescription>
       </DescriptionListGroup>
       <Divider />
+      {activity.rules?.pauseWorkspace && (
+        <>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Pauses after</DescriptionListTerm>
+            <DescriptionListDescription data-testid="pausesIn">
+              {format(new Date(activity.rules.pauseWorkspace.eligibleAfter), DATE_FORMAT)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <Divider />
+        </>
+      )}
       <DescriptionListGroup>
-        <DescriptionListTerm>Pause time</DescriptionListTerm>
+        <DescriptionListTerm>Paused since</DescriptionListTerm>
         <DescriptionListDescription data-testid="pauseTime">
           {pausedTime === 0 ? 'unknown' : format(pausedTime, DATE_FORMAT)}
         </DescriptionListDescription>

--- a/workspaces/frontend/src/shared/mock/mockBuilder.ts
+++ b/workspaces/frontend/src/shared/mock/mockBuilder.ts
@@ -396,6 +396,11 @@ export const buildMockWorkspace = (
   activity: {
     lastActivity: new Date(2025, 5, 1).getTime(),
     lastUpdate: new Date(2025, 4, 1).getTime(),
+    rules: {
+      pauseWorkspace: {
+        eligibleAfter: new Date(2025, 5, 2).getTime(),
+      },
+    },
   },
   services: [
     {

--- a/workspaces/frontend/src/shared/mock/mockNotebookServiceData.ts
+++ b/workspaces/frontend/src/shared/mock/mockNotebookServiceData.ts
@@ -250,6 +250,11 @@ export const mockWorkspace3: WorkspacesWorkspaceListItem = buildMockWorkspace({
   activity: {
     lastActivity: new Date(2025, 2, 15).getTime(),
     lastUpdate: new Date(2025, 2, 1).getTime(),
+    rules: {
+      pauseWorkspace: {
+        eligibleAfter: new Date(Date.now() + 500 * 60 * 60 * 24).getTime(),
+      },
+    },
   },
 });
 


### PR DESCRIPTION
 closes: #1202

- Add pauseWorkspace tooltip to Workspace Table when the user hovers over the Last Activity time
<img width="1060" height="437" alt="Screenshot 2026-08-13 at 4 29 10 PM" src="https://github.com/user-attachments/assets/e589d6ca-28be-437a-be12-b02408dcfd62" />
- Add "Pauses After" field in Activity Tab in Workspace Details
 <img width="1091" height="423" alt="Screenshot 2026-08-13 at 4 42 05 PM" src="https://github.com/user-attachments/assets/ed3d78b3-2b9b-4f9a-9abb-7e0979aa056e" />
- Add mocks