### PR TITLE
feat: add activity warning indicators and toast notifications

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/components/toastNotification.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/components/toastNotification.ts
@@ -47,6 +47,22 @@ class ToastNotification {
     this.findInfoAlert().should('contain.text', message);
   }
 
+  findWarningAlert() {
+    return this.findAlert('warning');
+  }
+
+  assertWarningAlertExists() {
+    this.findWarningAlert().should('exist');
+  }
+
+  assertWarningAlertNotExists() {
+    this.find().findByTestId('toast-notification-warning').should('not.exist');
+  }
+
+  assertWarningAlertContainsMessage(message: string) {
+    this.findWarningAlert().should('contain.text', message);
+  }
+
   closeErrorAlert() {
     this.findErrorAlert().find('button[aria-label="Close"]').click();
   }

--- a/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/pages/workspaces/workspaces.ts
@@ -83,6 +83,31 @@ class Workspaces {
     cy.findByTestId('workspace-lastActivity-tooltip').should('contain.text', text);
   }
 
+  findActivityWarningIndicator(rowIndex: number) {
+    return cy.findByTestId(`workspace-row-${rowIndex}`).findByTestId('activity-warning-indicator');
+  }
+
+  findActivityCriticalIndicator(rowIndex: number) {
+    return cy.findByTestId(`workspace-row-${rowIndex}`).findByTestId('activity-critical-indicator');
+  }
+
+  assertActivityWarningExists(rowIndex: number) {
+    this.findActivityWarningIndicator(rowIndex).should('exist');
+  }
+
+  assertActivityCriticalExists(rowIndex: number) {
+    this.findActivityCriticalIndicator(rowIndex).should('exist');
+  }
+
+  assertNoActivityIndicator(rowIndex: number) {
+    cy.findByTestId(`workspace-row-${rowIndex}`)
+      .findByTestId('activity-warning-indicator')
+      .should('not.exist');
+    cy.findByTestId(`workspace-row-${rowIndex}`)
+      .findByTestId('activity-critical-indicator')
+      .should('not.exist');
+  }
+
   assertTooltipNotExists() {
     cy.get('.pf-v6-c-tooltip').should('not.exist');
   }

