### PR TITLE
fix: infinite status reconciliation loop in notebook controller

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -137,6 +137,9 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Reconcile StatefulSet
 	ss := generateStatefulSet(instance)
+	if err := reconcilehelper.SetStatefulSetTemplateHash(ss); err != nil {
+		return ctrl.Result{}, err
+	}
 	if err := ctrl.SetControllerReference(instance, ss, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -235,6 +238,10 @@ func updateNotebookStatus(r *NotebookReconciler, nb *v1beta1.Notebook,
 		return err
 	}
 
+	if reflect.DeepEqual(nb.Status, status) {
+		return nil
+	}
+
 	log.Info("Updating Notebook CR Status", "status", status)
 	nb.Status = status
 	return r.Status().Update(ctx, nb)
@@ -269,13 +276,11 @@ func createNotebookStatus(r *NotebookReconciler, nb *v1beta1.Notebook,
 			continue
 		}
 
-		if pod.Status.ContainerStatuses[i].State == nb.Status.ContainerState {
-			continue
-		}
-
 		// Update Notebook CR's status.ContainerState
 		cs := pod.Status.ContainerStatuses[i].State
-		log.Info("Updating Notebook CR state: ", "state", cs)
+		if cs != nb.Status.ContainerState {
+			log.Info("Updating Notebook CR state: ", "state", cs)
+		}
 
 		status.ContainerState = cs
 		notebookContainerFound = true
@@ -321,22 +326,20 @@ func PodCondToNotebookCond(podc corev1.PodCondition) v1beta1.NotebookCondition {
 		condition.Reason = podc.Reason
 	}
 
-	// check if podc.LastProbeTime is null. If so initialize
-	// the field with metav1.Now()
-	check := podc.LastProbeTime.Time.Equal(time.Time{})
-	if !check {
-		condition.LastProbeTime = podc.LastProbeTime
-	} else {
-		condition.LastProbeTime = metav1.Now()
-	}
-
 	// check if podc.LastTransitionTime is null. If so initialize
 	// the field with metav1.Now()
-	check = podc.LastTransitionTime.Time.Equal(time.Time{})
+	check := podc.LastTransitionTime.Time.Equal(time.Time{})
 	if !check {
 		condition.LastTransitionTime = podc.LastTransitionTime
 	} else {
 		condition.LastTransitionTime = metav1.Now()
+	}
+
+	check = podc.LastProbeTime.Time.Equal(time.Time{})
+	if !check {
+		condition.LastProbeTime = podc.LastProbeTime
+	} else {
+		condition.LastProbeTime = condition.LastTransitionTime
 	}
 
 	return condition

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -180,6 +180,35 @@ func TestCreateNotebookStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "NotebookContainerStateUnchanged",
+			currentNb: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{Name: "test"},
+				Status: nbv1beta1.NotebookStatus{
+					ContainerState: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "test",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions: []nbv1beta1.NotebookCondition{},
+				ContainerState: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			},
+		},
+		{
 			name: "mirroringPodConditions",
 			pod: corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
@@ -226,6 +255,31 @@ func TestCreateNotebookStatus(t *testing.T) {
 					},
 				},
 				ReadyReplicas:  int32(1),
+				ContainerState: corev1.ContainerState{},
+			},
+		},
+		{
+			name: "mirroringPodConditionWithoutProbeTime",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               "Ready",
+							Status:             "True",
+							LastTransitionTime: v1.Date(2022, time.Month(8), 30, 1, 10, 30, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions: []nbv1beta1.NotebookCondition{
+					{
+						Type:               "Ready",
+						Status:             "True",
+						LastProbeTime:      v1.Date(2022, time.Month(8), 30, 1, 10, 30, 0, time.UTC),
+						LastTransitionTime: v1.Date(2022, time.Month(8), 30, 1, 10, 30, 0, time.UTC),
+					},
+				},
 				ContainerState: corev1.ContainerState{},
 			},
 		},
@@ -287,6 +341,21 @@ func TestCreateNotebookStatus(t *testing.T) {
 		})
 	}
 
