### PR TITLE
feat: show imageConfig/podConfig description as tooltip in workspace table

### DIFF
--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -453,9 +453,19 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               {columnKey === 'name' && workspace.name}
                               {columnKey === 'image' && (
                                 <Content>
-                                  <span data-testid="workspace-image-name">
-                                    {workspace.podTemplate.options.imageConfig.current.displayName}
-                                  </span>{' '}
+                                  <Tooltip
+                                    data-testid="workspace-image-description-tooltip"
+                                    content={
+                                      workspace.podTemplate.options.imageConfig.current.description
+                                    }
+                                  >
+                                    <span data-testid="workspace-image-name">
+                                      {
+                                        workspace.podTemplate.options.imageConfig.current
+                                          .displayName
+                                      }
+                                    </span>
+                                  </Tooltip>{' '}
                                   <RedirectIconWithPopover
                                     redirectChain={
                                       workspace.podTemplate.options.imageConfig.redirectChain
@@ -470,9 +480,16 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               )}
                               {columnKey === 'podConfig' && (
                                 <Content>
-                                  <span data-testid="workspace-pod-config-name">
-                                    {workspace.podTemplate.options.podConfig.current.displayName}
-                                  </span>{' '}
+                                  <Tooltip
+                                    data-testid="workspace-pod-config-description-tooltip"
+                                    content={
+                                      workspace.podTemplate.options.podConfig.current.description
+                                    }
+                                  >
+                                    <span data-testid="workspace-pod-config-name">
+                                      {workspace.podTemplate.options.podConfig.current.displayName}
+                                    </span>
+                                  </Tooltip>{' '}
                                   <RedirectIconWithPopover
                                     redirectChain={
                                       workspace.podTemplate.options.podConfig.redirectChain


### PR DESCRIPTION
The workspace table lists each workspace's image and pod config only by their `displayName` (e.g. "Small CPU"). The underlying `WorkspaceKind` options already carry a human-written `description` explaining what the option actually provides (resources, intended use, etc.), but it wasn't surfaced anywhere in the table view — users had to open the workspace kind or the create/edit form to see it.

This PR adds a hover tooltip on the image and pod config cells in the workspace table, showing that option's `description`, so users can understand what an option means without leaving the table.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
