### PR TITLE
feat: make workspace name clickable to open details drawer

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -47,6 +47,15 @@
   text-decoration: line-through;
 }
 
+/* Workspace name link in the table: looks like plain text, reveals the link
+   underline on hover/focus. Anchored to `.pf-v6-c-button` so it beats the base
+   `.pf-v6-c-button` rule (equal single-class specificity would lose, since PF
+   injects its component styles at runtime after app.css). The higher-specificity
+   `.pf-v6-c-button:hover`/`:focus` rule still wins, so the underline reveals. */
+.pf-v6-c-button.workspace-name-btn {
+  text-decoration: none;
+}
+
 .workspace-form__full-height {
   height: 100%;
 }

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -28,6 +28,7 @@ import {
   Td,
   ThProps,
   ActionsColumn,
+  IAction,
   IActions,
 } from '@patternfly/react-table/dist/esm/components/Table';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
@@ -450,7 +451,32 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               }
                               dataLabel={wsTableColumns[columnKey].label}
                             >
-                              {columnKey === 'name' && workspace.name}
+                              {columnKey === 'name' &&
+                                (() => {
+                                  const viewDetailsAction = rowActions(workspace).find(
+                                    (action): action is IAction =>
+                                      !('isSeparator' in action && action.isSeparator) &&
+                                      action.id === 'viewDetails',
+                                  );
+
+                                  return viewDetailsAction ? (
+                                    <Button
+                                      variant="link"
+                                      isInline
+                                      // Looks like plain text until hovered/focused, then reveals link styling.
+                                      // See the `workspace-name-btn` rule in app.css.
+                                      className="pf-v6-u-text-color-regular workspace-name-btn"
+                                      data-testid="workspace-name-link"
+                                      onClick={(event) =>
+                                        viewDetailsAction.onClick?.(event, rowIndex, {}, {})
+                                      }
+                                    >
+                                      {workspace.name}
+                                    </Button>
+                                  ) : (
+                                    workspace.name
+                                  );
+                                })()}
                               {columnKey === 'image' && (
                                 <Content>
                                   <Tooltip

--- a/workspaces/frontend/src/app/components/__tests__/WorkspaceTable.spec.tsx
+++ b/workspaces/frontend/src/app/components/__tests__/WorkspaceTable.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import WorkspaceTable from '~/app/components/WorkspaceTable';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
@@ -62,5 +63,45 @@ describe('WorkspaceTable state column', () => {
 
     const stateCell = screen.getByTestId('state-label');
     expect(stateCell).toHaveTextContent('Running');
+  });
+});
+
+describe('WorkspaceTable name column', () => {
+  it('renders the name as plain text when no viewDetails row action is provided', () => {
+    const workspace = buildMockWorkspace({});
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.queryByTestId('workspace-name-link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-name')).toHaveTextContent(workspace.name);
+  });
+
+  it('renders the name as a clickable link that triggers the viewDetails action', async () => {
+    const user = userEvent.setup();
+    const workspace = buildMockWorkspace({});
+    const onViewDetailsClick = jest.fn();
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => [
+          { id: 'viewDetails', title: 'View Details', onClick: onViewDetailsClick },
+        ]}
+      />,
+    );
+
+    const nameLink = screen.getByTestId('workspace-name-link');
+    expect(nameLink).toHaveTextContent(workspace.name);
+
+    await user.click(nameLink);
+
+    expect(onViewDetailsClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Clicking a workspace's name in the table now opens the same details
drawer as the row's "View Details" action, giving users a quicker path
to the same destination.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