+}
+
+func TestUpdateNotebookStatusSkipsUnchangedStatus(t *testing.T) {
+	reconciler := createMockReconciler()
+	reconciler.Client = fake.NewFakeClientWithScheme(scheme.Scheme)
+	notebook := &nbv1beta1.Notebook{
+		Status: nbv1beta1.NotebookStatus{
+			Conditions:     []nbv1beta1.NotebookCondition{},
+			ContainerState: corev1.ContainerState{},
+		},
+	}
+
+	if err := updateNotebookStatus(reconciler, notebook, &appsv1.StatefulSet{}, &corev1.Pod{}, ctrl.Request{}); err != nil {
+		t.Fatalf("expected unchanged status to skip API update: %v", err)
+	}
 }
 
 func createMockReconciler() *NotebookReconciler {

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -259,7 +259,7 @@ func TestCreateNotebookStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "mirroringPodConditionWithoutProbeTime",
+			name: "LastProbeTimeDefaultsToLastTransitionTime",
 			pod: corev1.Pod{
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{

--- a/components/notebook-controller/reconcilehelper/util.go
+++ b/components/notebook-controller/reconcilehelper/util.go
@@ -2,12 +2,16 @@ package reconcile
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -102,33 +106,41 @@ func VirtualService(ctx context.Context, r client.Client, virtualServiceName, na
 
 // Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/pkg/util/util.go
 
+const StatefulSetTemplateHashAnnotation = "notebooks.kubeflow.org/statefulset-template-hash"
+
+func SetStatefulSetTemplateHash(statefulSet *appsv1.StatefulSet) error {
+	serializedTemplate, err := json.Marshal(statefulSet.Spec.Template)
+	if err != nil {
+		return fmt.Errorf("serialize StatefulSet pod template: %w", err)
+	}
+
+	if statefulSet.Annotations == nil {
+		statefulSet.Annotations = make(map[string]string)
+	}
+	statefulSet.Annotations[StatefulSetTemplateHashAnnotation] = fmt.Sprintf("%x", sha256.Sum256(serializedTemplate))
+	return nil
+}
+
 // CopyStatefulSetFields copies the owned fields from one StatefulSet to another
 // Returns true if the fields copied from don't match to.
 func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 	requireUpdate := false
-	for k, v := range to.Labels {
-		if from.Labels[k] != v {
-			requireUpdate = true
-		}
-	}
-	to.Labels = from.Labels
-
-	for k, v := range to.Annotations {
-		if from.Annotations[k] != v {
-			requireUpdate = true
-		}
-	}
-	to.Annotations = from.Annotations
 
 	if *from.Spec.Replicas != *to.Spec.Replicas {
 		*to.Spec.Replicas = *from.Spec.Replicas
 		requireUpdate = true
 	}
 
-	if !reflect.DeepEqual(to.Spec.Template.Spec, from.Spec.Template.Spec) {
+	desiredTemplateHash := from.Annotations[StatefulSetTemplateHashAnnotation]
+	if desiredTemplateHash != to.Annotations[StatefulSetTemplateHashAnnotation] ||
+		!apiequality.Semantic.DeepDerivative(from.Spec.Template, to.Spec.Template) {
+		to.Spec.Template = from.Spec.Template
+		if to.Annotations == nil {
+			to.Annotations = make(map[string]string)
+		}
+		to.Annotations[StatefulSetTemplateHashAnnotation] = desiredTemplateHash
 		requireUpdate = true
 	}
-	to.Spec.Template.Spec = from.Spec.Template.Spec
 
 	return requireUpdate
 }

--- a/components/notebook-controller/reconcilehelper/util_test.go
+++ b/components/notebook-controller/reconcilehelper/util_test.go
@@ -1,0 +1,180 @@
+package reconcile
+
+import (
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCopyStatefulSetFieldsPodSpecification(t *testing.T) {
+	tests := []struct {
+		name                     string
+		previousPodSpecification corev1.PodSpec
+		desiredPodSpecification  corev1.PodSpec
+		storedPodSpecification   corev1.PodSpec
+		requiresUpdate           bool
+	}{
+		{
+			name: "IgnoresStoredDefaults",
+			previousPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+			},
+			desiredPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+			},
+			storedPodSpecification: corev1.PodSpec{
+				Containers:    []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+				RestartPolicy: corev1.RestartPolicyAlways,
+				DNSPolicy:     corev1.DNSClusterFirst,
+			},
+			requiresUpdate: false,
+		},
+		{
+			name: "IgnoresStoredAdditionalEnvironmentVariable",
+			previousPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "notebook",
+					Env:  []corev1.EnvVar{{Name: "CONFIGURED"}},
+				}},
+			},
+			desiredPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "notebook",
+					Env:  []corev1.EnvVar{{Name: "CONFIGURED"}},
+				}},
+			},
+			storedPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "notebook",
+					Env: []corev1.EnvVar{
+						{Name: "CONFIGURED"},
+						{Name: "ADDED"},
+					},
+				}},
+			},
+			requiresUpdate: false,
+		},
+		{
+			name: "DetectsDesiredFieldChange",
+			previousPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+			},
+			desiredPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:2"}},
+			},
+			storedPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+			},
+			requiresUpdate: true,
+		},
+		{
+			name: "DetectsRemovedDesiredListEntry",
+			previousPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "notebook",
+					Env: []corev1.EnvVar{
+						{Name: "RETAINED"},
+						{Name: "REMOVED"},
+					},
+				}},
+			},
+			desiredPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "notebook",
+					Env:  []corev1.EnvVar{{Name: "RETAINED"}},
+				}},
+			},
+			storedPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "notebook",
+					Env: []corev1.EnvVar{
+						{Name: "RETAINED"},
+						{Name: "REMOVED"},
+					},
+				}},
+			},
+			requiresUpdate: true,
+		},
+		{
+			name: "DetectsStoredDesiredFieldDrift",
+			previousPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+			},
+			desiredPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:1"}},
+			},
+			storedPodSpecification: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "notebook", Image: "notebook:modified"}},
+			},
+			requiresUpdate: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			desiredReplicas := int32(1)
+			storedReplicas := int32(1)
+			previousStatefulSet := &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{Spec: test.previousPodSpecification},
+				},
+			}
+			desiredStatefulSet := &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &desiredReplicas,
+					Template: corev1.PodTemplateSpec{Spec: test.desiredPodSpecification},
+				},
+			}
+			storedStatefulSet := &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &storedReplicas,
+					Template: corev1.PodTemplateSpec{Spec: test.storedPodSpecification},
+				},
+			}
+			if err := SetStatefulSetTemplateHash(previousStatefulSet); err != nil {
+				t.Fatalf("could not hash previous StatefulSet template: %v", err)
+			}
+			if err := SetStatefulSetTemplateHash(desiredStatefulSet); err != nil {
+				t.Fatalf("could not hash desired StatefulSet template: %v", err)
+			}
+			storedStatefulSet.Annotations = previousStatefulSet.Annotations
+
+			if requiresUpdate := CopyStatefulSetFields(desiredStatefulSet, storedStatefulSet); requiresUpdate != test.requiresUpdate {
+				t.Fatalf("expected requiresUpdate %t, got %t", test.requiresUpdate, requiresUpdate)
+			}
+			if test.requiresUpdate && !reflect.DeepEqual(storedStatefulSet.Spec.Template, desiredStatefulSet.Spec.Template) {
+				t.Fatalf("expected desired pod template to be copied")
+			}
+		})
+	}
+}
+
+func TestCopyStatefulSetFieldsAddsTemplateHashToExistingStatefulSet(t *testing.T) {
+	replicas := int32(1)
+	desiredStatefulSet := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "notebook"}},
+				},
+			},
+		},
+	}
+	storedStatefulSet := desiredStatefulSet.DeepCopy()
+	if err := SetStatefulSetTemplateHash(desiredStatefulSet); err != nil {
+		t.Fatalf("could not hash desired StatefulSet template: %v", err)
+	}
+
+	if !CopyStatefulSetFields(desiredStatefulSet, storedStatefulSet) {
+		t.Fatal("expected existing StatefulSet without template hash to require update")
+	}
+	if storedStatefulSet.Annotations[StatefulSetTemplateHashAnnotation] == "" {
+		t.Fatal("expected template hash annotation to be copied")
+	}
+	if CopyStatefulSetFields(desiredStatefulSet, storedStatefulSet) {
+		t.Fatal("expected StatefulSet to converge after template hash migration")
+	}
+}


