### PR TITLE
fix: restore Connect button outline in MUI theme

### DIFF
--- a/workspaces/frontend/src/app/app.css
+++ b/workspaces/frontend/src/app/app.css
@@ -252,6 +252,33 @@ body,
   margin-left: 0;
 }
 
+/* Preserve secondary MenuToggle styling when using the Kubeflow MUI theme. */
+.mui-theme .kubeflow-connect-toggle.pf-m-secondary {
+  --pf-v6-c-menu-toggle--BackgroundColor: var(--pf-v6-c-menu-toggle--m-secondary--BackgroundColor);
+  --pf-v6-c-menu-toggle--PaddingInlineStart: var(
+    --pf-v6-c-menu-toggle--m-secondary--PaddingInlineStart
+  );
+  --pf-v6-c-menu-toggle--PaddingInlineEnd: var(
+    --pf-v6-c-menu-toggle--m-secondary--PaddingInlineEnd
+  );
+  --pf-v6-c-menu-toggle--BorderColor: var(--pf-v6-c-menu-toggle--m-secondary--BorderColor);
+  --pf-v6-c-menu-toggle--hover--BorderColor: var(
+    --pf-v6-c-menu-toggle--m-secondary--hover--BorderColor
+  );
+  --pf-v6-c-menu-toggle--expanded--BorderColor: var(
+    --pf-v6-c-menu-toggle--m-secondary--expanded--BorderColor
+  );
+}
+
+/* Preserve plain MenuToggle styling for workspace row actions when using the Kubeflow MUI theme. */
+.mui-theme .kubeflow-workspace-actions-cell .pf-v6-c-menu-toggle.pf-m-plain {
+  --pf-v6-c-menu-toggle--BackgroundColor: var(--pf-v6-c-menu-toggle--m-plain--BackgroundColor);
+  --pf-v6-c-menu-toggle--PaddingInlineStart: var(
+    --pf-v6-c-menu-toggle--m-plain--PaddingInlineStart
+  );
+  --pf-v6-c-menu-toggle--PaddingInlineEnd: var(--pf-v6-c-menu-toggle--m-plain--PaddingInlineEnd);
+}
+
 /* Single-endpoint "Connect" control: rendered as a MenuToggle (so it keeps the
    same size as the multi-endpoint dropdown), but its caret is rotated to point
    right to signal that clicking connects directly instead of opening a menu. */

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -428,7 +428,12 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
 
                           if (columnKey === 'actions') {
                             return (
-                              <Td isActionCell key="actions" data-testid="action-column">
+                              <Td
+                                isActionCell
+                                key="actions"
+                                data-testid="action-column"
+                                className="kubeflow-workspace-actions-cell"
+                              >
                                 <ActionsColumn
                                   items={rowActions(workspace).map((action) => ({
                                     ...action,

--- a/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/WorkspaceConnectAction.tsx
@@ -56,7 +56,7 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
     return (
       <MenuToggle
         variant="secondary"
-        className="kubeflow-connect-toggle--direct"
+        className="kubeflow-connect-toggle kubeflow-connect-toggle--direct"
         isDisabled={isDisabled}
         onClick={() => openEndpoint(connectableServices[0].httpPath)}
         aria-label="Connect to workspace"
@@ -75,6 +75,7 @@ export const WorkspaceConnectAction: React.FunctionComponent<WorkspaceConnectAct
         <MenuToggle
           ref={toggleRef}
           variant="secondary"
+          className="kubeflow-connect-toggle"
           onClick={onToggleClick}
           isExpanded={open}
           isDisabled={isDisabled}


### PR DESCRIPTION
## What

Fixes the Workspaces action controls rendering differently when Notebooks v2 is embedded in the Kubeflow Community Dashboard.

Closes #1345

## Root cause

The Connect and row-action controls use PatternFly `MenuToggle` variants.

When comparing the same UI at the same viewport in standalone Notebooks v2 and Community Dashboard, the variant-specific PatternFly tokens were already correct in both environments.

The difference was in which CSS declarations won the cascade:

- standalone: the PatternFly variant mappings win
- Community Dashboard: generic `mod-arch-kubeflow` / MUI compatibility mappings win

For the secondary Connect toggle this changed the final border, background, and horizontal padding.

For the plain row-actions toggle this changed the background and horizontal padding.

### Before

<img width="2880" height="1248" alt="localhost-_-workspaces-workspaces_Before" src="https://github.com/user-attachments/assets/7bed17e5-908b-46a4-8a5f-f628596d15e3" />


## Fix

- Add a common class to both Connect variants.
- Restore the existing PatternFly secondary semantic mappings for the Connect control.
- Scope the workspace row-actions toggle through its action cell and restore its existing PatternFly plain mappings.
- Reuse PatternFly theme variables rather than hard-coding colors, spacing, or dimensions.

The overrides remain scoped to the affected Workspaces controls.

### After

<img width="2880" height="1248" alt="localhost-_-workspaces-workspaces_After" src="https://github.com/user-attachments/assets/771950d4-1179-414d-970d-92bf6d266ee6" />


## Verification

Compared the same Workspace at a 1111px viewport in:

- standalone Notebooks v2 / Tilt
- Community Distribution baseline
- Community Distribution with this PR

Before, Community resolved:

- Connect border: `transparent`
- Connect padding: `10px`
- Connect background: `#fff`
- row-actions background: `#fff`
- row-actions padding: `10px`

After the fix, the Community controls match the standalone variant semantics:

- Connect width: `134.953125px`
- Connect height: `37px`
- Connect padding: `24px / 24px`
- Connect background: transparent
- Connect border: `#1976d2`
- row-actions: `37px × 37px`
- row-actions padding: `8px / 8px`
- row-actions background: transparent

Hover/focus behavior was also verified.

Checks:

- `npm run prettier:check`
- `npm run test:lint`
- `npm run test:type-check`
- `npm run test:unit` — 452 tests passed
- `npm run build`