--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/activityWarnings.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/activityWarnings.cy.ts
@@ -1,0 +1,152 @@
+import { mockModArchResponse } from 'mod-arch-core';
+import {
+  buildMockNamespace,
+  buildMockWorkspace,
+  buildMockWorkspaceKindInfo,
+} from '~/shared/mock/mockBuilder';
+import { NOTEBOOKS_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { workspaces } from '~/__tests__/cypress/cypress/pages/workspaces/workspaces';
+import { toastNotification } from '~/__tests__/cypress/cypress/pages/components/toastNotification';
+import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
+
+const MINUTE = 60 * 1000;
+const FROZEN_TIME = new Date('2025-06-15T12:00:00Z').getTime();
+
+const mockNamespace = buildMockNamespace({ name: 'default' });
+const mockKind = buildMockWorkspaceKindInfo({ name: 'jupyterlab' });
+
+const buildActivityWorkspace = (
+  name: string,
+  eligibleAfterMs: number,
+  state: V1Beta1WorkspaceState = V1Beta1WorkspaceState.WorkspaceStateRunning,
+) =>
+  buildMockWorkspace({
+    name,
+    namespace: 'default',
+    workspaceKind: mockKind,
+    state,
+    stateMessage: `Workspace is ${state}`,
+    activity: {
+      lastActivity: FROZEN_TIME - 10 * MINUTE,
+      lastUpdate: FROZEN_TIME - 10 * MINUTE,
+      rules: { pauseWorkspace: { eligibleAfter: FROZEN_TIME + eligibleAfterMs } },
+    },
+  });
+
+const buildSafeWorkspace = (name: string) =>
+  buildMockWorkspace({
+    name,
+    namespace: 'default',
+    workspaceKind: mockKind,
+    state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+    stateMessage: 'Workspace is Running',
+    activity: {
+      lastActivity: FROZEN_TIME - 5 * MINUTE,
+      lastUpdate: FROZEN_TIME - 5 * MINUTE,
+    },
+  });
+
+const setupIntercepts = (mockWorkspaces: ReturnType<typeof buildMockWorkspace>[]) => {
+  cy.interceptApi(
+    'GET /api/:apiVersion/namespaces',
+    { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+    mockModArchResponse([mockNamespace]),
+  ).as('getNamespaces');
+
+  cy.interceptApi(
+    'GET /api/:apiVersion/workspaces/:namespace',
+    { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: 'default' } },
+    mockModArchResponse(mockWorkspaces),
+  ).as('getWorkspaces');
+
+  cy.interceptApi(
+    'GET /api/:apiVersion/workspacekinds',
+    { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+    mockModArchResponse([]),
+  ).as('getWorkspaceKinds');
+};
+
+describe('Activity warning indicators', () => {
+  beforeEach(() => {
+    cy.clock(FROZEN_TIME, ['Date']);
+  });
+
+  it('shows warning indicator for workspace within 15 minutes of auto-pause', () => {
+    const warningWorkspace = buildActivityWorkspace('ws-warning', 10 * MINUTE);
+    setupIntercepts([warningWorkspace]);
+
+    workspaces.visit();
+    cy.wait('@getWorkspaces');
+
+    workspaces.assertActivityWarningExists(0);
+  });
+
+  it('shows critical indicator for workspace within 5 minutes of auto-pause', () => {
+    const criticalWorkspace = buildActivityWorkspace('ws-critical', 3 * MINUTE);
+    setupIntercepts([criticalWorkspace]);
+
+    workspaces.visit();
+    cy.wait('@getWorkspaces');
+
+    workspaces.assertActivityCriticalExists(0);
+  });
+
+  it('does not show indicator for workspace 30 minutes from auto-pause', () => {
+    const safeWorkspace = buildActivityWorkspace('ws-safe', 30 * MINUTE);
+    setupIntercepts([safeWorkspace]);
+
+    workspaces.visit();
+    cy.wait('@getWorkspaces');
+
+    workspaces.assertNoActivityIndicator(0);
+  });
+
+  it('does not show indicator for paused workspace regardless of eligibleAfter', () => {
+    const pausedWorkspace = buildActivityWorkspace(
+      'ws-paused',
+      3 * MINUTE,
+      V1Beta1WorkspaceState.WorkspaceStatePaused,
+    );
+    setupIntercepts([pausedWorkspace]);
+
+    workspaces.visit();
+    cy.wait('@getWorkspaces');
+
+    workspaces.assertNoActivityIndicator(0);
+  });
+
+  it('does not show indicator for workspace without activity rules', () => {
+    const noRulesWorkspace = buildSafeWorkspace('ws-no-rules');
+    setupIntercepts([noRulesWorkspace]);
+
+    workspaces.visit();
+    cy.wait('@getWorkspaces');
+
+    workspaces.assertNoActivityIndicator(0);
+  });
+
+  it('shows toast when data refresh transitions workspace into warning state', () => {
+    const safeWorkspace = buildActivityWorkspace('ws-transition', 20 * MINUTE);
+    setupIntercepts([safeWorkspace]);
+
+    workspaces.visit();
+    cy.wait('@getWorkspaces');
+
+    workspaces.assertNoActivityIndicator(0);
+    toastNotification.assertWarningAlertNotExists();
+
+    const warningWorkspace = buildActivityWorkspace('ws-transition', 10 * MINUTE);
+    cy.interceptApi(
+      'GET /api/:apiVersion/workspaces/:namespace',
+      { path: { apiVersion: NOTEBOOKS_API_VERSION, namespace: 'default' } },
+      mockModArchResponse([warningWorkspace]),
+    ).as('getWorkspacesRefresh');
+
+    cy.findByTestId('workspace-refresh-now').click();
+    cy.wait('@getWorkspacesRefresh');
+
+    toastNotification.assertWarningAlertExists();
+    toastNotification.assertWarningAlertContainsMessage('ws-transition');
+    workspaces.assertActivityWarningExists(0);
+  });
+});

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import { Timestamp } from '@patternfly/react-core/dist/esm/components/Timestamp';
 import { Label } from '@patternfly/react-core/dist/esm/components/Label';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import {
   PaginationVariant,
   Pagination,
@@ -45,13 +47,12 @@ import {
   extractWorkspaceStateColor,
   normalizeWorkspaceState,
   WORKSPACE_STATE_COLORS,
+  ActivityWarningLevel,
+  getActivityStatus,
+  formatTimeRemaining,
 } from '~/shared/utilities/WorkspaceUtils';
 import CustomEmptyState from '~/shared/components/CustomEmptyState';
-import {
-  WorkspacesActivity,
-  WorkspacesWorkspaceListItem,
-  V1Beta1WorkspaceState,
-} from '~/generated/data-contracts';
+import { WorkspacesWorkspaceListItem, V1Beta1WorkspaceState } from '~/generated/data-contracts';
 import { RedirectIconWithPopover } from '~/app/components/RedirectIconWithPopover';
 import { POLL_INTERVAL } from '~/shared/utilities/const';
 import { RefreshCounter } from '~/app/components/RefreshCounter';
@@ -117,7 +118,27 @@ type WorkspaceFilterKey = keyof typeof filterConfig;
 // Defines which filters should appear in the dropdown
 const visibleFilterKeys: readonly WorkspaceFilterKey[] = ['name', 'kind', 'image', 'state'];
 
-const LastActivityCell: React.FC<{ activity: WorkspacesActivity }> = ({ activity }) => {
+const ACTIVITY_WARNING_ICONS: Record<ActivityWarningLevel, React.ReactNode> = {
+  [ActivityWarningLevel.Warning]: (
+    <ExclamationTriangleIcon
+      color="var(--pf-t--global--icon--color--status--warning--default)"
+      data-testid="activity-warning-indicator"
+      aria-label="Activity warning"
+    />
+  ),
+  [ActivityWarningLevel.Critical]: (
+    <ExclamationCircleIcon
+      color="var(--pf-t--global--icon--color--status--danger--default)"
+      data-testid="activity-critical-indicator"
+      aria-label="Activity critical"
+    />
+  ),
+  [ActivityWarningLevel.None]: null,
+};
+
+const LastActivityCell: React.FC<{ workspace: WorkspacesWorkspaceListItem }> = ({ workspace }) => {
+  const { activity } = workspace;
+
   if (activity.lastActivity === 0) {
     return <span className="pf-v6-c-timestamp pf-m-help-text">unknown</span>;
   }
@@ -128,17 +149,27 @@ const LastActivityCell: React.FC<{ activity: WorkspacesActivity }> = ({ activity
     </Timestamp>
   );
 
-  const pauseRule = activity.rules?.pauseWorkspace;
-  if (!pauseRule) {
+  const { warningLevel, timeRemainingMs, actionMessage } = getActivityStatus(workspace);
+  const eligibleAfter = activity.rules?.pauseWorkspace?.eligibleAfter;
+
+  if (eligibleAfter == null) {
     return timestamp;
   }
+
+  const action = actionMessage ?? 'paused';
+  const tooltipTime =
+    timeRemainingMs != null
+      ? formatTimeRemaining(timeRemainingMs)
+      : formatDistanceToNow(new Date(eligibleAfter));
 
   return (
     <Tooltip
       data-testid="workspace-lastActivity-tooltip"
-      content={`Workspace will be paused in ${formatDistanceToNow(new Date(pauseRule.eligibleAfter))}`}
+      content={`Workspace will be ${action} in ${tooltipTime}`}
     >
-      <span>{timestamp}</span>
+      <span>
+        {timestamp} {ACTIVITY_WARNING_ICONS[warningLevel]}
+      </span>
     </Tooltip>
   );
 };
@@ -568,7 +599,7 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
                               {columnKey === 'gpu' && formatResourceFromWorkspace(workspace, 'gpu')}
                               {columnKey === 'idleGpu' && formatWorkspaceIdleState(workspace)}
                               {columnKey === 'lastActivity' && (
-                                <LastActivityCell activity={workspace.activity} />
+                                <LastActivityCell workspace={workspace} />
                               )}
                             </Td>
                           );

--- a/workspaces/frontend/src/app/components/__tests__/WorkspaceTable.spec.tsx
+++ b/workspaces/frontend/src/app/components/__tests__/WorkspaceTable.spec.tsx
@@ -4,7 +4,12 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import WorkspaceTable from '~/app/components/WorkspaceTable';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
-import { buildMockWorkspace } from '~/shared/mock/mockBuilder';
+import {
+  buildMockWorkspace,
+  buildMockWorkspaceWithActivityWarning,
+  buildMockWorkspaceWithActivityCritical,
+  buildMockWorkspaceNoActivityRules,
+} from '~/shared/mock/mockBuilder';
 
 jest.mock('~/app/hooks/useWorkspaceKinds', () => ({
   __esModule: true,
@@ -103,5 +108,103 @@ describe('WorkspaceTable name column', () => {
     await user.click(nameLink);
 
     expect(onViewDetailsClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WorkspaceTable activity indicators', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows outlined warning label for workspace ~10 min from activity', () => {
+    const workspace = buildMockWorkspaceWithActivityWarning();
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.getByTestId('activity-warning-indicator')).toBeInTheDocument();
+  });
+
+  it('shows outlined danger label for workspace ~3 min from activity', () => {
+    const workspace = buildMockWorkspaceWithActivityCritical();
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.getByTestId('activity-critical-indicator')).toBeInTheDocument();
+  });
+
+  it('does not show activity indicator for workspace 20 min from activity', () => {
+    const workspace = buildMockWorkspace({
+      state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+      activity: {
+        lastActivity: Date.now() - 5 * 60 * 1000,
+        lastUpdate: Date.now() - 5 * 60 * 1000,
+        rules: { pauseWorkspace: { eligibleAfter: Date.now() + 20 * 60 * 1000 } },
+      },
+    });
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.queryByTestId('activity-warning-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('activity-critical-indicator')).not.toBeInTheDocument();
+  });
+
+  it('does not show activity indicator for paused workspace', () => {
+    const workspace = buildMockWorkspace({
+      state: V1Beta1WorkspaceState.WorkspaceStatePaused,
+      activity: {
+        lastActivity: Date.now() - 20 * 60 * 1000,
+        lastUpdate: Date.now() - 20 * 60 * 1000,
+        rules: { pauseWorkspace: { eligibleAfter: Date.now() + 3 * 60 * 1000 } },
+      },
+    });
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.queryByTestId('activity-warning-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('activity-critical-indicator')).not.toBeInTheDocument();
+  });
+
+  it('does not show activity indicator for workspace without activity rules', () => {
+    const workspace = buildMockWorkspaceNoActivityRules();
+
+    render(
+      <WorkspaceTable
+        workspaces={[workspace]}
+        refreshWorkspaces={jest.fn()}
+        rowActions={() => []}
+      />,
+    );
+
+    expect(screen.queryByTestId('activity-warning-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('activity-critical-indicator')).not.toBeInTheDocument();
   });
 });

--- a/workspaces/frontend/src/app/hooks/__tests__/useActivityNotifications.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useActivityNotifications.spec.tsx
@@ -1,0 +1,172 @@
+import { renderHook } from '~/__tests__/unit/testUtils/hooks';
+import useActivityNotifications from '~/app/hooks/useActivityNotifications';
+import { V1Beta1WorkspaceState, WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import { buildMockWorkspace } from '~/shared/mock/mockBuilder';
+
+const MINUTE = 60 * 1000;
+
+const mockWarning = jest.fn();
+
+jest.mock('mod-arch-core', () => ({
+  ...jest.requireActual('mod-arch-core'),
+  useNotification: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warning: mockWarning,
+    remove: jest.fn(),
+  }),
+}));
+
+const buildRunningWorkspace = (
+  name: string,
+  eligibleAfterMs: number,
+): WorkspacesWorkspaceListItem =>
+  buildMockWorkspace({
+    name,
+    namespace: 'default',
+    state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+    activity: {
+      lastActivity: Date.now() - 10 * MINUTE,
+      lastUpdate: Date.now() - 10 * MINUTE,
+      rules: { pauseWorkspace: { eligibleAfter: Date.now() + eligibleAfterMs } },
+    },
+  });
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+  mockWarning.mockClear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useActivityNotifications', () => {
+  it('does not fire toast on initial render even if workspaces are in warning state', () => {
+    const workspaces = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+
+    renderHook(() => useActivityNotifications(workspaces));
+
+    expect(mockWarning).not.toHaveBeenCalled();
+  });
+
+  it('fires toast on None → Warning transition', () => {
+    const safeWorkspace = [buildRunningWorkspace('ws-1', 20 * MINUTE)];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: safeWorkspace } },
+    );
+
+    expect(mockWarning).not.toHaveBeenCalled();
+
+    const warningWorkspace = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+    rerender({ ws: warningWorkspace });
+
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    expect(mockWarning).toHaveBeenCalledWith(expect.stringContaining('ws-1'));
+  });
+
+  it('fires toast on None → Critical transition', () => {
+    const safeWorkspace = [buildRunningWorkspace('ws-1', 20 * MINUTE)];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: safeWorkspace } },
+    );
+
+    const criticalWorkspace = [buildRunningWorkspace('ws-1', 3 * MINUTE)];
+    rerender({ ws: criticalWorkspace });
+
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    expect(mockWarning).toHaveBeenCalledWith(expect.stringContaining('ws-1'));
+  });
+
+  it('fires toast on Warning → Critical escalation', () => {
+    const safeWorkspace = [buildRunningWorkspace('ws-1', 20 * MINUTE)];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: safeWorkspace } },
+    );
+
+    const warningWorkspace = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+    rerender({ ws: warningWorkspace });
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+
+    const criticalWorkspace = [buildRunningWorkspace('ws-1', 3 * MINUTE)];
+    rerender({ ws: criticalWorkspace });
+    expect(mockWarning).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire toast on Warning → None (auto-clear)', () => {
+    const safeWorkspace = [buildRunningWorkspace('ws-1', 20 * MINUTE)];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: safeWorkspace } },
+    );
+
+    const warningWorkspace = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+    rerender({ ws: warningWorkspace });
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    mockWarning.mockClear();
+
+    const clearedWorkspace = [buildRunningWorkspace('ws-1', 25 * MINUTE)];
+    rerender({ ws: clearedWorkspace });
+    expect(mockWarning).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fire toast on stable Warning → Warning', () => {
+    const safeWorkspace = [buildRunningWorkspace('ws-1', 20 * MINUTE)];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: safeWorkspace } },
+    );
+
+    const warningWorkspace1 = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+    rerender({ ws: warningWorkspace1 });
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+
+    const warningWorkspace2 = [buildRunningWorkspace('ws-1', 8 * MINUTE)];
+    rerender({ ws: warningWorkspace2 });
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('only fires toast for transitioning workspaces, not stable ones', () => {
+    const initial = [
+      buildRunningWorkspace('ws-stable', 20 * MINUTE),
+      buildRunningWorkspace('ws-transition', 20 * MINUTE),
+    ];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: initial } },
+    );
+
+    const updated = [
+      buildRunningWorkspace('ws-stable', 20 * MINUTE),
+      buildRunningWorkspace('ws-transition', 10 * MINUTE),
+    ];
+    rerender({ ws: updated });
+
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    expect(mockWarning).toHaveBeenCalledWith(expect.stringContaining('ws-transition'));
+  });
+
+  it('cleans up tracking for removed workspaces', () => {
+    const initial = [buildRunningWorkspace('ws-1', 20 * MINUTE)];
+    const { rerender } = renderHook(
+      ({ ws }: { ws: WorkspacesWorkspaceListItem[] }) => useActivityNotifications(ws),
+      { initialProps: { ws: initial } },
+    );
+
+    const warningState = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+    rerender({ ws: warningState });
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    mockWarning.mockClear();
+
+    rerender({ ws: [] });
+
+    const reappeared = [buildRunningWorkspace('ws-1', 10 * MINUTE)];
+    rerender({ ws: reappeared });
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/workspaces/frontend/src/app/hooks/useActivityNotifications.ts
+++ b/workspaces/frontend/src/app/hooks/useActivityNotifications.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+import { useNotification } from 'mod-arch-core';
+import { WorkspacesWorkspaceListItem } from '~/generated/data-contracts';
+import {
+  ActivityWarningLevel,
+  getActivityStatus,
+  formatTimeRemaining,
+} from '~/shared/utilities/WorkspaceUtils';
+
+const workspaceKey = (ws: WorkspacesWorkspaceListItem): string => `${ws.namespace}/${ws.name}`;
+
+const useActivityNotifications = (workspaces: WorkspacesWorkspaceListItem[]): void => {
+  const notification = useNotification();
+  const prevLevelsRef = useRef<Map<string, ActivityWarningLevel> | null>(null);
+
+  useEffect(() => {
+    const currentLevels = new Map<string, ActivityWarningLevel>();
+
+    for (const ws of workspaces) {
+      const status = getActivityStatus(ws);
+      const key = workspaceKey(ws);
+      const currentLevel = status.warningLevel;
+
+      if (currentLevel !== ActivityWarningLevel.None) {
+        currentLevels.set(key, currentLevel);
+      }
+
+      if (prevLevelsRef.current) {
+        const prevLevel = prevLevelsRef.current.get(key) ?? ActivityWarningLevel.None;
+
+        if (currentLevel === ActivityWarningLevel.None || currentLevel === prevLevel) {
+          continue;
+        }
+
+        const isEscalation =
+          prevLevel === ActivityWarningLevel.None || prevLevel === ActivityWarningLevel.Warning;
+
+        if (isEscalation) {
+          const timeStr =
+            status.timeRemainingMs != null ? formatTimeRemaining(status.timeRemainingMs) : 'soon';
+          const action = status.actionMessage ?? 'paused';
+          notification.warning(`Workspace "${ws.name}" will be ${action} in ${timeStr}`);
+        }
+      }
+    }
+
+    prevLevelsRef.current = currentLevels;
+  }, [workspaces, notification]);
+};
+
+export default useActivityNotifications;

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -8,6 +8,7 @@ import { useNamespaceSelectorWrapper } from '~/app/hooks/useNamespaceSelectorWra
 import { LoadingSpinner } from '~/app/components/LoadingSpinner';
 import { LoadError } from '~/app/components/LoadError';
 import { useWorkspaceRowActions } from '~/app/hooks/useWorkspaceRowActions';
+import useActivityNotifications from '~/app/hooks/useActivityNotifications';
 import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
 
 export const Workspaces: React.FunctionComponent = () => {
@@ -15,6 +16,8 @@ export const Workspaces: React.FunctionComponent = () => {
 
   const [workspaces, workspacesLoaded, workspacesLoadError, refreshWorkspaces] =
     useWorkspacesByNamespace(selectedNamespace);
+
+  useActivityNotifications(workspaces);
 
   const tableRowActions = useWorkspaceRowActions([
     { id: 'viewDetails' },

--- a/workspaces/frontend/src/shared/mock/mockBuilder.ts
+++ b/workspaces/frontend/src/shared/mock/mockBuilder.ts
@@ -973,6 +973,44 @@ export const buildMockWorkspaceDetails = (
   ...details,
 });
 
+export const buildMockWorkspaceWithActivityWarning = (
+  workspace?: Partial<WorkspacesWorkspaceListItem>,
+): WorkspacesWorkspaceListItem =>
+  buildMockWorkspace({
+    state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+    activity: {
+      lastActivity: Date.now() - 10 * 60 * 1000,
+      lastUpdate: Date.now() - 10 * 60 * 1000,
+      rules: { pauseWorkspace: { eligibleAfter: Date.now() + 10 * 60 * 1000 } },
+    },
+    ...workspace,
+  });
+
+export const buildMockWorkspaceWithActivityCritical = (
+  workspace?: Partial<WorkspacesWorkspaceListItem>,
+): WorkspacesWorkspaceListItem =>
+  buildMockWorkspace({
+    state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+    activity: {
+      lastActivity: Date.now() - 20 * 60 * 1000,
+      lastUpdate: Date.now() - 20 * 60 * 1000,
+      rules: { pauseWorkspace: { eligibleAfter: Date.now() + 3 * 60 * 1000 } },
+    },
+    ...workspace,
+  });
+
+export const buildMockWorkspaceNoActivityRules = (
+  workspace?: Partial<WorkspacesWorkspaceListItem>,
+): WorkspacesWorkspaceListItem =>
+  buildMockWorkspace({
+    state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+    activity: {
+      lastActivity: Date.now() - 5 * 60 * 1000,
+      lastUpdate: Date.now() - 5 * 60 * 1000,
+    },
+    ...workspace,
+  });
+
 // The logs endpoint returns a raw text/plain stream, where every line is
 // prefixed with the RFC3339 timestamp added by the Kubernetes pod logs API.
 export const buildMockWorkspaceLogs = (lineCount = 5): string => {

--- a/workspaces/frontend/src/shared/utilities/WorkspaceUtils.ts
+++ b/workspaces/frontend/src/shared/utilities/WorkspaceUtils.ts
@@ -1,4 +1,6 @@
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import {
+  WorkspacesActivityRules,
   WorkspacesOptionLabel,
   WorkspacesWorkspaceListItem,
   V1Beta1WorkspaceState,
@@ -143,6 +145,61 @@ export const hasWorkspacePendingUpdate = (
 
 // For now, label keys will be showed as they are in the backend.
 export const formatLabelKey = (key: string): string => key;
+
+export const ACTIVITY_ACTION_MESSAGES: Record<keyof WorkspacesActivityRules, string> = {
+  pauseWorkspace: 'paused',
+};
+
+export enum ActivityWarningLevel {
+  None = 'none',
+  Warning = 'warning',
+  Critical = 'critical',
+}
+
+const ACTIVITY_WARNING_THRESHOLD_MS = 15 * 60 * 1000;
+const ACTIVITY_CRITICAL_THRESHOLD_MS = 5 * 60 * 1000;
+
+export type ActivityStatus = {
+  warningLevel: ActivityWarningLevel;
+  timeRemainingMs: number | null;
+  actionMessage: string | null;
+};
+
+export const getActivityStatus = (workspace: WorkspacesWorkspaceListItem): ActivityStatus => {
+  const { rules } = workspace.activity;
+  const isRunning = workspace.state === V1Beta1WorkspaceState.WorkspaceStateRunning;
+
+  let actionMessage: string | null = null;
+  if (rules) {
+    for (const key of Object.keys(ACTIVITY_ACTION_MESSAGES) as (keyof WorkspacesActivityRules)[]) {
+      if (rules[key]) {
+        actionMessage = ACTIVITY_ACTION_MESSAGES[key];
+        break;
+      }
+    }
+  }
+
+  const eligibleAfter = rules?.pauseWorkspace?.eligibleAfter;
+  const timeRemainingMs = isRunning && eligibleAfter != null ? eligibleAfter - Date.now() : null;
+
+  let warningLevel = ActivityWarningLevel.None;
+  if (timeRemainingMs != null) {
+    if (timeRemainingMs <= ACTIVITY_CRITICAL_THRESHOLD_MS) {
+      warningLevel = ActivityWarningLevel.Critical;
+    } else if (timeRemainingMs <= ACTIVITY_WARNING_THRESHOLD_MS) {
+      warningLevel = ActivityWarningLevel.Warning;
+    }
+  }
+
+  return { warningLevel, timeRemainingMs, actionMessage };
+};
+
+export const formatTimeRemaining = (ms: number): string => {
+  if (ms <= 0) {
+    return 'less than a minute';
+  }
+  return formatDistanceToNow(new Date(Date.now() + ms));
+};
 
 // Check if a label represents version/package information
 export const isPackageLabel = (key: string): boolean => key.endsWith('Version');

--- a/workspaces/frontend/src/shared/utilities/__tests__/WorkspaceUtils.activity.spec.ts
+++ b/workspaces/frontend/src/shared/utilities/__tests__/WorkspaceUtils.activity.spec.ts
@@ -1,0 +1,230 @@
+import { buildMockWorkspace } from '~/shared/mock/mockBuilder';
+import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import {
+  ActivityWarningLevel,
+  getActivityStatus,
+  formatTimeRemaining,
+} from '~/shared/utilities/WorkspaceUtils';
+
+const MINUTE = 60 * 1000;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('getActivityStatus', () => {
+  describe('warningLevel', () => {
+    it('returns Critical when eligibleAfter is 3 minutes from now', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 3 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.Critical);
+    });
+
+    it('returns Warning when eligibleAfter is 10 minutes from now', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 10 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.Warning);
+    });
+
+    it('returns None when eligibleAfter is 20 minutes from now', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 20 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.None);
+    });
+
+    it('returns Critical when eligibleAfter is in the past', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 30 * MINUTE,
+          lastUpdate: Date.now() - 30 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() - 2 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.Critical);
+    });
+
+    it('returns Critical at exactly 5 minutes boundary', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 5 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.Critical);
+    });
+
+    it('returns Warning at exactly 15 minutes boundary', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 15 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.Warning);
+    });
+
+    it.each([
+      V1Beta1WorkspaceState.WorkspaceStatePaused,
+      V1Beta1WorkspaceState.WorkspaceStatePending,
+      V1Beta1WorkspaceState.WorkspaceStateTerminating,
+      V1Beta1WorkspaceState.WorkspaceStateError,
+      V1Beta1WorkspaceState.WorkspaceStateUnknown,
+    ])('returns None for non-running state: %s', (state) => {
+      const workspace = buildMockWorkspace({
+        state,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 3 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.None);
+    });
+
+    it('returns None when no activity rules exist', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.None);
+    });
+
+    it('returns None when pauseWorkspace rule is undefined', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: {},
+        },
+      });
+      expect(getActivityStatus(workspace).warningLevel).toBe(ActivityWarningLevel.None);
+    });
+  });
+
+  describe('timeRemainingMs', () => {
+    it('returns milliseconds until auto-pause for a running workspace', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 10 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).timeRemainingMs).toBe(10 * MINUTE);
+    });
+
+    it('returns null for non-running workspace', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStatePaused,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 10 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).timeRemainingMs).toBeNull();
+    });
+
+    it('returns null when no pauseWorkspace rule exists', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+        },
+      });
+      expect(getActivityStatus(workspace).timeRemainingMs).toBeNull();
+    });
+
+    it('returns negative value when eligibleAfter is in the past', () => {
+      const workspace = buildMockWorkspace({
+        state: V1Beta1WorkspaceState.WorkspaceStateRunning,
+        activity: {
+          lastActivity: Date.now() - 30 * MINUTE,
+          lastUpdate: Date.now() - 30 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() - 5 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).timeRemainingMs).toBe(-5 * MINUTE);
+    });
+  });
+
+  describe('actionMessage', () => {
+    it('returns "paused" when pauseWorkspace rule exists', () => {
+      const workspace = buildMockWorkspace({
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: { pauseWorkspace: { eligibleAfter: Date.now() + 10 * MINUTE } },
+        },
+      });
+      expect(getActivityStatus(workspace).actionMessage).toBe('paused');
+    });
+
+    it('returns null when no activity rules exist', () => {
+      const workspace = buildMockWorkspace({
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+        },
+      });
+      expect(getActivityStatus(workspace).actionMessage).toBeNull();
+    });
+
+    it('returns null when rules object is empty', () => {
+      const workspace = buildMockWorkspace({
+        activity: {
+          lastActivity: Date.now() - 10 * MINUTE,
+          lastUpdate: Date.now() - 10 * MINUTE,
+          rules: {},
+        },
+      });
+      expect(getActivityStatus(workspace).actionMessage).toBeNull();
+    });
+  });
+});
+
+describe('formatTimeRemaining', () => {
+  it('returns a human-readable string for positive time', () => {
+    const result = formatTimeRemaining(10 * MINUTE);
+    expect(result).toMatch(/minute/);
+  });
+
+  it('returns "less than a minute" for zero or negative time', () => {
+    expect(formatTimeRemaining(0)).toBe('less than a minute');
+    expect(formatTimeRemaining(-5 * MINUTE)).toBe('less than a minute');
+  });
+});


### PR DESCRIPTION

Add warning/critical visual indicators on workspace table rows when a workspace approaches its auto-pause threshold, plus toast notifications on state transitions. Warnings clear automatically when the next data refresh shows updated activity.


 closes: #1203
<img width="1173" height="683" alt="Screenshot 2026-08-19 at 3 24 23 PM" src="https://github.com/user-attachments/assets/5b39498c-e1cc-44e2-b439-78475f095e63" />
<img width="1536" height="738" alt="Screenshot 2026-08-19 at 2 19 54 PM" src="https://github.com/user-attachments/assets/26a25ba7-0f00-4559-922b-9aab56f8344a" />