### PR DESCRIPTION
Alternative to https://github.com/kubeflow/notebooks/pull/1341

The reconcilliation loop creates a lot of logging costs and api server load if you have for example 250 notebooks on a cluster.

```
│ 1.7873218948448386e+09    INFO    controllers.Notebook    Reconciliation loop started    {"notebook": "my-namespace/my-notebook"}                    │
│ 1.787321894844961e+09    INFO    controllers.Notebook    Updating StatefulSet    {"notebook": "my-namespace/my-notebook", "namespace": "xdiv-finance │
│ -ior-prediction-dev", "name": "daniel"}                                                                                                                            │
│ 1.7873218949141026e+09    INFO    controllers.Notebook    Initializing Notebook CR Status    {"notebook": "my-namespace/my-notebook"}                │
│ 1.7873218949141288e+09    INFO    controllers.Notebook    Calculating Notebook's  containerState    {"notebook": "my-namespace/my-notebook"}         │
│ 1.7873218949141347e+09    INFO    controllers.Notebook    Updating Notebook CR state:     {"notebook": "my-namespace/my-notebook", "state": {"runnin │
│ g":{"startedAt":"2026-08-18T13:11:00Z"}}}                                                                                                                          │
│ 1.7873218949141548e+09    INFO    controllers.Notebook    Calculating Notebook's Conditions    {"notebook": "my-namespace/my-notebook"}              │
│ 1.787321894914165e+09    INFO    controllers.Notebook    Updating Notebook CR Status    {"notebook": "my-namespace/my-notebook", "status": {"conditi │
│ ons":[{"type":"PodReadyToStartContainers","status":"True","lastProbeTime":"2026-08-21T14:18:14Z","lastTransitionTime":"2026-08-18T13:10:58Z"},{"type":"Initialized │
│ ","status":"True","lastProbeTime":"2026-08-21T14:18:14Z","lastTransitionTime":"2026-08-18T13:11:00Z"},{"type":"Ready","status":"True","lastProbeTime":"2026-08-21T │
│ 14:18:14Z","lastTransitionTime":"2026-08-18T13:11:07Z"},{"type":"ContainersReady","status":"True","lastProbeTime":"2026-08-21T14:18:14Z","lastTransitionTime":"202 │
│ 6-08-18T13:11:07Z"},{"type":"PodScheduled","status":"True","lastProbeTime":"2026-08-21T14:18:14Z","lastTransitionTime":"2026-08-18T13:10:37Z"}],"readyReplicas":1, │
│ "containerState":{"running":{"startedAt":"2026-08-18T13:11:00Z"}}}}   
```
Imagine this continously at full speed without interruption increasing the revisions.
Assisted-by: GitHub Copilot