### PR TITLE
fix: break infinite status reconciliation loop in notebook controller

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -235,6 +235,10 @@ func updateNotebookStatus(r *NotebookReconciler, nb *v1beta1.Notebook,
 		return err
 	}
 
+	if reflect.DeepEqual(nb.Status, status) {
+		return nil
+	}
+
 	log.Info("Updating Notebook CR Status", "status", status)
 	nb.Status = status
 	return r.Status().Update(ctx, nb)
@@ -321,22 +325,22 @@ func PodCondToNotebookCond(podc corev1.PodCondition) v1beta1.NotebookCondition {
 		condition.Reason = podc.Reason
 	}
 
-	// check if podc.LastProbeTime is null. If so initialize
-	// the field with metav1.Now()
-	check := podc.LastProbeTime.Time.Equal(time.Time{})
-	if !check {
-		condition.LastProbeTime = podc.LastProbeTime
-	} else {
-		condition.LastProbeTime = metav1.Now()
-	}
-
 	// check if podc.LastTransitionTime is null. If so initialize
 	// the field with metav1.Now()
-	check = podc.LastTransitionTime.Time.Equal(time.Time{})
+	check := podc.LastTransitionTime.Time.Equal(time.Time{})
 	if !check {
 		condition.LastTransitionTime = podc.LastTransitionTime
 	} else {
 		condition.LastTransitionTime = metav1.Now()
+	}
+
+	// Kubelet never sets LastProbeTime on Pod conditions; defaulting it to now()
+	// rewrites the status on every reconcile and drives an endless update loop.
+	check = podc.LastProbeTime.Time.Equal(time.Time{})
+	if !check {
+		condition.LastProbeTime = podc.LastProbeTime
+	} else {
+		condition.LastProbeTime = condition.LastTransitionTime
 	}
 
 	return condition

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -271,6 +271,54 @@ func TestCreateNotebookStatus(t *testing.T) {
 				ContainerState: corev1.ContainerState{},
 			},
 		},
+		{
+			name: "lastProbeTimeDefaultsToLastTransitionTime",
+			currentNb: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               "Ready",
+							Status:             "True",
+							LastTransitionTime: v1.Date(2022, time.Month(6), 15, 12, 0, 0, 0, time.UTC),
+							// LastProbeTime intentionally omitted (zero value)
+							// to simulate kubelet behavior
+						},
+					},
+				},
+			},
+			sts: appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: int32(1),
+				},
+			},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions: []nbv1beta1.NotebookCondition{
+					{
+						Type:               "Ready",
+						Status:             "True",
+						LastProbeTime:      v1.Date(2022, time.Month(6), 15, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: v1.Date(2022, time.Month(6), 15, 12, 0, 0, 0, time.UTC),
+					},
+				},
+				ReadyReplicas:  int32(1),
+				ContainerState: corev1.ContainerState{},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Fixes the infinite reconciliation loop in the notebook controller where `updateNotebookStatus` issues a `Status().Update()` PUT on every reconcile even when nothing has changed.

## Root Cause

Three-link causal chain:

1. [`PodCondToNotebookCond` (line 330)](https://github.com/kubeflow/notebooks/blob/notebooks-v1/components/notebook-controller/controllers/notebook_controller.go#L330) — kubelet never sets `LastProbeTime` on pod conditions, so the else branch injects `metav1.Now()` on every reconcile, producing a different timestamp each time.

2. [`updateNotebookStatus` (line 238-240)](https://github.com/kubeflow/notebooks/blob/notebooks-v1/components/notebook-controller/controllers/notebook_controller.go#L238-L240) — unconditional `r.Status().Update(ctx, nb)` with no comparison guard.

3. [`SetupWithManager` (line 713-714)](https://github.com/kubeflow/notebooks/blob/notebooks-v1/components/notebook-controller/controllers/notebook_controller.go#L713-L714) — `For(&v1beta1.Notebook{})` with no `GenerationChangedPredicate`, so the status write bumps `resourceVersion`, emits a watch event, and re-enqueues.

## Changes

| File | Change |
|------|--------|
| `controllers/notebook_controller.go` | Reorder `PodCondToNotebookCond` to resolve `LastTransitionTime` first, fall back `LastProbeTime` to `condition.LastTransitionTime` instead of `metav1.Now()`, add `reflect.DeepEqual` guard in `updateNotebookStatus` |

## Design Decisions

- **`LastProbeTime` falls back to `LastTransitionTime`, not zero** — the [CRD schema](https://github.com/kubeflow/notebooks/blob/notebooks-v1/components/notebook-controller/config/crd/bases/kubeflow.org_notebooks.yaml#L3133-L3135) declares `lastProbeTime` as `type: string, format: date-time` without `nullable: true`, and `omitempty` on [`metav1.Time` (a struct)](https://github.com/kubeflow/notebooks/blob/notebooks-v1/components/notebook-controller/api/v1beta1/notebook_types.go#L53) does not suppress the zero value.
- **Block reorder** — `LastTransitionTime` resolved first so `LastProbeTime` can reference it without a second `metav1.Now()` call.
- **Both changes needed** — `DeepEqual` guard alone does not break the loop because `metav1.Now()` makes it return false every time. The timestamp fix makes the status deterministic; the guard eliminates the residual no-op PUT.
- **No new imports** — `reflect` already used at [line 257](https://github.com/kubeflow/notebooks/blob/notebooks-v1/components/notebook-controller/controllers/notebook_controller.go#L257).

## Test Results

All 5 `TestCreateNotebookStatus` subtests pass. `go vet` and `go build` clean.

## Follow-up

- Add test case with `LastProbeTime` omitted asserting fallback equals `LastTransitionTime`
- `CopyStatefulSetFields` secondary loop is a separate concern

## Contributor Checklist

- [x] DCO sign-off
- [x] All existing tests pass
- [x] `go vet` clean
- [x] `go build` clean
- [x] Single file, minimal diff
