### PR TITLE
fix: add trailing slash to hardcoded kubeflow `BASE_PATH` in webpack config

### DIFF
--- a/workspaces/frontend/config/webpack.common.js
+++ b/workspaces/frontend/config/webpack.common.js
@@ -18,7 +18,7 @@ const FAVICON = process.env.FAVICON;
 const PRODUCT_NAME = process.env.PRODUCT_NAME;
 const COVERAGE = process.env.COVERAGE;
 const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
-const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
+const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces/' : PUBLIC_PATH;
 
 if (OUTPUT_ONLY !== 'true') {
   console.info(

--- a/workspaces/frontend/config/webpack.dev.js
+++ b/workspaces/frontend/config/webpack.dev.js
@@ -26,7 +26,7 @@ const PROXY_HOST = process.env._PROXY_HOST;
 const PROXY_PORT = process.env._PROXY_PORT;
 const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
-const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
+const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces/' : PUBLIC_PATH;
 
 // Function to generate headers based on deployment mode
 const getProxyHeaders = () => {


### PR DESCRIPTION
## Summary

In production/Kubeflow-mode builds of `workspaces/frontend`, opening a route that requires a lazily-loaded webpack chunk (e.g. the Workspace details view) fails with a `ChunkLoadError`. The browser requests a malformed URL like `/workspaces449.bundle.js` instead of `/workspaces/449.bundle.js`, which doesn't match this frontend's Istio `VirtualService` prefix match (`prefix: /workspaces/`) and therefore never reaches the app's own nginx.

**Root cause:** `config/webpack.common.js` and `config/webpack.dev.js` hardcode `BASE_PATH` to the literal `'/workspaces'` (no trailing slash) whenever `DEPLOYMENT_MODE === 'kubeflow'`:

```js
const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
```

This value becomes webpack's runtime `publicPath` (`__webpack_require__.p`), which webpack's dynamic `import()` runtime uses via **raw string concatenation** with the chunk filename — it does not insert a `/` separator, since `publicPath` is expected to already end in one. So a chunk file `449.bundle.js` gets requested as `'/workspaces' + '449.bundle.js'` = `/workspaces449.bundle.js`.

The entry bundle (`app.bundle.js`) is unaffected because `html-webpack-plugin` normalizes `publicPath` itself when injecting the `<script>` tag and `<base href>` into `index.html` — only *dynamically imported* chunks go through the raw webpack runtime and hit the bug. This is also why it's easy to miss in local dev: `.env.tilt` sets `DEPLOYMENT_MODE=standalone` and `PUBLIC_PATH=/workspaces/` (with a trailing slash already), which takes the other branch of the ternary and never triggers the bug.

## Fix

Add the missing trailing slash to the hardcoded `kubeflow`-mode literal in both files, matching what `PUBLIC_PATH=/workspaces/` already does correctly for the non-`kubeflow` branch:

```diff
- const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
+ const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces/' : PUBLIC_PATH;
```

## Verification

- Ran `npm run build:prod` and confirmed the built `app.bundle.js` now embeds `__webpack_require__.p="/workspaces/"` (previously `"/workspaces"`), so lazily-loaded chunks now resolve to `/workspaces/<id>.bundle.js`.
- Confirmed `dist/index.html`'s `<base href>` and `<script src>` are unaffected (still correctly `/workspaces/...`) — only the runtime chunk-loading path was wrong before this change.
- `npm run test:lint` passes.
- Reproduced the original bug against a live Kubeflow Community distribution deployment (KIND cluster) before the fix: opening a Workspace's details panel threw `ChunkLoadError: Loading chunk 449 failed. (missing: http://<host>/workspaces449.bundle.js)` in the browser console, with the network request returning a non-2xx response since it doesn't match this service's Istio route.

## Test plan

- [x] `npm run build:prod` succeeds and the emitted `app.bundle.js` has `publicPath` = `/workspaces/`
- [x] `npm run test:lint` passes
- [x] Deploy to a cluster running the Kubeflow Community distribution manifests, open Notebooks v2 → Workspaces → click into a workspace's details panel, confirm no `ChunkLoadError` and the details panel renders (reviewer/CI verification)

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
