### PR TITLE
fix: stabilize workspace kind ordering

### DIFF
--- a/workspaces/frontend/config/cspell-ignore-words.txt
+++ b/workspaces/frontend/config/cspell-ignore-words.txt
@@ -21,3 +21,4 @@ tolerations
 podtemplate
 listvalues
 cuda
+rstudio

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindList.tsx
@@ -49,9 +49,17 @@ export const WorkspaceFormKindList: React.FunctionComponent<WorkspaceFormKindLis
   const { filterValues, setFilter, clearAllFilters } =
     useToolbarFilters<KindFilterKey>(filterConfig);
 
+  const sortedWorkspaceKinds = useMemo(
+    () =>
+      [...allWorkspaceKinds].sort(
+        (a, b) => a.displayName.localeCompare(b.displayName) || a.name.localeCompare(b.name),
+      ),
+    [allWorkspaceKinds],
+  );
+
   const filteredWorkspaceKinds = useMemo(
-    () => applyFilters(allWorkspaceKinds, filterValues, filterableProperties),
-    [allWorkspaceKinds, filterValues],
+    () => applyFilters(sortedWorkspaceKinds, filterValues, filterableProperties),
+    [sortedWorkspaceKinds, filterValues],
   );
 
   const onChange = useCallback(

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/__tests__/WorkspaceFormKindList.spec.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/__tests__/WorkspaceFormKindList.spec.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { buildMockWorkspaceKind } from '~/shared/mock/mockBuilder';
+import { WorkspaceFormKindList } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindList';
+
+// For this test, we're using mock WorkspaceKindImage, because image loading and API context are unrelated to the behavior we are testing.
+
+jest.mock('~/app/components/WorkspaceKindImage', () => ({
+  __esModule: true,
+  default: ({ children }: { children: (src: string) => React.ReactNode }) =>
+    children('mock-logo.svg'),
+}));
+
+describe('WorkspaceFormKindList', () => {
+  it('renders workspace kinds sorted by display name', () => {
+    const vscode = buildMockWorkspaceKind({
+      name: 'codeserver',
+      displayName: 'VS Code',
+    });
+
+    const jupyter = buildMockWorkspaceKind({
+      name: 'jupyterlab',
+      displayName: 'JupyterLab',
+    });
+
+    const rStudio = buildMockWorkspaceKind({
+      name: 'rstudio',
+      displayName: 'RStudio',
+    });
+
+    render(
+      <WorkspaceFormKindList
+        allWorkspaceKinds={[vscode, jupyter, rStudio]}
+        selectedKind={undefined}
+        onSelect={jest.fn()}
+        isSelectionDisabled={false}
+      />,
+    );
+
+    const cards = screen.getAllByTestId(/^kind-card-/);
+
+    // We aren't testing .sort() itself. We're testing the user-visible guarantee.
+
+    expect(cards.map((card) => card.getAttribute('data-testid'))).toEqual([
+      'kind-card-jupyterlab',
+      'kind-card-rstudio',
+      'kind-card-codeserver',
+    ]);
+  });
+
+  it('uses name as a tie-breaker when display names are equal', () => {
+    const second = buildMockWorkspaceKind({
+      name: 'jupyter-z',
+      displayName: 'JupyterLab',
+    });
+
+    const first = buildMockWorkspaceKind({
+      name: 'jupyter-a',
+      displayName: 'JupyterLab',
+    });
+
+    render(
+      <WorkspaceFormKindList
+        allWorkspaceKinds={[second, first]}
+        selectedKind={undefined}
+        onSelect={jest.fn()}
+        isSelectionDisabled={false}
+      />,
+    );
+
+    const cards = screen.getAllByTestId(/^kind-card-/);
+
+    expect(cards.map((card) => card.getAttribute('data-testid'))).toEqual([
+      'kind-card-jupyter-a',
+      'kind-card-jupyter-z',
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Sort WorkspaceKinds by `displayName` before rendering them in the Create Workspace form, using `name` as a deterministic tie-breaker.

## Why

The WorkspaceKinds API does not guarantee a presentation order, so the order of cards on the Create Workspace page could change between page refreshes.

The frontend owns presentation sorting for WorkspaceKinds, so the selection list should apply a deterministic default order before rendering.

## Testing

- Added unit coverage for ordering WorkspaceKinds by `displayName`
- Added coverage for deterministic ordering when display names are equal
- 454/454 Jest tests pass
- Create Workspace Cypress suite passes 73/73 tests
- Manually verified across repeated page refreshes that the UI consistently renders:
  - JupyterLab
  - RStudio
  - VS Code

  even when the WorkspaceKinds API returns the items in different orders

The full mocked Cypress run has one unrelated failure in `workspaces/secretsEdit.cy.ts`. The same failure is reproducible on a clean `origin/notebooks-v2` checkout.

## Related

related: #336
related: #1112

#336 documents the decision to keep paging, sorting, and filtering in the frontend.

#1112 separately tracks duplicate WorkspaceKind requests and is not addressed by this change.