### PR TITLE
chore: Workspace table view adjustments

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -37,6 +37,14 @@
   cursor: pointer;
 }
 
+/* Workspace table row name: looks like plain text until hovered/focused, then reveals link styling.
+   Selector specificity matches PatternFly's own `.pf-v6-c-button` base rule (which also sets these
+   custom properties) so this override wins regardless of CSS injection order. */
+.pf-v6-c-button.workspace-table__name-link {
+  --pf-v6-c-button--m-link--m-inline--Color: var(--pf-t--global--text--color--regular);
+  --pf-v6-c-button--m-link--m-inline--TextDecorationLine: none;
+}
+
 .summary-redirect-icon-button {
   cursor: pointer;
   display: inline-flex;

--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -45,6 +45,28 @@
   --pf-v6-c-button--m-link--m-inline--TextDecorationLine: none;
 }
 
+/* Name is the only workspace table column whose content is unbounded user input, so it is the only
+   one that can grow without limit. Capping it means a pathological name truncates instead of
+   pushing the whole table into a horizontal scroll.
+
+   The cap sits on this span — an element the app owns and renders itself — rather than on the cell
+   or the button. Because `40ch` is an absolute length, the span shrink-wraps and bounds the cell's
+   `min-width: fit-content` on its own, so the constraint does not have to be threaded through the
+   boxes in between. Styling our own element also keeps us clear of PatternFly's internals: its
+   Button renders children inside a `.pf-v6-c-button__text` span that takes no className prop, and
+   reaching for that class directly would break on any release that changes it.
+
+   These declarations are `pf-v6-u-text-truncate` minus its `max-width: 100%`, which cannot be used
+   here because it would override the cap. `white-space` is required because PatternFly's base
+   button rule sets `normal`, overriding the `nowrap` the cell inherits from `fitContent`. */
+.workspace-table__name-text {
+  display: block;
+  max-width: 40ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .summary-redirect-icon-button {
   cursor: pointer;
   display: inline-flex;

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -67,9 +67,9 @@ const {
   sortableKeyArray: sortableWsTableColumnKeyArray,
 } = defineDataFields({
   name: { label: 'Name', isFilterable: true, isSortable: true, width: 20 },
-  image: { label: 'Image', isFilterable: true, isSortable: true, width: undefined },
-  podConfig: { label: 'Pod config', isFilterable: true, isSortable: true, width: undefined },
   kind: { label: 'Kind', isFilterable: true, isSortable: true, width: undefined },
+  podConfig: { label: 'Pod config', isFilterable: true, isSortable: true, width: undefined },
+  image: { label: 'Image', isFilterable: true, isSortable: true, width: undefined },
   namespace: { label: 'Namespace', isFilterable: true, isSortable: true, width: 15 },
   state: { label: 'State', isFilterable: true, isSortable: true, width: undefined },
   gpu: { label: 'GPU', isFilterable: true, isSortable: true, width: 15 },

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -67,11 +67,11 @@ const {
   sortableKeyArray: sortableWsTableColumnKeyArray,
 } = defineDataFields({
   name: { label: 'Name', isFilterable: true, isSortable: true, width: 20 },
-  image: { label: 'Image', isFilterable: true, isSortable: true, width: 15 },
-  podConfig: { label: 'Pod config', isFilterable: true, isSortable: true, width: 15 },
-  kind: { label: 'Kind', isFilterable: true, isSortable: true, width: 10 },
+  image: { label: 'Image', isFilterable: true, isSortable: true, width: undefined },
+  podConfig: { label: 'Pod config', isFilterable: true, isSortable: true, width: undefined },
+  kind: { label: 'Kind', isFilterable: true, isSortable: true, width: undefined },
   namespace: { label: 'Namespace', isFilterable: true, isSortable: true, width: 15 },
-  state: { label: 'State', isFilterable: true, isSortable: true, width: 10 },
+  state: { label: 'State', isFilterable: true, isSortable: true, width: undefined },
   gpu: { label: 'GPU', isFilterable: true, isSortable: true, width: 15 },
   idleGpu: { label: 'Idle GPU', isFilterable: true, isSortable: true, width: 15 },
   lastActivity: { label: 'Last activity', isFilterable: false, isSortable: true, width: 15 },
@@ -271,27 +271,33 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
       };
     };
 
-    // Column-specific modifiers and special properties
+    // Column-specific modifiers. Columns with inherently small/fixed-size content (an icon, a
+    // badge, a button) use fitContent to size to that content. The remaining columns keep a
+    // percentage `width` so they absorb the table's leftover width instead — auto table layout
+    // doesn't let fitContent columns shrink below their content unless other columns are
+    // "greedy" enough to claim the rest.
     const getColumnModifier = (
       columnKey: WorkspaceTableColumnKeys,
-    ): 'wrap' | 'nowrap' | undefined => {
+    ): 'wrap' | 'nowrap' | 'fitContent' | undefined => {
       switch (columnKey) {
-        case 'name':
         case 'kind':
-          return 'nowrap';
+        case 'state':
         case 'image':
         case 'podConfig':
-        case 'namespace':
-        case 'state':
-        case 'gpu':
-          return 'wrap';
+        case 'connect':
+          return 'fitContent';
+        case 'name':
         case 'lastActivity':
           return 'nowrap';
+        case 'namespace':
+        case 'gpu':
+          return 'wrap';
         default:
           return undefined;
       }
     };
 
+    // Column-specific special properties
     const getSpecialColumnProps = (columnKey: WorkspaceTableColumnKeys) => {
       switch (columnKey) {
         case 'connect':
@@ -423,6 +429,7 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                                     : `workspace-${columnKey}`
                               }
                               dataLabel={wsTableColumns[columnKey].label}
+                              modifier={getColumnModifier(columnKey)}
                             >
                               {columnKey === 'name' &&
                                 (() => {

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -30,6 +30,7 @@ import {
   Tbody,
   Td,
   ThProps,
+  BaseCellProps,
   ActionsColumn,
   IAction,
   IActions,
@@ -66,24 +67,53 @@ const {
   keyArray: wsTableColumnKeyArray,
   sortableKeyArray: sortableWsTableColumnKeyArray,
 } = defineDataFields({
-  name: { label: 'Name', isFilterable: true, isSortable: true, width: 20 },
+  name: { label: 'Name', isFilterable: true, isSortable: true },
   // Kind renders only a logo, and its header is rendered for screen readers alone (see
   // getSpecialColumnProps), so there is no header control to sort from. Filtering by kind
   // remains available from the toolbar.
-  kind: { label: 'Kind', isFilterable: true, isSortable: false, width: undefined },
-  podConfig: { label: 'Pod config', isFilterable: true, isSortable: true, width: undefined },
-  image: { label: 'Image', isFilterable: true, isSortable: true, width: undefined },
-  namespace: { label: 'Namespace', isFilterable: true, isSortable: true, width: 15 },
-  state: { label: 'State', isFilterable: true, isSortable: true, width: undefined },
-  gpu: { label: 'GPU', isFilterable: true, isSortable: true, width: 15 },
-  idleGpu: { label: 'Idle GPU', isFilterable: true, isSortable: true, width: 15 },
-  lastActivity: { label: 'Last activity', isFilterable: false, isSortable: true, width: 15 },
-  connect: { label: '', isFilterable: false, isSortable: false, width: undefined },
-  actions: { label: '', isFilterable: false, isSortable: false, width: undefined },
+  kind: { label: 'Kind', isFilterable: true, isSortable: false },
+  podConfig: { label: 'Pod config', isFilterable: true, isSortable: true },
+  image: { label: 'Image', isFilterable: true, isSortable: true },
+  namespace: { label: 'Namespace', isFilterable: true, isSortable: true },
+  state: { label: 'State', isFilterable: true, isSortable: true },
+  gpu: { label: 'GPU', isFilterable: true, isSortable: true },
+  idleGpu: { label: 'Idle GPU', isFilterable: true, isSortable: true },
+  lastActivity: { label: 'Last activity', isFilterable: false, isSortable: true },
+  connect: { label: '', isFilterable: false, isSortable: false },
+  actions: { label: '', isFilterable: false, isSortable: false },
 });
 
 export type WorkspaceTableColumnKeys = DataFieldKey<typeof wsTableColumns>;
 type WorkspaceTableSortableColumnKeys = SortableDataFieldKey<typeof wsTableColumns>;
+
+/**
+ * The breakpoints at which each column is rendered; `undefined` means always visible.
+ *
+ * Every column renders `fitContent` (`width: 1%; min-width: fit-content`), so each one is sized to
+ * its own content and auto table layout shares whatever is left over evenly between them. Only
+ * Name carries content that can grow without limit, and it is capped in `app.css`.
+ *
+ * Dropping the lowest-priority columns as the viewport narrows lets the table degrade in a chosen
+ * order rather than overflowing into a horizontal scrollbar. Below PatternFly's own `md` grid
+ * breakpoint the table stops being a grid altogether and stacks each row into a card, labelled by
+ * the `dataLabel` on each cell.
+ *
+ * This is an exhaustive `Record` rather than a `Partial` so that a new column has to make an
+ * explicit choice instead of silently defaulting to always-visible.
+ */
+const columnVisibility: Record<WorkspaceTableColumnKeys, BaseCellProps['visibility']> = {
+  name: undefined,
+  kind: undefined,
+  podConfig: ['hidden', 'visibleOnLg'],
+  image: ['hidden', 'visibleOnMd'],
+  namespace: ['hidden', 'visibleOnLg'],
+  state: undefined,
+  gpu: ['hidden', 'visibleOnXl'],
+  idleGpu: ['hidden', 'visibleOnXl'],
+  lastActivity: ['hidden', 'visibleOnXl'],
+  connect: undefined,
+  actions: undefined,
+};
 
 interface WorkspaceTableProps {
   workspaces: WorkspacesWorkspaceListItem[];
@@ -273,32 +303,6 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
       };
     };
 
-    // Column-specific modifiers. Columns with inherently small/fixed-size content (an icon, a
-    // badge, a button) use fitContent to size to that content. The remaining columns keep a
-    // percentage `width` so they absorb the table's leftover width instead — auto table layout
-    // doesn't let fitContent columns shrink below their content unless other columns are
-    // "greedy" enough to claim the rest.
-    const getColumnModifier = (
-      columnKey: WorkspaceTableColumnKeys,
-    ): 'wrap' | 'nowrap' | 'fitContent' | undefined => {
-      switch (columnKey) {
-        case 'kind':
-        case 'state':
-        case 'image':
-        case 'podConfig':
-        case 'connect':
-          return 'fitContent';
-        case 'name':
-        case 'lastActivity':
-          return 'nowrap';
-        case 'namespace':
-        case 'gpu':
-          return 'wrap';
-        default:
-          return undefined;
-      }
-    };
-
     // Column-specific special properties
     const getSpecialColumnProps = (columnKey: WorkspaceTableColumnKeys) => {
       switch (columnKey) {
@@ -363,21 +367,19 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
               aria-label="Sortable table"
               ouiaId="SortableTable"
               variant="compact"
-              style={{ minWidth: '1200px' }}
             >
               <Thead>
                 <Tr>
                   {visibleColumnKeys.map((columnKey) => {
                     const specialProps = getSpecialColumnProps(columnKey);
-                    const modifier = getColumnModifier(columnKey);
 
                     return (
                       <Th
                         key={`workspace-table-column-${columnKey}`}
-                        width={wsTableColumns[columnKey].width}
                         sort={specialProps.hasContent ? getSortParams(columnKey) : undefined}
                         aria-label={specialProps.hasContent ? columnKey : undefined}
-                        modifier={modifier}
+                        modifier="fitContent"
+                        visibility={columnVisibility[columnKey]}
                         screenReaderText={specialProps.screenReaderText}
                       >
                         {specialProps.hasContent ? wsTableColumns[columnKey].label : undefined}
@@ -402,6 +404,7 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               <Td
                                 dataLabel={wsTableColumns[columnKey].label}
                                 modifier="fitContent"
+                                visibility={columnVisibility[columnKey]}
                                 hasAction
                                 key="connect"
                               >
@@ -414,7 +417,12 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
 
                           if (columnKey === 'actions') {
                             return (
-                              <Td isActionCell key="actions" data-testid="action-column">
+                              <Td
+                                isActionCell
+                                visibility={columnVisibility[columnKey]}
+                                key="actions"
+                                data-testid="action-column"
+                              >
                                 <ActionsColumn
                                   items={rowActions(workspace).map((action) => ({
                                     ...action,
@@ -436,7 +444,8 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                                     : `workspace-${columnKey}`
                               }
                               dataLabel={wsTableColumns[columnKey].label}
-                              modifier={getColumnModifier(columnKey)}
+                              modifier="fitContent"
+                              visibility={columnVisibility[columnKey]}
                             >
                               {columnKey === 'name' &&
                                 (() => {
@@ -444,6 +453,15 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                                     (action): action is IAction =>
                                       !('isSeparator' in action && action.isSeparator) &&
                                       action.id === 'viewDetails',
+                                  );
+
+                                  // The cap that keeps a long name from widening the column lives
+                                  // on this span rather than on the cell, so that it applies
+                                  // whether or not the name is rendered as a link.
+                                  const nameText = (
+                                    <span className="workspace-table__name-text">
+                                      {workspace.name}
+                                    </span>
                                   );
 
                                   return viewDetailsAction ? (
@@ -456,10 +474,10 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                                         viewDetailsAction.onClick?.(event, rowIndex, {}, {})
                                       }
                                     >
-                                      {workspace.name}
+                                      {nameText}
                                     </Button>
                                   ) : (
-                                    workspace.name
+                                    nameText
                                   );
                                 })()}
                               {columnKey === 'image' && (

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -31,6 +31,7 @@ import {
   Td,
   ThProps,
   ActionsColumn,
+  IAction,
   IActions,
 } from '@patternfly/react-table/dist/esm/components/Table';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
@@ -423,7 +424,30 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               }
                               dataLabel={wsTableColumns[columnKey].label}
                             >
-                              {columnKey === 'name' && workspace.name}
+                              {columnKey === 'name' &&
+                                (() => {
+                                  const viewDetailsAction = rowActions(workspace).find(
+                                    (action): action is IAction =>
+                                      !('isSeparator' in action && action.isSeparator) &&
+                                      action.id === 'viewDetails',
+                                  );
+
+                                  return viewDetailsAction ? (
+                                    <Button
+                                      variant="link"
+                                      isInline
+                                      className="workspace-table__name-link"
+                                      data-testid="workspace-name-link"
+                                      onClick={(event) =>
+                                        viewDetailsAction.onClick?.(event, rowIndex, {}, {})
+                                      }
+                                    >
+                                      {workspace.name}
+                                    </Button>
+                                  ) : (
+                                    workspace.name
+                                  );
+                                })()}
                               {columnKey === 'image' && (
                                 <Content>
                                   <span data-testid="workspace-image-name">

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -68,10 +68,7 @@ const {
   sortableKeyArray: sortableWsTableColumnKeyArray,
 } = defineDataFields({
   name: { label: 'Name', isFilterable: true, isSortable: true },
-  // Kind renders only a logo, and its header is rendered for screen readers alone (see
-  // getSpecialColumnProps), so there is no header control to sort from. Filtering by kind
-  // remains available from the toolbar.
-  kind: { label: 'Kind', isFilterable: true, isSortable: false },
+  kind: { label: 'Kind', isFilterable: true, isSortable: true },
   podConfig: { label: 'Pod config', isFilterable: true, isSortable: true },
   image: { label: 'Image', isFilterable: true, isSortable: true },
   namespace: { label: 'Namespace', isFilterable: true, isSortable: true },
@@ -245,6 +242,7 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
       workspace: WorkspacesWorkspaceListItem,
     ): Record<WorkspaceTableSortableColumnKeys, string | number> => ({
       name: workspace.name,
+      kind: workspace.workspaceKind.name,
       namespace: workspace.namespace,
       image: workspace.podTemplate.options.imageConfig.current.displayName,
       podConfig: workspace.podTemplate.options.podConfig.current.displayName,
@@ -306,11 +304,6 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
     // Column-specific special properties
     const getSpecialColumnProps = (columnKey: WorkspaceTableColumnKeys) => {
       switch (columnKey) {
-        case 'kind':
-          // A visible "Kind" label plus its sort control would be four times wider than the
-          // logo the column actually holds, so the header is exposed to screen readers only.
-          // The logo carries a tooltip naming the kind.
-          return { screenReaderText: 'Kind', hasContent: false };
         case 'connect':
           return { screenReaderText: 'Connect action', hasContent: false };
         case 'actions':

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -67,7 +67,10 @@ const {
   sortableKeyArray: sortableWsTableColumnKeyArray,
 } = defineDataFields({
   name: { label: 'Name', isFilterable: true, isSortable: true, width: 20 },
-  kind: { label: 'Kind', isFilterable: true, isSortable: true, width: undefined },
+  // Kind renders only a logo, and its header is rendered for screen readers alone (see
+  // getSpecialColumnProps), so there is no header control to sort from. Filtering by kind
+  // remains available from the toolbar.
+  kind: { label: 'Kind', isFilterable: true, isSortable: false, width: undefined },
   podConfig: { label: 'Pod config', isFilterable: true, isSortable: true, width: undefined },
   image: { label: 'Image', isFilterable: true, isSortable: true, width: undefined },
   namespace: { label: 'Namespace', isFilterable: true, isSortable: true, width: 15 },
@@ -212,7 +215,6 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
       workspace: WorkspacesWorkspaceListItem,
     ): Record<WorkspaceTableSortableColumnKeys, string | number> => ({
       name: workspace.name,
-      kind: workspace.workspaceKind.name,
       namespace: workspace.namespace,
       image: workspace.podTemplate.options.imageConfig.current.displayName,
       podConfig: workspace.podTemplate.options.podConfig.current.displayName,
@@ -300,6 +302,11 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
     // Column-specific special properties
     const getSpecialColumnProps = (columnKey: WorkspaceTableColumnKeys) => {
       switch (columnKey) {
+        case 'kind':
+          // A visible "Kind" label plus its sort control would be four times wider than the
+          // logo the column actually holds, so the header is exposed to screen readers only.
+          // The logo carries a tooltip naming the kind.
+          return { screenReaderText: 'Kind', hasContent: false };
         case 'connect':
           return { screenReaderText: 'Connect action', hasContent: false };
         case 'actions':
@@ -509,6 +516,10 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                                         style={{
                                           width: '20px',
                                           height: '20px',
+                                          // PatternFly's reset caps images at max-width: 100%.
+                                          // Without a floor the logo is squashed to a few pixels,
+                                          // since nothing else in this column claims any width.
+                                          minWidth: '20px',
                                           cursor: 'pointer',
                                         }}
                                       />

--- a/workspaces/frontend/src/app/components/__tests__/WorkspaceTable.spec.tsx
+++ b/workspaces/frontend/src/app/components/__tests__/WorkspaceTable.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import WorkspaceTable from '~/app/components/WorkspaceTable';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
@@ -62,5 +63,45 @@ describe('WorkspaceTable state column', () => {
 
     const stateCell = screen.getByTestId('state-label');
     expect(stateCell).toHaveTextContent('Running');
+  });
+});
+
+describe('WorkspaceTable name column', () => {
+  it('renders the name as plain text when no viewDetails row action is provided', () => {
+    const workspace = buildMockWorkspace({});
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.queryByTestId('workspace-name-link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-name')).toHaveTextContent(workspace.name);
+  });
+
+  it('renders the name as a clickable link that triggers the viewDetails action', async () => {
+    const user = userEvent.setup();
+    const workspace = buildMockWorkspace({});
+    const onViewDetailsClick = jest.fn();
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => [
+          { id: 'viewDetails', title: 'View Details', onClick: onViewDetailsClick },
+        ]}
+      />,
+    );
+
+    const nameLink = screen.getByTestId('workspace-name-link');
+    expect(nameLink).toHaveTextContent(workspace.name);
+
+    await user.click(nameLink);
+
+    expect(onViewDetailsClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/workspaces/frontend/src/app/filterableDataHelper.ts
+++ b/workspaces/frontend/src/app/filterableDataHelper.ts
@@ -2,7 +2,6 @@ export interface DataFieldDefinition {
   label: string;
   isSortable: boolean;
   isFilterable: boolean;
-  width?: number;
 }
 
 export type FilterableDataFieldKey<T extends Record<string, DataFieldDefinition>> = {

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
@@ -5,6 +5,7 @@ import {
 } from '@patternfly/react-core/dist/esm/components/Dropdown';
 import {
   MenuToggle,
+  MenuToggleAction,
   MenuToggleElement,
 } from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import React, { useState } from 'react';
@@ -19,8 +20,31 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
 }) => {
   const [open, setIsOpen] = useState(false);
 
+  const httpServices = workspace.services.filter((service) => service.httpService);
+  const hasMultipleEndpoints = httpServices.length > 1;
+  const isRunning = workspace.state === V1Beta1WorkspaceState.WorkspaceStateRunning;
+  const isDisabled = !isRunning || httpServices.length === 0;
+
+  const openEndpoint = (value: string) => {
+    window.open(value, '_blank');
+  };
+
+  const onPrimaryConnect = () => {
+    setIsOpen(false);
+    const primary = httpServices[0]?.httpService;
+    if (primary) {
+      openEndpoint(primary.httpPath);
+    }
+  };
+
   const onToggleClick = () => {
-    setIsOpen(!open);
+    // Only open the dropdown when there is a choice to make; with a single
+    // endpoint the caret behaves like the primary action and connects directly.
+    if (hasMultipleEndpoints) {
+      setIsOpen(!open);
+    } else {
+      onPrimaryConnect();
+    }
   };
 
   const onSelect = (
@@ -31,10 +55,6 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
     if (typeof value === 'string') {
       openEndpoint(value);
     }
-  };
-
-  const openEndpoint = (value: string) => {
-    window.open(value, '_blank');
   };
 
   return (
@@ -48,17 +68,26 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
           variant="secondary"
           onClick={onToggleClick}
           isExpanded={open}
-          isDisabled={workspace.state !== V1Beta1WorkspaceState.WorkspaceStateRunning}
+          isDisabled={isDisabled}
           aria-label="Select connection endpoint"
-        >
-          Connect
-        </MenuToggle>
+          splitButtonItems={[
+            <MenuToggleAction
+              id={`${workspace.name}-connect`}
+              key={`${workspace.name}-connect`}
+              aria-label="Connect"
+              isDisabled={isDisabled}
+              onClick={onPrimaryConnect}
+            >
+              Connect
+            </MenuToggleAction>,
+          ]}
+          ouiaId="BasicDropdown"
+        />
       )}
-      ouiaId="BasicDropdown"
       shouldFocusToggleOnSelect
     >
       <DropdownList>
-        {workspace.services.map((service) => {
+        {httpServices.map((service) => {
           if (!service.httpService) {
             return null;
           }


### PR DESCRIPTION
## Summary

This PR reworks the workspaces table (`WorkspaceTable.tsx`) based on feedback
from a recent walkthrough that we did in a Notebooks WG leads session with the
goal to have the UI be easier to navigate for the Data Scientist persona.

The PR covers the following broad changes:

- quicker navigation to the details view by clicking a workspace's name ➡️ Split out to #1331 
- an adjusted (perhaps more sensible) column order
- responsive sizing that degrades more gracefully on narrow viewports
- a redesigned **Connect** control that is now a split button ➡️ Split out to #1332 

_Note_: This is not so much about the actual implementation but more intended as
a conversation starter on what we like or don't like about these changes.

The plan is to then split out/adapt changes as needed so that we can include
what we would like to keep in the context of the beta.

# Screenshots

## Wide viewport

<img width="2560" height="1273" alt="grafik" src="https://github.com/user-attachments/assets/23073d92-6aeb-421a-bf7b-b35b4f53343f" />


## Narrow

<img width="1002" height="633" alt="grafik" src="https://github.com/user-attachments/assets/4b9fd15d-a554-4581-82cb-3656b4c6fe89" />

