### PR TITLE
ci: narrow semantic-prs trigger to open/title-edit events

### DIFF
--- a/.github/workflows/semantic-prs.yaml
+++ b/.github/workflows/semantic-prs.yaml
@@ -3,10 +3,8 @@ name: Semantic PRs
 on:
   pull_request_target:
     types:
-      - edited
       - opened
-      - reopened
-      - synchronize
+      - edited
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
@@ -16,6 +14,8 @@ jobs:
   validate_title:
     name: Validate Title
     runs-on: ubuntu-latest
+    # only run on 'opened', or on 'edited' when the title itself changed
+    if: github.event.action == 'opened' || github.event.changes.title != null
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:


### PR DESCRIPTION
## Summary

The `Semantic PRs` workflow was re-validating the PR title on every `synchronize` (each new commit push) and every `edited` event, even when only the description or base branch changed. This narrows the trigger to `opened` plus title-changing `edited` events only.

- Dropped `reopened` and `synchronize` from the `pull_request_target` trigger types.
- Added a job-level `if` guard so `edited` events only run the check when `github.event.changes.title` is set (i.e. the title itself changed, not just the body).

## Test plan

- [x] End-to-end verified on a scratch fork PR: body-only edit → job skipped; title edited to a non-semantic string → job runs and fails; new commit pushed → no run created at all; title edited to a valid semantic form → job runs and passes. Full report below.

<details>
<summary>Verification report</summary>

### What changed

```diff
 on:
   pull_request_target:
     types:
-      - edited
       - opened
-      - reopened
-      - synchronize
+      - edited

 jobs:
   validate_title:
     name: Validate Title
     runs-on: ubuntu-latest
+    if: github.event.action == 'opened' || github.event.changes.title != null
     steps:
```

### Why a job-level guard, not just a trigger list

GitHub's `edited` action covers title, body, and base-branch edits alike — there's no separate "title edited" event type. Removing `edited` entirely would also silence real title fixes made after the initial title validation failed. Keeping it but gating on `github.event.changes.title` (only present when the title itself changed) gets the narrow behavior without losing title-edit coverage. A workflow run is still scheduled for any listed event (that's unavoidable at the trigger level), but the job inside it is skipped rather than actually validating when only the body changed.

### End-to-end verification

Tested against a throwaway PR ([playground#135](https://github.com/christian-heusel/notebooks-playground/pull/135), closed after testing) on a disposable scratch fork, with this fix pushed to its `main` for testing purposes.

| # | Action taken | Expected | Observed | Run |
|---|---|---|---|---|
| 1 | Edited PR body only, title unchanged | job skipped | skipped | [31898818095](https://github.com/christian-heusel/notebooks-playground/actions/runs/31898818095) |
| 2 | Edited PR title to a still-non-semantic string | job runs, fails | ran, failed | [31898842434](https://github.com/christian-heusel/notebooks-playground/actions/runs/31898842434) |
| 3 | Pushed a new commit (synchronize) | no run created | no run created | — |
| 4 | Edited PR title to a valid semantic form | job runs, passes | ran, passed | [31898887963](https://github.com/christian-heusel/notebooks-playground/actions/runs/31898887963) |

All four observed outcomes matched expectations.

</details>
