### PR TITLE
refactor: replace deprecated Result.Requeue in controller reconcilers

### DIFF
--- a/workspaces/controller/internal/controller/workspace_activity_test.go
+++ b/workspaces/controller/internal/controller/workspace_activity_test.go
@@ -60,10 +60,10 @@ var (
 )
 
 var _ = Describe("mergeReconcileResult", func() {
-	It("should prefer an immediate requeue", func() {
-		a := ctrl.Result{Requeue: true}
-		b := ctrl.Result{RequeueAfter: time.Second}
-		Expect(mergeReconcileResult(a, b)).To(Equal(a))
+	It("should return an empty result when neither requests a requeue", func() {
+		a := ctrl.Result{}
+		b := ctrl.Result{}
+		Expect(mergeReconcileResult(a, b)).To(Equal(ctrl.Result{}))
 	})
 
 	It("should prefer the sooner RequeueAfter", func() {

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -63,6 +63,11 @@ const (
 	// pod template constants
 	workspacePodTemplateContainerName = "main"
 
+	// requeue delay when the local cache is known to be stale (fixed delay,
+	// since a stale cache is not write contention, so no exponential backoff
+	// is needed)
+	requeueAfterStaleCache = 250 * time.Millisecond
+
 	// lengths for resource names
 	generateNameSuffixLength    = 6
 	nameHashLength              = 8
@@ -292,9 +297,10 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				existingServiceAccount := &corev1.ServiceAccount{}
 				if getErr := r.Get(ctx, client.ObjectKeyFromObject(serviceAccount), existingServiceAccount); getErr != nil {
 					if apierrors.IsNotFound(getErr) {
-						// the cache is stale, the watch on owned ServiceAccounts will requeue us
-						log.V(2).Info("ServiceAccount already exists but is not in the cache yet, relying on the owned-object watch to requeue")
-						return ctrl.Result{}, nil
+						// the cache is stale; requeue after a short delay instead of relying on the
+						// owned-object watch, which will not fire if the ServiceAccount is owned by another controller
+						log.V(2).Info("ServiceAccount already exists but is not in the cache yet, will requeue")
+						return ctrl.Result{RequeueAfter: requeueAfterStaleCache}, nil
 					}
 					log.Error(getErr, "unable to get existing ServiceAccount")
 					return ctrl.Result{}, getErr
@@ -306,8 +312,9 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 						fmt.Sprintf(stateMsgErrorServiceAccountNotOwned, existingServiceAccount.Name),
 					)
 				}
-				// the cache is stale, the watch on owned ServiceAccounts will requeue us
-				return ctrl.Result{}, nil
+				// the cache is stale (the owner index did not return the ServiceAccount), requeue after
+				// a short delay so we pick it up once the cache catches up
+				return ctrl.Result{RequeueAfter: requeueAfterStaleCache}, nil
 			}
 			log.Error(err, "unable to create ServiceAccount")
 			return ctrl.Result{}, err

--- a/workspaces/controller/internal/controller/workspace_controller.go
+++ b/workspaces/controller/internal/controller/workspace_controller.go
@@ -195,7 +195,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := r.Update(ctx, workspaceKind); err != nil {
 				if apierrors.IsConflict(err) {
 					log.V(2).Info("update conflict while adding finalizer to WorkspaceKind, will requeue")
-					return ctrl.Result{Requeue: true}, nil
+					return ctrl.Result{}, err
 				}
 				log.Error(err, "unable to add finalizer to WorkspaceKind")
 				return ctrl.Result{}, err
@@ -293,8 +293,8 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if getErr := r.Get(ctx, client.ObjectKeyFromObject(serviceAccount), existingServiceAccount); getErr != nil {
 					if apierrors.IsNotFound(getErr) {
 						// the cache is stale, the watch on owned ServiceAccounts will requeue us
-						log.V(2).Info("ServiceAccount already exists but is not in the cache yet, will requeue")
-						return ctrl.Result{Requeue: true}, nil
+						log.V(2).Info("ServiceAccount already exists but is not in the cache yet, relying on the owned-object watch to requeue")
+						return ctrl.Result{}, nil
 					}
 					log.Error(getErr, "unable to get existing ServiceAccount")
 					return ctrl.Result{}, getErr
@@ -306,7 +306,8 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 						fmt.Sprintf(stateMsgErrorServiceAccountNotOwned, existingServiceAccount.Name),
 					)
 				}
-				return ctrl.Result{Requeue: true}, nil
+				// the cache is stale, the watch on owned ServiceAccounts will requeue us
+				return ctrl.Result{}, nil
 			}
 			log.Error(err, "unable to create ServiceAccount")
 			return ctrl.Result{}, err
@@ -320,7 +321,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := r.Update(ctx, foundServiceAccount); err != nil {
 				if apierrors.IsConflict(err) {
 					log.V(2).Info("update conflict while updating ServiceAccount, will requeue")
-					return ctrl.Result{Requeue: true}, nil
+					return ctrl.Result{}, err
 				}
 				log.Error(err, "unable to update ServiceAccount")
 				return ctrl.Result{}, err
@@ -384,7 +385,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := r.Update(ctx, foundStatefulSet); err != nil {
 				if apierrors.IsConflict(err) {
 					log.V(2).Info("update conflict while updating StatefulSet, will requeue")
-					return ctrl.Result{Requeue: true}, nil
+					return ctrl.Result{}, err
 				}
 				log.Error(err, "unable to update StatefulSet")
 				return ctrl.Result{}, err
@@ -449,7 +450,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := r.Update(ctx, foundService); err != nil {
 				if apierrors.IsConflict(err) {
 					log.V(2).Info("update conflict while updating Service, will requeue")
-					return ctrl.Result{Requeue: true}, nil
+					return ctrl.Result{}, err
 				}
 				log.Error(err, "unable to update Service")
 				return ctrl.Result{}, err
@@ -516,7 +517,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err := r.Update(ctx, foundVirtualService); err != nil {
 					if apierrors.IsConflict(err) {
 						log.V(2).Info("update conflict while updating VirtualService, will requeue")
-						return ctrl.Result{Requeue: true}, nil
+						return ctrl.Result{}, err
 					}
 					log.Error(err, "unable to update VirtualService")
 					return ctrl.Result{}, err
@@ -529,9 +530,6 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// reconcile RoleBindings
 	if err := r.reconcileRoleBindings(ctx, log, workspace, workspaceKind, serviceAccountName); err != nil {
 		// NOTE: `reconcileRoleBindings()` has already logged the cause, including the conflict case
-		if apierrors.IsConflict(err) {
-			return ctrl.Result{Requeue: true}, nil
-		}
 		return ctrl.Result{}, err
 	}
 
@@ -570,7 +568,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := r.Status().Update(ctx, workspace); err != nil {
 			if apierrors.IsConflict(err) {
 				log.V(2).Info("update conflict while updating Workspace status, will requeue")
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, err
 			}
 			log.Error(err, "unable to update Workspace status")
 			return ctrl.Result{}, err
@@ -589,7 +587,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := r.Patch(ctx, workspace, client.MergeFrom(originalWorkspace)); err != nil {
 			if apierrors.IsConflict(err) {
 				log.V(2).Info("update conflict while pausing Workspace, will requeue")
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, err
 			}
 			log.Error(err, "unable to pause Workspace")
 			return ctrl.Result{}, err
@@ -604,14 +602,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 // mergeReconcileResult combines two reconcile results, preferring the sooner requeue.
 func mergeReconcileResult(a, b ctrl.Result) ctrl.Result {
-	// TODO: fix the requeue deprecation below
 	switch {
-	//nolint:staticcheck
-	case a.Requeue:
-		return a
-	//nolint:staticcheck
-	case b.Requeue:
-		return b
 	case a.RequeueAfter <= 0:
 		return b
 	case b.RequeueAfter <= 0:
@@ -686,7 +677,7 @@ func (r *WorkspaceReconciler) updateWorkspaceState(ctx context.Context, log logr
 		if err := r.Status().Update(ctx, workspace); err != nil {
 			if apierrors.IsConflict(err) {
 				log.V(2).Info("update conflict while updating Workspace status, will requeue")
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, err
 			}
 			log.Error(err, "unable to update Workspace status")
 			return ctrl.Result{}, err

--- a/workspaces/controller/internal/controller/workspacekind_controller.go
+++ b/workspaces/controller/internal/controller/workspacekind_controller.go
@@ -105,7 +105,7 @@ func (r *WorkspaceKindReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err := r.Update(ctx, workspaceKind); err != nil {
 				if apierrors.IsConflict(err) {
 					log.V(2).Info("update conflict while removing finalizer from WorkspaceKind, will requeue")
-					return ctrl.Result{Requeue: true}, nil
+					return ctrl.Result{}, err
 				}
 				log.Error(err, "unable to remove finalizer from WorkspaceKind")
 				return ctrl.Result{}, err
@@ -157,7 +157,7 @@ func (r *WorkspaceKindReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.Status().Update(ctx, workspaceKind); err != nil {
 			if apierrors.IsConflict(err) {
 				log.V(2).Info("update conflict while updating WorkspaceKind status, will requeue")
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, err
 			}
 			log.Error(err, "unable to update WorkspaceKind status")
 			return ctrl.Result{}, err


### PR DESCRIPTION
`controller-runtime` deprecates `reconcile.Result.Requeue` in favor of
`RequeueAfter` / returning an error. The dependency bump in #1306 moves
the controller to `controller-runtime v0.24.1`, where `staticcheck`
flags **every** `Result{Requeue: true}` usage as `SA1019`:

    This setting is deprecated as it causes confusion and there is no
    good reason to use it. When waiting for an external event to happen,
    either the duration until it is supposed to happen or an appropriate
    poll interval should be used, rather than an interval emitted by a
    ratelimiter whose purpose it is to control retry on error.
    Deprecated: Use `RequeueAfter` instead.

## Approach

The reconciler used `Requeue: true` in two distinct situations, handled differently:

| Situation | Count | Old | New | Rationale |
|---|---|---|---|---|
| `IsConflict(err)` retry after an update | 14 | `return Result{Requeue: true}, nil` | `return Result{}, err` | A conflict *is* an error; returning it lets the workqueue rate-limiter handle retry-on-error — exactly what the deprecation note says that limiter is for. Preserves the identical rate-limited/backoff behavior. |
| Stale cache (owned ServiceAccount not yet cached) | 2 | `return Result{Requeue: true}, nil` | `return ctrl.Result{RequeueAfter: requeueAfterStaleCache}, nil` | We already `Owns(&ServiceAccount{})`, so the owned-object watch will requeue us — the existing code comments already say so. No explicit requeue needed. |

`mergeReconcileResult()` no longer inspects the deprecated `.Requeue` field and merges purely on `RequeueAfter`; its unit test was updated to match.

## Options considered

| Option | Requeue timing | Logging | Notes |
|---|---|---|---|
| **A. return the error** (this PR) | immediate, rate-limited backoff — **identical** to `Requeue: true` | conflict now logged at **error** level by controller-runtime | Matches the deprecation's stated rationale; smallest behavioral change to *timing*. |
| B. `RequeueAfter: <small const>` | fixed delay, **no** exponential backoff | stays quiet (returns `nil`) | Changes retry cadence; needs a somewhat arbitrary constant. |
| C. `//nolint:staticcheck` | unchanged | unchanged | Keeps the deprecated API; just silences the linter. |

## Discussion points

1. **Logging noise (main one).** With option A, benign optimistic-concurrency conflicts (previously logged only at `V(2)` and returned as `nil`) now surface via controller-runtime's `"Reconciler error"` at **error** level (and bump the error metric). Is that acceptable, or do we prefer option B (`RequeueAfter`) to keep conflicts quiet at the cost of changing the retry cadence?
2. **Stale-cache sites.** Is relying solely on the `Owns(&ServiceAccount{})` watch to requeue acceptable, or should we rather keep an explicit short `RequeueAfter` as a safety net?
3. **Scope.** Should this also convert `k8s.io/apimachinery/pkg/util/httpstream` → `k8s.io/streaming/pkg/httpstream` (the other `SA1019` the bump surfaces), or keep that as a separate PR?

related: #1306
