### PR TITLE
feat: skip dropdown for single connect endpoint

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -242,3 +242,10 @@ body,
 .mui-theme .pf-v6-c-page.pf-m-no-sidebar .pf-v6-c-page__main {
   margin-left: 0;
 }
+
+/* Single-endpoint "Connect" control: rendered as a MenuToggle (so it keeps the
+   same size as the multi-endpoint dropdown), but its caret is rotated to point
+   right to signal that clicking connects directly instead of opening a menu. */
+.kubeflow-connect-toggle--direct .pf-v6-c-menu-toggle__toggle-icon {
+  transform: rotate(-90deg);
+}

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
@@ -8,7 +8,11 @@ import {
   MenuToggleElement,
 } from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import React, { useState } from 'react';
-import { WorkspacesWorkspaceListItem, V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import {
+  WorkspacesWorkspaceListItem,
+  WorkspacesHttpService,
+  V1Beta1WorkspaceState,
+} from '~/generated/data-contracts';
 
 type WorkspaceConnectActionProps = {
   workspace: WorkspacesWorkspaceListItem;
@@ -18,6 +22,16 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
   workspace,
 }) => {
   const [open, setIsOpen] = useState(false);
+
+  const connectableServices = workspace.services
+    .map((service) => service.httpService)
+    .filter((httpService): httpService is WorkspacesHttpService => !!httpService);
+
+  const isDisabled = workspace.state !== V1Beta1WorkspaceState.WorkspaceStateRunning;
+
+  const openEndpoint = (value: string) => {
+    window.open(value, '_blank');
+  };
 
   const onToggleClick = () => {
     setIsOpen(!open);
@@ -33,9 +47,24 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
     }
   };
 
-  const openEndpoint = (value: string) => {
-    window.open(value, '_blank');
-  };
+  // With a single endpoint there is nothing to choose, so skip the dropdown and
+  // connect directly. We still render a MenuToggle (rather than a plain Button)
+  // so the control keeps the exact same size as the multi-endpoint variant; the
+  // `--direct` modifier rotates its caret to point right, signalling that the
+  // click connects immediately instead of opening a menu.
+  if (connectableServices.length === 1) {
+    return (
+      <MenuToggle
+        variant="secondary"
+        className="kubeflow-connect-toggle--direct"
+        isDisabled={isDisabled}
+        onClick={() => openEndpoint(connectableServices[0].httpPath)}
+        aria-label="Connect to workspace"
+      >
+        Connect
+      </MenuToggle>
+    );
+  }
 
   return (
     <Dropdown
@@ -48,7 +77,7 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
           variant="secondary"
           onClick={onToggleClick}
           isExpanded={open}
-          isDisabled={workspace.state !== V1Beta1WorkspaceState.WorkspaceStateRunning}
+          isDisabled={isDisabled}
           aria-label="Select connection endpoint"
         >
           Connect
@@ -58,19 +87,14 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
       shouldFocusToggleOnSelect
     >
       <DropdownList>
-        {workspace.services.map((service) => {
-          if (!service.httpService) {
-            return null;
-          }
-          return (
-            <DropdownItem
-              value={service.httpService.httpPath}
-              key={`${workspace.name}-${service.httpService.displayName}`}
-            >
-              {service.httpService.displayName}
-            </DropdownItem>
-          );
-        })}
+        {connectableServices.map((httpService) => (
+          <DropdownItem
+            value={httpService.httpPath}
+            key={`${workspace.name}-${httpService.displayName}`}
+          >
+            {httpService.displayName}
+          </DropdownItem>
+        ))}
       </DropdownList>
     </Dropdown>
   );


### PR DESCRIPTION
When a workspace only has one connectable HTTP service, clicking "Connect" now opens it directly instead of showing a single-item dropdown.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/368f5766-c497-4a89-8d98-2510515a93a4" />


<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->