### PR TITLE
feat: expose workspace podtemplate resources endpoint and OpenAPI schema

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -110,6 +110,7 @@ func (a *App) Routes() http.Handler {
 	router.POST(constants.PauseWorkspacePath, a.PauseActionWorkspaceHandler)
 	router.GET(constants.WorkspacePodTemplateDetailsPath, a.GetWorkspacePodTemplateDetailsHandler)
 	router.GET(constants.WorkspacePodTemplatePodLogsBatchPath, a.GetWorkspacePodTemplateLogsHandler)
+	router.GET(constants.WorkspacePodTemplateResourcesPath, a.GetWorkspacePodTemplateResourcesHandler)
 
 	// workspacekinds
 	router.GET(constants.AllWorkspaceKindsPath, a.GetWorkspaceKindsHandler)

--- a/workspaces/backend/api/constants/paths.go
+++ b/workspaces/backend/api/constants/paths.go
@@ -30,6 +30,7 @@ const (
 	WorkspaceActionsPath                 = WorkspacesByNamePath + "/actions"
 	PauseWorkspacePath                   = WorkspaceActionsPath + "/pause"
 	WorkspacePodTemplateDetailsPath      = WorkspacesByNamePath + "/podtemplate/details"
+	WorkspacePodTemplateResourcesPath    = WorkspacesByNamePath + "/podtemplate/resources"
 	WorkspacePodTemplatePodLogsBatchPath = WorkspacesByNamePath + "/podtemplate/logs/batch"
 
 	// workspacekinds

--- a/workspaces/backend/api/response_errors.go
+++ b/workspaces/backend/api/response_errors.go
@@ -185,6 +185,18 @@ func (a *App) notFoundResponse(w http.ResponseWriter, r *http.Request) {
 	a.errorResponse(w, r, httpError)
 }
 
+// HTTP: 503
+func (a *App) serviceUnavailableResponse(w http.ResponseWriter, r *http.Request, msg string) {
+	httpError := &HTTPError{
+		StatusCode: http.StatusServiceUnavailable,
+		ErrorResponse: ErrorResponse{
+			Code:    strconv.Itoa(http.StatusServiceUnavailable),
+			Message: msg,
+		},
+	}
+	a.errorResponse(w, r, httpError)
+}
+
 // HTTP: 405
 func (a *App) methodNotAllowedResponse(w http.ResponseWriter, r *http.Request) {
 	httpError := &HTTPError{

--- a/workspaces/backend/api/workspace_actions_handler.go
+++ b/workspaces/backend/api/workspace_actions_handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/actions"
+	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
 	repository "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/workspaces"
 )
 
@@ -109,7 +110,7 @@ func (a *App) PauseActionWorkspaceHandler(w http.ResponseWriter, r *http.Request
 
 	workspaceActionPauseState, err := a.repositories.Workspace.HandlePauseAction(r.Context(), namespace, workspaceName, workspaceActionPause)
 	if err != nil {
-		if errors.Is(err, repository.ErrWorkspaceNotFound) {
+		if errors.Is(err, repoCommon.ErrWorkspaceNotFound) {
 			a.notFoundResponse(w, r)
 			return
 		}

--- a/workspaces/backend/api/workspace_podtemplate_resources_handler.go
+++ b/workspaces/backend/api/workspace_podtemplate_resources_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/metrics"
 	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
+	metricsrepo "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/metrics"
 )
 
 // WorkspaceResourceUsageEnvelope is the response envelope for workspace resource usage.
@@ -36,18 +37,19 @@ type WorkspaceResourceUsageEnvelope Envelope[*models.WorkspaceResourceUsage]
 // GetWorkspacePodTemplateResourcesHandler returns point-in-time resource usage for a workspace.
 //
 //	@Summary		Get workspace pod template resources
-//	@Description	Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. When usage cannot be retrieved the response is still 200 OK, with a `data.error` code explaining why (`METRICS_API_NOT_AVAILABLE` when the Metrics Server is not installed, `WORKSPACE_NOT_RUNNING` when the workspace has no pods).
+//	@Description	Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. A paused or not-yet-running workspace still returns 200 OK with `data.error = WORKSPACE_NOT_RUNNING` and no container data. When the Metrics Server itself is unavailable the response is 503 Service Unavailable.
 //	@Tags			workspaces
 //	@ID				getWorkspacePodTemplateResources
 //	@Produce		json
 //	@Param			namespace	path		string							true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
 //	@Param			name		path		string							true	"Name of the workspace"			extensions(x-example=my-workspace)
-//	@Success		200			{object}	WorkspaceResourceUsageEnvelope	"Successful operation. Returns per-container usage and configured resources, or an error code when usage is unavailable."
+//	@Success		200			{object}	WorkspaceResourceUsageEnvelope	"Successful operation. Returns per-container usage and configured resources, or `data.error = WORKSPACE_NOT_RUNNING` when the workspace has no pods."
 //	@Failure		401			{object}	ErrorEnvelope					"Unauthorized."
 //	@Failure		403			{object}	ErrorEnvelope					"Forbidden."
 //	@Failure		404			{object}	ErrorEnvelope					"Workspace not found."
 //	@Failure		422			{object}	ErrorEnvelope					"Unprocessable Entity. Validation error."
 //	@Failure		500			{object}	ErrorEnvelope					"Internal server error."
+//	@Failure		503			{object}	ErrorEnvelope					"Metrics server not available."
 //	@Router			/workspaces/{namespace}/{name}/podtemplate/resources [get]
 func (a *App) GetWorkspacePodTemplateResourcesHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
@@ -73,11 +75,14 @@ func (a *App) GetWorkspacePodTemplateResourcesHandler(w http.ResponseWriter, r *
 
 	usage, err := a.repositories.Metrics.GetWorkspaceResourceUsage(r.Context(), namespace, workspaceName)
 	if err != nil {
-		if errors.Is(err, repoCommon.ErrWorkspaceNotFound) {
+		switch {
+		case errors.Is(err, repoCommon.ErrWorkspaceNotFound):
 			a.notFoundResponse(w, r)
-			return
+		case errors.Is(err, metricsrepo.ErrMetricsAPINotAvailable):
+			a.serviceUnavailableResponse(w, r, "metrics server not available")
+		default:
+			a.serverErrorResponse(w, r, err)
 		}
-		a.serverErrorResponse(w, r, err)
 		return
 	}
 

--- a/workspaces/backend/api/workspace_podtemplate_resources_handler.go
+++ b/workspaces/backend/api/workspace_podtemplate_resources_handler.go
@@ -26,30 +26,30 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
-	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/podtemplate/details"
+	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/metrics"
 	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
 )
 
-// WorkspaceDetailsEnvelope is the response envelope for workspace details.
-type WorkspaceDetailsEnvelope Envelope[*models.WorkspaceDetails]
+// WorkspaceResourceUsageEnvelope is the response envelope for workspace resource usage.
+type WorkspaceResourceUsageEnvelope Envelope[*models.WorkspaceResourceUsage]
 
-// GetWorkspacePodTemplateDetailsHandler returns pod template details for the workspace details overlay.
+// GetWorkspacePodTemplateResourcesHandler returns point-in-time resource usage for a workspace.
 //
-//	@Summary		Get workspace pod template details
-//	@Description	Returns detail-level data for the workspace details overlay (volumes, secrets, pod info).
+//	@Summary		Get workspace pod template resources
+//	@Description	Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. When usage cannot be retrieved the response is still 200 OK, with a `data.error` code explaining why (`METRICS_API_NOT_AVAILABLE` when the Metrics Server is not installed, `WORKSPACE_NOT_RUNNING` when the workspace has no pods).
 //	@Tags			workspaces
-//	@ID				getWorkspacePodTemplateDetails
+//	@ID				getWorkspacePodTemplateResources
 //	@Produce		json
-//	@Param			namespace	path		string						true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
-//	@Param			name		path		string						true	"Name of the workspace"			extensions(x-example=my-workspace)
-//	@Success		200			{object}	WorkspaceDetailsEnvelope	"Successful operation."
-//	@Failure		401			{object}	ErrorEnvelope				"Unauthorized."
-//	@Failure		403			{object}	ErrorEnvelope				"Forbidden."
-//	@Failure		404			{object}	ErrorEnvelope				"Workspace not found."
-//	@Failure		422			{object}	ErrorEnvelope				"Unprocessable Entity. Validation error."
-//	@Failure		500			{object}	ErrorEnvelope				"Internal server error."
-//	@Router			/workspaces/{namespace}/{name}/podtemplate/details [get]
-func (a *App) GetWorkspacePodTemplateDetailsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+//	@Param			namespace	path		string							true	"Namespace of the workspace"	extensions(x-example=kubeflow-user-example-com)
+//	@Param			name		path		string							true	"Name of the workspace"			extensions(x-example=my-workspace)
+//	@Success		200			{object}	WorkspaceResourceUsageEnvelope	"Successful operation. Returns per-container usage and configured resources, or an error code when usage is unavailable."
+//	@Failure		401			{object}	ErrorEnvelope					"Unauthorized."
+//	@Failure		403			{object}	ErrorEnvelope					"Forbidden."
+//	@Failure		404			{object}	ErrorEnvelope					"Workspace not found."
+//	@Failure		422			{object}	ErrorEnvelope					"Unprocessable Entity. Validation error."
+//	@Failure		500			{object}	ErrorEnvelope					"Internal server error."
+//	@Router			/workspaces/{namespace}/{name}/podtemplate/resources [get]
+func (a *App) GetWorkspacePodTemplateResourcesHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespace := ps.ByName(constants.NamespacePathParam)
 	workspaceName := ps.ByName(constants.ResourceNamePathParam)
 
@@ -71,7 +71,7 @@ func (a *App) GetWorkspacePodTemplateDetailsHandler(w http.ResponseWriter, r *ht
 	}
 	// ============================================================
 
-	details, err := a.repositories.Workspace.GetWorkspaceDetails(r.Context(), namespace, workspaceName)
+	usage, err := a.repositories.Metrics.GetWorkspaceResourceUsage(r.Context(), namespace, workspaceName)
 	if err != nil {
 		if errors.Is(err, repoCommon.ErrWorkspaceNotFound) {
 			a.notFoundResponse(w, r)
@@ -81,6 +81,6 @@ func (a *App) GetWorkspacePodTemplateDetailsHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	responseEnvelope := &WorkspaceDetailsEnvelope{Data: details}
+	responseEnvelope := &WorkspaceResourceUsageEnvelope{Data: usage}
 	a.dataResponse(w, r, responseEnvelope)
 }

--- a/workspaces/backend/api/workspace_podtemplate_resources_handler_test.go
+++ b/workspaces/backend/api/workspace_podtemplate_resources_handler_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Workspace PodTemplate Resources Handler", func() {
 
 		It("should degrade gracefully with 200 OK when usage is unavailable", func() {
 			By("executing GetWorkspacePodTemplateResourcesHandler")
-			rs := doResourcesRequest(namespaceName, workspaceName, adminUser)
+			rs := doPodTemplateResourcesRequest(namespaceName, workspaceName, adminUser)
 			defer rs.Body.Close()
 
 			By("verifying status is 200 OK")
@@ -117,14 +117,14 @@ var _ = Describe("Workspace PodTemplate Resources Handler", func() {
 		It("should return 404 when workspace does not exist", func() {
 			// The metrics repository resolves pods by label, so without an existence check a
 			// missing workspace would degrade to WORKSPACE_NOT_RUNNING instead of a 404.
-			rs := doResourcesRequest(testNamespace, testWorkspace, adminUser)
+			rs := doPodTemplateResourcesRequest(testNamespace, testWorkspace, adminUser)
 			defer rs.Body.Close()
 
 			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
 		})
 
 		It("should return 422 for invalid parameters", func() {
-			rs := doResourcesRequest("INVALID!!!", testWorkspace, adminUser)
+			rs := doPodTemplateResourcesRequest("INVALID!!!", testWorkspace, adminUser)
 			defer rs.Body.Close()
 
 			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity))

--- a/workspaces/backend/api/workspace_podtemplate_resources_handler_test.go
+++ b/workspaces/backend/api/workspace_podtemplate_resources_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
@@ -32,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
-	modelsMetrics "github.com/kubeflow/notebooks/workspaces/backend/internal/models/metrics"
 )
 
 var _ = Describe("Workspace PodTemplate Resources Handler", func() {
@@ -83,30 +83,24 @@ var _ = Describe("Workspace PodTemplate Resources Handler", func() {
 			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
 		})
 
-		It("should degrade gracefully with 200 OK when usage is unavailable", func() {
+		It("should return 503 when the Metrics Server is not available", func() {
 			By("executing GetWorkspacePodTemplateResourcesHandler")
 			rs := doPodTemplateResourcesRequest(namespaceName, workspaceName, adminUser)
 			defer rs.Body.Close()
 
-			By("verifying status is 200 OK")
-			// envtest has no Metrics Server and no controller creating pods, so usage cannot be
-			// retrieved. That must still be a 200 with a degraded error code, never a 5xx.
-			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			By("verifying status is 503 Service Unavailable")
+			// envtest has no aggregated Metrics Server, so the metrics.k8s.io API is never served.
+			// The handler surfaces that as a 503, not a 5xx internal error.
+			Expect(rs.StatusCode).To(Equal(http.StatusServiceUnavailable))
 
-			By("verifying the response is wrapped in the standard envelope")
+			By("verifying the response is a standard error envelope")
 			body, err := io.ReadAll(rs.Body)
 			Expect(err).NotTo(HaveOccurred())
 
-			var response WorkspaceResourceUsageEnvelope
+			var response ErrorEnvelope
 			Expect(json.Unmarshal(body, &response)).To(Succeed())
-			Expect(response.Data).NotTo(BeNil())
-
-			By("verifying a degraded error code is set, with no container data")
-			Expect(response.Data.Error).To(BeElementOf(
-				modelsMetrics.ErrorCodeMetricsAPINotAvailable,
-				modelsMetrics.ErrorCodeWorkspaceNotRunning,
-			))
-			Expect(response.Data.Containers).To(BeEmpty())
+			Expect(response.Error).NotTo(BeNil())
+			Expect(response.Error.Code).To(Equal(strconv.Itoa(http.StatusServiceUnavailable)))
 		})
 	})
 

--- a/workspaces/backend/api/workspace_podtemplate_resources_handler_test.go
+++ b/workspaces/backend/api/workspace_podtemplate_resources_handler_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
+	modelsMetrics "github.com/kubeflow/notebooks/workspaces/backend/internal/models/metrics"
+)
+
+var _ = Describe("Workspace PodTemplate Resources Handler", func() {
+	Context("with existing Workspace", Serial, Ordered, func() {
+		const namespaceName = "resources-happy-ns"
+		var (
+			workspaceName     string
+			workspaceKindName string
+		)
+
+		BeforeAll(func() {
+			uniqueName := "resources-happy-test"
+			workspaceName = fmt.Sprintf("workspace-%s", uniqueName)
+			workspaceKindName = fmt.Sprintf("workspacekind-%s", uniqueName)
+
+			By("creating the Namespace")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
+			}
+			Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+
+			By("creating the WorkspaceKind")
+			wsk := NewExampleWorkspaceKind(workspaceKindName)
+			Expect(k8sClient.Create(ctx, wsk)).To(Succeed())
+
+			By("creating the Workspace")
+			ws := NewExampleWorkspace(workspaceName, namespaceName, workspaceKindName)
+			Expect(k8sClient.Create(ctx, ws)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			By("deleting the Workspace")
+			ws := &kubefloworgv1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: workspaceName, Namespace: namespaceName},
+			}
+			Expect(k8sClient.Delete(ctx, ws)).To(Succeed())
+
+			By("deleting the WorkspaceKind")
+			wsk := &kubefloworgv1beta1.WorkspaceKind{
+				ObjectMeta: metav1.ObjectMeta{Name: workspaceKindName},
+			}
+			Expect(k8sClient.Delete(ctx, wsk)).To(Succeed())
+
+			By("deleting the Namespace")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
+			}
+			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+		})
+
+		It("should degrade gracefully with 200 OK when usage is unavailable", func() {
+			By("executing GetWorkspacePodTemplateResourcesHandler")
+			rs := doResourcesRequest(namespaceName, workspaceName, adminUser)
+			defer rs.Body.Close()
+
+			By("verifying status is 200 OK")
+			// envtest has no Metrics Server and no controller creating pods, so usage cannot be
+			// retrieved. That must still be a 200 with a degraded error code, never a 5xx.
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			By("verifying the response is wrapped in the standard envelope")
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var response WorkspaceResourceUsageEnvelope
+			Expect(json.Unmarshal(body, &response)).To(Succeed())
+			Expect(response.Data).NotTo(BeNil())
+
+			By("verifying a degraded error code is set, with no container data")
+			Expect(response.Data.Error).To(BeElementOf(
+				modelsMetrics.ErrorCodeMetricsAPINotAvailable,
+				modelsMetrics.ErrorCodeWorkspaceNotRunning,
+			))
+			Expect(response.Data.Containers).To(BeEmpty())
+		})
+	})
+
+	Context("when querying workspace podtemplate resources errors", func() {
+		const testNamespace = "ns-resources-test"
+		const testWorkspace = "my-workspace"
+
+		It("should return 404 when workspace does not exist", func() {
+			// The metrics repository resolves pods by label, so without an existence check a
+			// missing workspace would degrade to WORKSPACE_NOT_RUNNING instead of a 404.
+			rs := doResourcesRequest(testNamespace, testWorkspace, adminUser)
+			defer rs.Body.Close()
+
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("should return 422 for invalid parameters", func() {
+			rs := doResourcesRequest("INVALID!!!", testWorkspace, adminUser)
+			defer rs.Body.Close()
+
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+		})
+	})
+})
+
+func doPodTemplateResourcesRequest(namespace, workspace, userID string) *http.Response {
+	req, err := http.NewRequest(http.MethodGet, resourcesPathFor(namespace, workspace), http.NoBody)
+	Expect(err).NotTo(HaveOccurred())
+	req.Header.Set(userIdHeader, userID)
+
+	ps := httprouter.Params{
+		httprouter.Param{Key: constants.NamespacePathParam, Value: namespace},
+		httprouter.Param{Key: constants.ResourceNamePathParam, Value: workspace},
+	}
+	rr := httptest.NewRecorder()
+	a.GetWorkspacePodTemplateResourcesHandler(rr, req, ps)
+	return rr.Result()
+}
+
+func resourcesPathFor(namespace, workspace string) string {
+	path := strings.Replace(constants.WorkspacePodTemplateResourcesPath, ":"+constants.NamespacePathParam, namespace, 1)
+	return strings.Replace(path, ":"+constants.ResourceNamePathParam, workspace, 1)
+}

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces"
+	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
 	repository "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/workspaces"
 )
 
@@ -79,7 +80,7 @@ func (a *App) GetWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps htt
 
 	workspace, err := a.repositories.Workspace.GetWorkspace(r.Context(), namespace, workspaceName)
 	if err != nil {
-		if errors.Is(err, repository.ErrWorkspaceNotFound) {
+		if errors.Is(err, repoCommon.ErrWorkspaceNotFound) {
 			a.notFoundResponse(w, r)
 			return
 		}
@@ -360,7 +361,7 @@ func (a *App) UpdateWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 
 	updatedWorkspace, err := a.repositories.Workspace.UpdateWorkspace(r.Context(), actor, workspaceUpdate, namespace, workspaceName)
 	if err != nil {
-		if errors.Is(err, repository.ErrWorkspaceNotFound) {
+		if errors.Is(err, repoCommon.ErrWorkspaceNotFound) {
 			a.notFoundResponse(w, r)
 			return
 		}
@@ -429,7 +430,7 @@ func (a *App) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, ps 
 
 	err := a.repositories.Workspace.DeleteWorkspace(r.Context(), namespace, workspaceName)
 	if err != nil {
-		if errors.Is(err, repository.ErrWorkspaceNotFound) {
+		if errors.Is(err, repoCommon.ErrWorkspaceNotFound) {
 			a.notFoundResponse(w, r)
 			return
 		} else if apierrors.IsConflict(err) {

--- a/workspaces/backend/internal/models/metrics/types.go
+++ b/workspaces/backend/internal/models/metrics/types.go
@@ -23,8 +23,7 @@ import (
 type ErrorCode string
 
 const (
-	ErrorCodeMetricsAPINotAvailable ErrorCode = "METRICS_API_NOT_AVAILABLE"
-	ErrorCodeWorkspaceNotRunning    ErrorCode = "WORKSPACE_NOT_RUNNING"
+	ErrorCodeWorkspaceNotRunning ErrorCode = "WORKSPACE_NOT_RUNNING"
 )
 
 // WorkspaceResourceUsage represents the point-in-time, pod-level resource

--- a/workspaces/backend/internal/repositories/common/errors.go
+++ b/workspaces/backend/internal/repositories/common/errors.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package common holds values shared between repositories.
+//
+// Sentinel errors live here when more than one repository can return them, so that callers
+// have a single value to match with errors.Is. Sentinels raised by exactly one repository
+// stay in that repository's own package.
+package common
+
+import "errors"
+
+// ErrWorkspaceNotFound is returned when a Workspace does not exist.
+var ErrWorkspaceNotFound = errors.New("workspace not found")

--- a/workspaces/backend/internal/repositories/metrics/repo.go
+++ b/workspaces/backend/internal/repositories/metrics/repo.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -40,6 +41,12 @@ const (
 	// TTL for API availability checks.
 	apiAvailabilityTTL = 60 * time.Second
 )
+
+// ErrMetricsAPINotAvailable is returned when workspace resource usage cannot be read because the
+// Kubernetes Metrics Server (metrics.k8s.io) is not available. The API layer maps this to a
+// 503 Service Unavailable. Only this repository raises it, so it stays local per the convention
+// documented in the repositories/common package.
+var ErrMetricsAPINotAvailable = errors.New("metrics API not available")
 
 // MetricsRepository exposes point-in-time workspace resource utilization, read from the
 // Kubernetes Metrics Server, to the API layer.
@@ -77,7 +84,7 @@ func (r *MetricsRepository) GetWorkspaceResourceUsage(ctx context.Context, ns, w
 	}
 
 	if !available {
-		return models.NewErrorResourceUsage(models.ErrorCodeMetricsAPINotAvailable), nil
+		return nil, ErrMetricsAPINotAvailable
 	}
 
 	selector := client.MatchingLabels{modelsCommon.LabelWorkspaceName: workspace}

--- a/workspaces/backend/internal/repositories/metrics/repo.go
+++ b/workspaces/backend/internal/repositories/metrics/repo.go
@@ -22,7 +22,9 @@ import (
 	"sync"
 	"time"
 
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -31,6 +33,7 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	modelsCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/metrics"
+	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
 )
 
 const (
@@ -57,6 +60,17 @@ func NewMetricsRepository(cfg *config.EnvConfig, c client.Client) *MetricsReposi
 
 // GetWorkspaceResourceUsage returns the resource usage for all pods in the given namespace and workspace.
 func (r *MetricsRepository) GetWorkspaceResourceUsage(ctx context.Context, ns, workspace string) (*models.WorkspaceResourceUsage, error) {
+	// Confirm the workspace exists first. Usage is resolved by pod label, so without this a
+	// workspace that never existed would be indistinguishable from one that is merely paused,
+	// and both would report WORKSPACE_NOT_RUNNING. This read is served from the informer cache.
+	ws := &kubefloworgv1beta1.Workspace{}
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: ns, Name: workspace}, ws); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, repoCommon.ErrWorkspaceNotFound
+		}
+		return nil, err
+	}
+
 	available, err := r.apiAvailable()
 	if err != nil {
 		return nil, err

--- a/workspaces/backend/internal/repositories/metrics/repo.go
+++ b/workspaces/backend/internal/repositories/metrics/repo.go
@@ -103,6 +103,13 @@ func (r *MetricsRepository) GetWorkspaceResourceUsage(ctx context.Context, ns, w
 	pod := &podList.Items[0]
 	podMetricsList := &metricsv1beta1.PodMetricsList{}
 	if err := r.client.List(ctx, podMetricsList, client.InNamespace(ns), selector); err != nil {
+		// API discovery is memoized (see apiAvailabilityTTL), so if the Metrics Server is
+		// uninstalled or restarts after startup the availability probe can still report true
+		// while the list itself fails. Treat that as the metrics API being unavailable rather
+		// than an internal error, so the endpoint degrades to 503 consistently.
+		if apierrors.IsNotFound(err) || apierrors.IsServiceUnavailable(err) {
+			return nil, ErrMetricsAPINotAvailable
+		}
 		return nil, err
 	}
 

--- a/workspaces/backend/internal/repositories/metrics/repo_test.go
+++ b/workspaces/backend/internal/repositories/metrics/repo_test.go
@@ -163,7 +163,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 		Expect(got.Error).To(Equal(modelsmetrics.ErrorCodeWorkspaceNotRunning))
 	})
 
-	It("returns METRICS_API_NOT_AVAILABLE error when API is not served", func() {
+	It("returns ErrMetricsAPINotAvailable when the API is not served", func() {
 		pod := workspacePod("pod-3", "container-3", nil)
 
 		client := fake.NewClientBuilder().
@@ -175,9 +175,8 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 		repo := newTestMetricsRepository(client, false)
 		got, err := repo.GetWorkspaceResourceUsage(ctx, "default", "test-workspace")
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(got).NotTo(BeNil())
-		Expect(got.Error).To(Equal(modelsmetrics.ErrorCodeMetricsAPINotAvailable))
+		Expect(err).To(MatchError(ErrMetricsAPINotAvailable))
+		Expect(got).To(BeNil())
 	})
 
 	It("returns error when the service account is forbidden", func() {

--- a/workspaces/backend/internal/repositories/metrics/repo_test.go
+++ b/workspaces/backend/internal/repositories/metrics/repo_test.go
@@ -204,6 +204,34 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 		Expect(got).To(BeNil())
 	})
 
+	DescribeTable("maps a metrics API outage during listing to ErrMetricsAPINotAvailable",
+		func(listErr error) {
+			pod := workspacePod("pod-6", "container-6", nil)
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(testWorkspaceCR()).
+				WithLists(&corev1.PodList{Items: []corev1.Pod{*pod}}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if _, isMetricsList := list.(*metricsv1beta1.PodMetricsList); isMetricsList {
+							return listErr
+						}
+						return cli.List(ctx, list, opts...)
+					},
+				}).
+				Build()
+
+			repo := newTestMetricsRepository(client, true)
+			got, err := repo.GetWorkspaceResourceUsage(ctx, "default", "test-workspace")
+
+			Expect(err).To(MatchError(ErrMetricsAPINotAvailable))
+			Expect(got).To(BeNil())
+		},
+		Entry("when the API is not found", apierrors.NewNotFound(schema.GroupResource{Group: metricsv1beta1.GroupName, Resource: "podmetrics"}, "")),
+		Entry("when the API is unavailable", apierrors.NewServiceUnavailable("metrics server is down")),
+	)
+
 	It("returns error when availability could not be determined", func() {
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/workspaces/backend/internal/repositories/metrics/repo_test.go
+++ b/workspaces/backend/internal/repositories/metrics/repo_test.go
@@ -24,7 +24,9 @@ import (
 
 	modelsCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 	modelsmetrics "github.com/kubeflow/notebooks/workspaces/backend/internal/models/metrics"
+	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
 
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -56,6 +58,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 		scheme = runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 		Expect(metricsv1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(kubefloworgv1beta1.AddToScheme(scheme)).To(Succeed())
 	})
 
 	It("returns available usage joined with requests when pods and metrics exist", func() {
@@ -69,6 +72,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
 			WithLists(
 				&corev1.PodList{Items: []corev1.Pod{*pod}},
 				&metricsv1beta1.PodMetricsList{Items: []metricsv1beta1.PodMetrics{*metrics}},
@@ -105,6 +109,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
 			WithLists(
 				&corev1.PodList{Items: []corev1.Pod{*pod}},
 				&metricsv1beta1.PodMetricsList{Items: []metricsv1beta1.PodMetrics{}},
@@ -128,9 +133,24 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 		Expect(got.Containers["container-2"]).To(BeComparableTo(expected))
 	})
 
+	It("returns ErrWorkspaceNotFound when the workspace does not exist", func() {
+		client := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
+			WithLists(&corev1.PodList{Items: []corev1.Pod{}}).
+			Build()
+
+		repo := newTestMetricsRepository(client, true)
+		got, err := repo.GetWorkspaceResourceUsage(ctx, "default", "no-such-workspace")
+
+		Expect(err).To(MatchError(repoCommon.ErrWorkspaceNotFound))
+		Expect(got).To(BeNil())
+	})
+
 	It("returns WORKSPACE_NOT_RUNNING error when no pods match", func() {
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
 			WithLists(
 				&corev1.PodList{Items: []corev1.Pod{}},
 			).Build()
@@ -148,6 +168,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
 			WithLists(&corev1.PodList{Items: []corev1.Pod{*pod}}).
 			Build()
 
@@ -164,6 +185,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
 			WithLists(&corev1.PodList{Items: []corev1.Pod{*pod}}).
 			WithInterceptorFuncs(interceptor.Funcs{
 				List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
@@ -186,6 +208,7 @@ var _ = Describe("MetricsRepository.GetWorkspaceResourceUsage", func() {
 	It("returns error when availability could not be determined", func() {
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).
+			WithObjects(testWorkspaceCR()).
 			WithLists(&corev1.PodList{Items: []corev1.Pod{*workspacePod("pod-5", "container-5", nil)}}).
 			Build()
 
@@ -283,6 +306,17 @@ type failingRESTMapper struct {
 
 func (m failingRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	return nil, m.err
+}
+
+// testWorkspaceCR is the Workspace the specs resolve usage for. GetWorkspaceResourceUsage
+// confirms the workspace exists before reading usage, so it must be present in the fake client.
+func testWorkspaceCR() *kubefloworgv1beta1.Workspace {
+	return &kubefloworgv1beta1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workspace",
+			Namespace: "default",
+		},
+	}
 }
 
 func newTestMetricsRepository(c client.Client, apiAvailable bool) *MetricsRepository {

--- a/workspaces/backend/internal/repositories/repositories.go
+++ b/workspaces/backend/internal/repositories/repositories.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/health_check"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/metrics"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/namespaces"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/podlogs"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/pvcs"
@@ -34,6 +35,7 @@ import (
 // Repositories is a single convenient container to hold and represent all our repositories.
 type Repositories struct {
 	HealthCheck   *health_check.HealthCheckRepository
+	Metrics       *metrics.MetricsRepository
 	Namespace     *namespaces.NamespaceRepository
 	PVC           *pvcs.PVCRepository
 	Secret        *secrets.SecretRepository
@@ -53,6 +55,7 @@ func NewRepositories(
 ) *Repositories {
 	return &Repositories{
 		HealthCheck:   health_check.NewHealthCheckRepository(cfg),
+		Metrics:       metrics.NewMetricsRepository(cfg, cl),
 		Namespace:     namespaces.NewNamespaceRepository(cfg, cl),
 		PVC:           pvcs.NewPVCRepository(cfg, cl),
 		Secret:        secrets.NewSecretRepository(cfg, cl),

--- a/workspaces/backend/internal/repositories/workspaces/repo.go
+++ b/workspaces/backend/internal/repositories/workspaces/repo.go
@@ -34,10 +34,10 @@ import (
 	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces"
 	modelsActions "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/actions"
 	modelsDetails "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces/podtemplate/details"
+	repoCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/repositories/common"
 )
 
 var (
-	ErrWorkspaceNotFound         = fmt.Errorf("workspace not found")
 	ErrWorkspaceAlreadyExists    = fmt.Errorf("workspace already exists")
 	ErrWorkspaceInvalidState     = fmt.Errorf("workspace is in an invalid state for this operation")
 	ErrWorkspaceRevisionConflict = fmt.Errorf("current workspace revision does not match request")
@@ -60,7 +60,7 @@ func (r *WorkspaceRepository) GetWorkspace(ctx context.Context, namespace string
 	workspace := &kubefloworgv1beta1.Workspace{}
 	if err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: workspaceName}, workspace); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrWorkspaceNotFound
+			return nil, repoCommon.ErrWorkspaceNotFound
 		}
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (r *WorkspaceRepository) GetWorkspaceDetails(ctx context.Context, namespace
 	workspace := &kubefloworgv1beta1.Workspace{}
 	if err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: workspaceName}, workspace); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrWorkspaceNotFound
+			return nil, repoCommon.ErrWorkspaceNotFound
 		}
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (r *WorkspaceRepository) UpdateWorkspace(ctx context.Context, actor user.In
 	workspace := &kubefloworgv1beta1.Workspace{}
 	if err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: workspaceName}, workspace); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrWorkspaceNotFound
+			return nil, repoCommon.ErrWorkspaceNotFound
 		}
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (r *WorkspaceRepository) UpdateWorkspace(ctx context.Context, actor user.In
 	//       error to the caller (DO NOT return a 409, as it's not the caller's fault)
 	if err := r.client.Update(ctx, workspace); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrWorkspaceNotFound
+			return nil, repoCommon.ErrWorkspaceNotFound
 		}
 		if apierrors.IsInvalid(err) {
 			// NOTE: we don't wrap this error so we can unpack it in the caller
@@ -214,7 +214,7 @@ func (r *WorkspaceRepository) DeleteWorkspace(ctx context.Context, namespace, wo
 
 	if err := r.client.Delete(ctx, workspace); err != nil {
 		if apierrors.IsNotFound(err) {
-			return ErrWorkspaceNotFound
+			return repoCommon.ErrWorkspaceNotFound
 		}
 		return err
 	}
@@ -278,7 +278,7 @@ func (r *WorkspaceRepository) HandlePauseAction(ctx context.Context, namespace, 
 
 	if err := r.client.Patch(ctx, workspace, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrWorkspaceNotFound
+			return nil, repoCommon.ErrWorkspaceNotFound
 		}
 		if apierrors.IsInvalid(err) {
 			return nil, ErrWorkspaceInvalidState

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -2043,6 +2043,75 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/workspaces/{namespace}/{name}/podtemplate/resources": {
+            "get": {
+                "description": "Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. When usage cannot be retrieved the response is still 200 OK, with a ` + "`" + `data.error` + "`" + ` code explaining why (` + "`" + `METRICS_API_NOT_AVAILABLE` + "`" + ` when the Metrics Server is not installed, ` + "`" + `WORKSPACE_NOT_RUNNING` + "`" + ` when the workspace has no pods).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Get workspace pod template resources",
+                "operationId": "getWorkspacePodTemplateResources",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace of the workspace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "x-example": "my-workspace",
+                        "description": "Name of the workspace",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation. Returns per-container usage and configured resources, or an error code when usage is unavailable.",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkspaceResourceUsageEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Workspace not found.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2374,6 +2443,17 @@ const docTemplate = `{
                 }
             }
         },
+        "api.WorkspaceResourceUsageEnvelope": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/metrics.WorkspaceResourceUsage"
+                }
+            }
+        },
         "assets.ImageRef": {
             "type": "object",
             "required": [
@@ -2694,6 +2774,93 @@ const docTemplate = `{
                 "Int",
                 "String"
             ]
+        },
+        "metrics.ContainerResourceUsage": {
+            "type": "object",
+            "required": [
+                "resources"
+            ],
+            "properties": {
+                "metricsFromMetricsServer": {
+                    "description": "MetricsFromMetricsServer holds live usage metrics. It is nil when metrics\nare pending (e.g., pod just started).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/metrics.MetricsFromMetricsServer"
+                        }
+                    ]
+                },
+                "resources": {
+                    "description": "Resources holds the configured resource requirements from the pod spec.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.ResourceRequirements"
+                        }
+                    ]
+                }
+            }
+        },
+        "metrics.ErrorCode": {
+            "type": "string",
+            "enum": [
+                "METRICS_API_NOT_AVAILABLE",
+                "WORKSPACE_NOT_RUNNING"
+            ],
+            "x-enum-varnames": [
+                "ErrorCodeMetricsAPINotAvailable",
+                "ErrorCodeWorkspaceNotRunning"
+            ]
+        },
+        "metrics.MetricsFromMetricsServer": {
+            "type": "object",
+            "required": [
+                "timestamp",
+                "usage"
+            ],
+            "properties": {
+                "timestamp": {
+                    "description": "Timestamp is the RFC3339 timestamp of when the sample was collected.",
+                    "type": "string"
+                },
+                "usage": {
+                    "description": "Usage is the current resource consumption.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/metrics.ResourceValues"
+                        }
+                    ]
+                }
+            }
+        },
+        "metrics.ResourceValues": {
+            "type": "object",
+            "properties": {
+                "cpu": {
+                    "type": "string"
+                },
+                "memory": {
+                    "type": "string"
+                }
+            }
+        },
+        "metrics.WorkspaceResourceUsage": {
+            "type": "object",
+            "properties": {
+                "containers": {
+                    "description": "Containers holds the per-container resource data, keyed by container name.\nAbsent when Error is present.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/metrics.ContainerResourceUsage"
+                    }
+                },
+                "error": {
+                    "description": "Error indicates why usage is unavailable. Absent means success.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/metrics.ErrorCode"
+                        }
+                    ]
+                }
+            }
         },
         "namespaces.Namespace": {
             "type": "object",

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -2046,7 +2046,7 @@ const docTemplate = `{
         },
         "/workspaces/{namespace}/{name}/podtemplate/resources": {
             "get": {
-                "description": "Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. When usage cannot be retrieved the response is still 200 OK, with a ` + "`" + `data.error` + "`" + ` code explaining why (` + "`" + `METRICS_API_NOT_AVAILABLE` + "`" + ` when the Metrics Server is not installed, ` + "`" + `WORKSPACE_NOT_RUNNING` + "`" + ` when the workspace has no pods).",
+                "description": "Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. A paused or not-yet-running workspace still returns 200 OK with ` + "`" + `data.error = WORKSPACE_NOT_RUNNING` + "`" + ` and no container data. When the Metrics Server itself is unavailable the response is 503 Service Unavailable.",
                 "produces": [
                     "application/json"
                 ],
@@ -2075,7 +2075,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation. Returns per-container usage and configured resources, or an error code when usage is unavailable.",
+                        "description": "Successful operation. Returns per-container usage and configured resources, or ` + "`" + `data.error = WORKSPACE_NOT_RUNNING` + "`" + ` when the workspace has no pods.",
                         "schema": {
                             "$ref": "#/definitions/api.WorkspaceResourceUsageEnvelope"
                         }
@@ -2106,6 +2106,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "503": {
+                        "description": "Metrics server not available.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -2802,11 +2808,9 @@ const docTemplate = `{
         "metrics.ErrorCode": {
             "type": "string",
             "enum": [
-                "METRICS_API_NOT_AVAILABLE",
                 "WORKSPACE_NOT_RUNNING"
             ],
             "x-enum-varnames": [
-                "ErrorCodeMetricsAPINotAvailable",
                 "ErrorCodeWorkspaceNotRunning"
             ]
         },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -2044,7 +2044,7 @@
         },
         "/workspaces/{namespace}/{name}/podtemplate/resources": {
             "get": {
-                "description": "Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. When usage cannot be retrieved the response is still 200 OK, with a `data.error` code explaining why (`METRICS_API_NOT_AVAILABLE` when the Metrics Server is not installed, `WORKSPACE_NOT_RUNNING` when the workspace has no pods).",
+                "description": "Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. A paused or not-yet-running workspace still returns 200 OK with `data.error = WORKSPACE_NOT_RUNNING` and no container data. When the Metrics Server itself is unavailable the response is 503 Service Unavailable.",
                 "produces": [
                     "application/json"
                 ],
@@ -2073,7 +2073,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation. Returns per-container usage and configured resources, or an error code when usage is unavailable.",
+                        "description": "Successful operation. Returns per-container usage and configured resources, or `data.error = WORKSPACE_NOT_RUNNING` when the workspace has no pods.",
                         "schema": {
                             "$ref": "#/definitions/api.WorkspaceResourceUsageEnvelope"
                         }
@@ -2104,6 +2104,12 @@
                     },
                     "500": {
                         "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "503": {
+                        "description": "Metrics server not available.",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorEnvelope"
                         }
@@ -2800,11 +2806,9 @@
         "metrics.ErrorCode": {
             "type": "string",
             "enum": [
-                "METRICS_API_NOT_AVAILABLE",
                 "WORKSPACE_NOT_RUNNING"
             ],
             "x-enum-varnames": [
-                "ErrorCodeMetricsAPINotAvailable",
                 "ErrorCodeWorkspaceNotRunning"
             ]
         },

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -2041,6 +2041,75 @@
                     }
                 }
             }
+        },
+        "/workspaces/{namespace}/{name}/podtemplate/resources": {
+            "get": {
+                "description": "Returns point-in-time CPU and memory usage for each container of the workspace pod, alongside the requests and limits configured in the pod spec. Usage is read from the Kubernetes Metrics Server. When usage cannot be retrieved the response is still 200 OK, with a `data.error` code explaining why (`METRICS_API_NOT_AVAILABLE` when the Metrics Server is not installed, `WORKSPACE_NOT_RUNNING` when the workspace has no pods).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Get workspace pod template resources",
+                "operationId": "getWorkspacePodTemplateResources",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "x-example": "kubeflow-user-example-com",
+                        "description": "Namespace of the workspace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "x-example": "my-workspace",
+                        "description": "Name of the workspace",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation. Returns per-container usage and configured resources, or an error code when usage is unavailable.",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkspaceResourceUsageEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Workspace not found.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity. Validation error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2372,6 +2441,17 @@
                 }
             }
         },
+        "api.WorkspaceResourceUsageEnvelope": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/metrics.WorkspaceResourceUsage"
+                }
+            }
+        },
         "assets.ImageRef": {
             "type": "object",
             "required": [
@@ -2692,6 +2772,93 @@
                 "Int",
                 "String"
             ]
+        },
+        "metrics.ContainerResourceUsage": {
+            "type": "object",
+            "required": [
+                "resources"
+            ],
+            "properties": {
+                "metricsFromMetricsServer": {
+                    "description": "MetricsFromMetricsServer holds live usage metrics. It is nil when metrics\nare pending (e.g., pod just started).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/metrics.MetricsFromMetricsServer"
+                        }
+                    ]
+                },
+                "resources": {
+                    "description": "Resources holds the configured resource requirements from the pod spec.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.ResourceRequirements"
+                        }
+                    ]
+                }
+            }
+        },
+        "metrics.ErrorCode": {
+            "type": "string",
+            "enum": [
+                "METRICS_API_NOT_AVAILABLE",
+                "WORKSPACE_NOT_RUNNING"
+            ],
+            "x-enum-varnames": [
+                "ErrorCodeMetricsAPINotAvailable",
+                "ErrorCodeWorkspaceNotRunning"
+            ]
+        },
+        "metrics.MetricsFromMetricsServer": {
+            "type": "object",
+            "required": [
+                "timestamp",
+                "usage"
+            ],
+            "properties": {
+                "timestamp": {
+                    "description": "Timestamp is the RFC3339 timestamp of when the sample was collected.",
+                    "type": "string"
+                },
+                "usage": {
+                    "description": "Usage is the current resource consumption.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/metrics.ResourceValues"
+                        }
+                    ]
+                }
+            }
+        },
+        "metrics.ResourceValues": {
+            "type": "object",
+            "properties": {
+                "cpu": {
+                    "type": "string"
+                },
+                "memory": {
+                    "type": "string"
+                }
+            }
+        },
+        "metrics.WorkspaceResourceUsage": {
+            "type": "object",
+            "properties": {
+                "containers": {
+                    "description": "Containers holds the per-container resource data, keyed by container name.\nAbsent when Error is present.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/metrics.ContainerResourceUsage"
+                    }
+                },
+                "error": {
+                    "description": "Error indicates why usage is unavailable. Absent means success.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/metrics.ErrorCode"
+                        }
+                    ]
+                }
+            }
         },
         "namespaces.Namespace": {
             "type": "object",


### PR DESCRIPTION
Supersedes #1312
Closes #1293.

Original endpoint work was done by @richabanker in #1312, her work is preserved
here, this PR just adds a few follow-ups and design fixes on top so that we can
potentially land it in time for the beta.

---

## Summary

Exposes the workspace resource-utilization repository from #1241 as a REST endpoint:

```
GET /api/v1/workspaces/{namespace}/{name}/podtemplate/resources
```

It returns point-in-time CPU/memory **usage** (read from the Kubernetes Metrics Server) for each
container of the workspace pod, joined with the **requests/limits** configured in the pod spec.

```jsonc
// running workspace
{
    "data": {
        "containers": {
            "main": {
                "metricsFromMetricsServer": {
                    "timestamp": "2026-08-14T04:22:31Z",
                    "usage": {
                        "cpu": "961220n",
                        "memory": "210992Ki"
                    }
                },
                "resources": {
                    "requests": {
                        "cpu": "1",
                        "memory": "2Gi"
                    }
                }
            }
        }
    }
}
```

## Response contract

| Situation | HTTP | Body |
|-----------|:----:|------|
| Running workspace | `200` | per-container `usage` + `resources` |
| Container has no metrics sample yet | `200` | container with `resources`, `metricsFromMetricsServer` omitted |
| Paused / not-running workspace | `200` | `{"data":{"error":"WORKSPACE_NOT_RUNNING"}}` |
| Workspace does not exist | `404` | standard error envelope |
| Invalid path params | `422` | validation error |
| Metrics Server unavailable | `503` | `{"error":{"code":"503","message":"metrics server not available"}}` |

## What changed relative to the original PR in #1312

Applying the review feedback and resolving the open questions Richa raised:

- **`METRICS_API_NOT_AVAILABLE` now returns `503`, not `200`**. The metrics
  repository raises a dedicated `ErrMetricsAPINotAvailable` sentinel (mirroring
  `ErrWorkspaceNotFound`) instead of encoding the condition in the data envelope, so the repository
  stays HTTP-agnostic and the handler owns the status mapping. The `metrics.ErrorCode` enum shrinks
  to the single value that can still appear in a `200` body (`WORKSPACE_NOT_RUNNING`).
- **Post-startup metrics outage no longer surfaces as `500`** (Richa's open question 4)). API
  discovery is memoized (~60s), so if the Metrics Server is removed while the backend is running the
  probe still reports it present, but the `PodMetrics` list then fails. A `NotFound`/
  `ServiceUnavailable` from that list is now caught and mapped to the same `503`.
- **CI fix**: corrected a test helper name mismatch (`doResourcesRequest` →
  `doPodTemplateResourcesRequest`) that was failing the lint/typecheck build.
- Regenerated the OpenAPI spec (adds the `503` response, narrows the enum).
- Rebased against the latest state in `notebooks-v2`

Already correct in Richa's original and carried over unchanged: the workspace existence check that
distinguishes a missing workspace (`404`) from a paused one (`WORKSPACE_NOT_RUNNING`), and the move
of `ErrWorkspaceNotFound` into the shared `repositories/common` package.

The change is organized as three reviewable commits on top of the original endpoint commit:
1. `fix: correct test helper name to unblock lint`
2. `feat: return 503 when the metrics server is unavailable`
3. `fix: map a post-startup metrics API outage to 503`

## Testing

Verified live against a local Tilt/Kind cluster through the Istio gateway — full status-code matrix
(happy path, per-container metrics-pending, paused → `WORKSPACE_NOT_RUNNING`, `404`, `422`, `401`,
`403`, `405`) plus a second run with the Metrics Server absent confirming `503` (and that `404`
still takes precedence over `503` for a missing workspace). The deployed Swagger UI models the
response with proper object schemas — resolving the earlier schema review comment.

<details>
<summary>Full test summary</summary>


# PR #1312 — Live API Verification: `GET /workspaces/{namespace}/{name}/podtemplate/resources`

**Date:** 2026-08-14
**Branch:** `pod-resource-metrics-handler` (commits `160ad677`, `cb947077`, `cd042e77`)
**Environment:** local Tilt/Kind cluster via Istio gateway `https://localhost:8443` (`DISABLE_AUTH=true`).
    - Run 1: metrics-server enabled (cases 1–12). 
    - Run 2: metrics-server absent (cases 13–14).
**Auth:** `Kubeflow-Userid` header (Tilt dev mode)

## Verdict

**PASS.** Every behavior we designed is confirmed live. All 12 automated cases returned the
expected status and body, the reversible pause test confirmed the `200 WORKSPACE_NOT_RUNNING`
degradation, the **metrics-down → 503** path was verified on a second run with the metrics server
absent, and the deployed OpenAPI spec models the response correctly (closing the schema review
thread). The only remaining item is the §5b *post-startup* runtime-race variant, which requires
removing the metrics server mid-run rather than starting without it — see
[§5](#5-metrics-down--503).

---

## 1. Status-code / behavior matrix

| # | Case | Request | Expected | Actual | Result |
|---|------|---------|----------|--------|:---:|
| 1 | Happy path — running (codeserver) | `GET default/test` | 200 + per-container usage & resources | 200, `main` w/ usage+requests | ✅ |
| 2 | Happy path — running (jupyterlab) | `GET default/jupyterlab-workspace` | 200 + usage & resources | 200, `main` w/ usage+requests | ✅ |
| 3 | Metrics sample pending (per-container) | `GET default/test123` (Error state, pod present) | 200, `resources` only, `metricsFromMetricsServer` omitted | 200, `resources` only | ✅ |
| 4 | Paused / not running | pause `default/test123` → `GET` | 200 `data.error=WORKSPACE_NOT_RUNNING` | 200 `WORKSPACE_NOT_RUNNING` (≤4s) | ✅ |
| 5 | Workspace does not exist | `GET default/does-not-exist` | 404 `ErrorEnvelope` | 404 | ✅ |
| 6 | Workspace absent in namespace | `GET kubeflow/test` | 404 `ErrorEnvelope` | 404 | ✅ |
| 7 | Invalid namespace param | `GET INVALID!!!/test` | 422 validation error | 422 | ✅ |
| 8 | Invalid workspace-name param | `GET default/Bad_Name!` | 422 validation error | 422 | ✅ |
| 9 | Missing auth header | `GET default/test` (no header) | 401 | 401 | ✅ |
| 10 | Unauthorized user | `GET default/test` as `nobody@example.com` | 403 | 403 | ✅ |
| 11 | Wrong method (POST) | `POST default/test/.../resources` | 405 | 405 | ✅ |
| 12 | Wrong method (DELETE) | `DELETE default/test/.../resources` | 405 | 405 | ✅ |
| 13 | Metrics server unavailable (startup) | `GET default/test` with metrics-server absent | **503** | 503 `{"code":"503","message":"metrics server not available"}` | ✅ |
| 14 | 404 precedes 503 (existence check first) | `GET default/does-not-exist` with metrics-server absent | 404, not 503 | 404 | ✅ |
| 15 | Metrics server removed *mid-run* (runtime race) | remove metrics API while backend runs | **503** (not 500) | *see §5b* | ⏳ |

---

## 2. Happy path & per-container detail (cases 1–3)

**Case 1 — `default/test` (codeserver, Running) → 200**
```json
{
    "data": {
        "containers": {
            "main": {
                "metricsFromMetricsServer": {
                    "timestamp": "2026-08-14T04:22:31Z",
                    "usage": {
                        "cpu": "961220n",
                        "memory": "210992Ki"
                    }
                },
                "resources": {
                    "requests": {
                        "cpu": "1",
                        "memory": "2Gi"
                    }
                }
            }
        }
    }
}
```

**Case 2 — `default/jupyterlab-workspace` (jupyterlab, Running) → 200**
```json
{
    "data": {
        "containers": {
            "main": {
                "metricsFromMetricsServer": {
                    "timestamp": "2026-08-14T04:22:29Z",
                    "usage": {
                        "cpu": "0",
                        "memory": "201400Ki"
                    }
                },
                "resources": {
                    "requests": {
                        "cpu": "100m",
                        "memory": "128Mi"
                    }
                }
            }
        }
    }
}
```

**Case 3 — `default/test123` (Error state; pod exists but no metrics sample yet) → 200**
```json
{
    "data": {
        "containers": {
            "main": {
                "resources": {
                    "requests": {
                        "cpu": "100m",
                        "memory": "128Mi"
                    }
                }
            }
        }
    }
}
```
This naturally exercised the `metricsFromMetricsServer,omitempty` path: the container is reported
with its configured `resources`, and the usage block is simply absent — the endpoint does **not**
fabricate a value or error when a sample hasn't landed.

---

## 3. Paused → `WORKSPACE_NOT_RUNNING` (case 4, reversible)

Driven entirely through the API (no kubectl), pausing `default/test123` and unpausing immediately
after:

```
0. baseline resources : HTTP 200  {"data":{"containers":{"main":{"resources":{"requests":{"cpu":"100m","memory":"128Mi"}}}}}}
1. POST .../actions/pause {"data":{"paused":true}}  : HTTP 200  {"data":{"paused":true}}
2. GET resources (t≈4s) : HTTP 200  {"data":{"error":"WORKSPACE_NOT_RUNNING"}}   <-- degraded as designed
3. POST .../actions/pause {"data":{"paused":false}} : HTTP 200  {"data":{"paused":false}}
4. confirm : test123 paused=false (workspace restored)
```

Key point: a paused workspace returns **200** with `WORKSPACE_NOT_RUNNING` — it is treated as a
normal, expected state, consistent with how every other workspace endpoint treats a paused
workspace. It is deliberately **not** a 4xx/5xx.

---

## 4. Error / validation / auth responses (cases 5–12)

All errors use the standard `ErrorEnvelope` (`{"error":{"code","message",...}}`):

```json
404  {"error":{"code":"404","message":"the requested resource could not be found"}}
422  {"error":{"code":"422","message":"path parameters were invalid","cause":{"validation_errors":[
       {"type":"FieldValueInvalid","field":"namespace","message":"Invalid value: \"INVALID!!!\": a lowercase RFC 1123 label ..."}]}}}
422  {"error":{"code":"422", ... "field":"name","message":"Invalid value: \"Bad_Name!\": a lowercase RFC 1123 subdomain ..."}}
401  {"error":{"code":"401","message":"authentication is required to access this resource"}}
403  {"error":{"code":"403","message":"you are not authorized to access this resource"}}
405  {"error":{"code":"405","message":"the POST method is not supported for this resource"}}
```

Notable confirmations:
- **404 vs. `WORKSPACE_NOT_RUNNING`** — a non-existent workspace returns **404**, not a false
  `WORKSPACE_NOT_RUNNING`. This validates the existence check added in this PR (Richa's
  consideration #1): a missing workspace is distinguished from a merely paused one.
- **403** — RBAC/SubjectAccessReview is enforced for the resource even with `DISABLE_AUTH=true`; an
  unknown user is rejected rather than served.

---

## 5. Metrics-down → 503

The endpoint under test:

```bash
GW="https://localhost:8443/workspaces/api/v1/workspaces/default/test/podtemplate/resources"
```

### 5a. Discovery-time unavailability (commit `cb947077`) — ✅ VERIFIED

Verified on a dedicated run with the Tilt environment started **without** the metrics server, so API
discovery reports `metrics.k8s.io` absent and the handler takes the discovery branch. All workspaces
returned 503 regardless of state:

```
GET default/test               -> HTTP/2 503  content-type: application/json  {"error":{"code":"503","message":"metrics server not available"}}
GET default/jupyterlab-workspace -> HTTP/2 503  {"error":{"code":"503","message":"metrics server not available"}}
GET default/test123 (Error)    -> HTTP/2 503  {"error":{"code":"503","message":"metrics server not available"}}
```

Ordering confirmed — the **workspace existence check runs before the metrics-availability check**, so
a missing workspace is still a 404 even with metrics down (case 14):

```
GET default/does-not-exist     -> HTTP 404  {"error":{"code":"404","message":"the requested resource could not be found"}}
```

### 5b. Post-startup runtime race (commit `cd042e77`) — ⏳ still to run

This variant is **not** exercised by starting without the metrics server (that only hits the
discovery branch in 5a). It needs the metrics API to be present at backend startup and removed
**while the backend keeps running**: discovery is memoized (~60s TTL) so it still reports
"available", but the `PodMetrics` list then fails and must be caught as unavailable (503, **not**
500):

```bash
# 1. start Tilt WITH the metrics server, confirm a running workspace returns 200 with usage.
# 2. remove the metrics API while the backend keeps running:
kubectl delete apiservice v1beta1.metrics.k8s.io
# 3. within the ~60s discovery cache window, before any backend restart:
curl -k -s -w '\n%{http_code}\n' -H 'Kubeflow-Userid: admin' "$GW"   # expect: 503, NOT 500
```

> To confirm 5b returns **503 and not 500**, watch the backend logs while curling — a 500 would log
> an internal server error; the fix converts the `NotFound`/`ServiceUnavailable` list error into the
> `ErrMetricsAPINotAvailable` → 503 path.

### Restore
```bash
# re-apply the components that create the v1beta1.metrics.k8s.io APIService (e.g. the Tilt metrics
# overlay / ENABLE_METRICS_SERVER=true), or restart the metrics-server deployment if only its pod
# was disrupted:
kubectl -n kube-system rollout restart deploy/metrics-server
```

---

## 6. Live OpenAPI spec verification (closes review thread #2)

Fetched from the running backend at `/workspaces/api/v1/swagger/doc.json`:

- **Responses**: `200, 401, 403, 404, 422, 500, 503` — the `503` is present with description
  *"Metrics server not available."*
- **`metrics.ErrorCode` enum**: `["WORKSPACE_NOT_RUNNING"]` — narrowed, since
  `METRICS_API_NOT_AVAILABLE` is no longer a data-envelope value.
- **`metrics.ContainerResourceUsage`**:
  - `metricsFromMetricsServer` → `$ref metrics.MetricsFromMetricsServer` (object, **not** `string`)
  - `resources` → `$ref v1.ResourceRequirements` (object, **not** `string`)

The original review screenshot showing `"string"` was a stale running Swagger UI; the deployed spec
models the response correctly.

---

## 7. Test fixtures used

Workspaces present in `default` at test time (unchanged by this run, except the reversible pause of
`test123`, which was restored):

| Workspace | Kind | State |
|-----------|------|-------|
| `jupyterlab-workspace` | jupyterlab | Running |
| `test` | codeserver | Running |
| `test123` | jupyterlab | Error (paused → unpaused during case 4) |

## 8. Follow-ups / observations

- Only the **§5b runtime-race variant (case 15)** remains to fully sign off the matrix. It cannot be
  reproduced by starting without the metrics server (that is the discovery path, 5a, already
  verified) — it needs the metrics API removed mid-run. Everything else is confirmed live.
- **404 is returned before 503**: the existence check precedes the metrics-availability check, so a
  missing workspace is a 404 even when the metrics server is down (case 14). Good, unambiguous
  precedence.
- No regressions observed in the sibling endpoints touched by the PR during testing.
- After the pause run, `test123` returned to `paused=false` — no manual cleanup required.

</details>

> Remaining manual check: the post-startup runtime-race variant (metrics API removed mid-run) — the
> discovery-time `503` path is verified; the runtime-race path returning `503` (not `500`) is covered
> by unit tests and pending one manual live confirmation.


<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
