### PR TITLE
feat: stream live Workspace updates to the dashboard via SSE

### DIFF
--- a/workspaces/backend/api/app.go
+++ b/workspaces/backend/api/app.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/repositories"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/streaming"
 	_ "github.com/kubeflow/notebooks/workspaces/backend/openapi"
 )
 
@@ -44,6 +45,9 @@ type App struct {
 	StrictYamlSerializer runtime.Serializer
 	RequestAuthN         authenticator.Request
 	RequestAuthZ         authorizer.Authorizer
+	// Hub broadcasts resource-change notifications to long-lived stream handlers
+	// (e.g. the workspaces Server-Sent Events endpoint).
+	Hub *streaming.Hub
 }
 
 // NewApp creates a new instance of the app.
@@ -57,6 +61,7 @@ func NewApp(
 	reqAuthN authenticator.Request,
 	reqAuthZ authorizer.Authorizer,
 	clientset kubernetes.Interface,
+	hub *streaming.Hub,
 ) (*App, error) {
 
 	// TODO: log the configuration on startup
@@ -76,6 +81,7 @@ func NewApp(
 		StrictYamlSerializer: yamlSerializerInfo.StrictSerializer,
 		RequestAuthN:         reqAuthN,
 		RequestAuthZ:         reqAuthZ,
+		Hub:                  hub,
 	}
 	return app, nil
 }
@@ -134,7 +140,17 @@ func (a *App) Routes() http.Handler {
 		router.GET(constants.SwaggerPath, a.GetSwaggerHandler)
 	}
 
-	handler := gzhttp.GzipHandler(router)
+	// Wrap with gzip compression, but never compress Server-Sent Events
+	// (text/event-stream): gzhttp buffers to decide whether to compress, which
+	// would break the incremental flushing that SSE relies on.
+	gzipWrapper, err := gzhttp.NewWrapper(gzhttp.ExceptContentTypes([]string{constants.MediaTypeEventStream}))
+	if err != nil {
+		// Should never happen with a static content-type list; fall back to the
+		// default gzip handler rather than serving uncompressed responses.
+		a.logger.Error("failed to build gzip wrapper, falling back to default", "error", err)
+		gzipWrapper = gzhttp.GzipHandler
+	}
+	handler := gzipWrapper(router)
 
 	return a.recoverPanic(a.enableCORS(handler))
 }

--- a/workspaces/backend/api/constants/media_types.go
+++ b/workspaces/backend/api/constants/media_types.go
@@ -15,7 +15,8 @@
 package constants
 
 const (
-	MediaTypeJson = "application/json"
-	MediaTypeYaml = "application/yaml"
-	MediaTypeSVG  = "image/svg+xml"
+	MediaTypeJson        = "application/json"
+	MediaTypeYaml        = "application/yaml"
+	MediaTypeSVG         = "image/svg+xml"
+	MediaTypeEventStream = "text/event-stream"
 )

--- a/workspaces/backend/api/suite_test.go
+++ b/workspaces/backend/api/suite_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/streaming"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -155,7 +156,7 @@ var _ = BeforeSuite(func() {
 
 	By("creating the application")
 	// NOTE: we use the `k8sClient` rather than `k8sManager.GetClient()` to avoid race conditions with the cached client
-	a, err = NewApp(&config.EnvConfig{}, appLogger, k8sClient, imageSourceConfigMapClient, k8sManager.GetScheme(), reqAuthN, reqAuthZ, clientset)
+	a, err = NewApp(&config.EnvConfig{}, appLogger, k8sClient, imageSourceConfigMapClient, k8sManager.GetScheme(), reqAuthN, reqAuthZ, clientset, streaming.NewHub())
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/workspaces/backend/api/workspaces_handler.go
+++ b/workspaces/backend/api/workspaces_handler.go
@@ -151,6 +151,13 @@ func (a *App) getWorkspacesHandler(w http.ResponseWriter, r *http.Request, ps ht
 	}
 	// ============================================================
 
+	// If the client requested a watch, upgrade to a Server-Sent Events stream
+	// that pushes a fresh snapshot on every change instead of a one-shot list.
+	if isWatchRequest(r) {
+		a.streamWorkspaces(w, r, namespace)
+		return
+	}
+
 	var workspaces []models.WorkspaceListItem
 	var err error
 	if namespace == "" {

--- a/workspaces/backend/api/workspaces_stream_handler.go
+++ b/workspaces/backend/api/workspaces_stream_handler.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
+	models "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspaces"
+)
+
+const (
+	// streamHeartbeatInterval is how often a comment "ping" is sent on an idle
+	// stream to keep the connection alive through proxies/gateways.
+	streamHeartbeatInterval = 20 * time.Second
+
+	// streamDebounceInterval coalesces bursts of change notifications into a
+	// single re-list, so a flurry of updates produces at most one snapshot per
+	// interval instead of one per event.
+	streamDebounceInterval = 250 * time.Millisecond
+)
+
+// isWatchRequest reports whether the request asked for a streaming watch via the
+// `watch` query parameter (mirroring the Kubernetes API's `?watch=1`/`?watch=true`).
+func isWatchRequest(r *http.Request) bool {
+	switch r.URL.Query().Get("watch") {
+	case "true", "1":
+		return true
+	default:
+		return false
+	}
+}
+
+// streamWorkspaces serves the workspace list as a Server-Sent Events stream. It
+// emits an initial full-list snapshot, then a fresh snapshot whenever a Workspace
+// in the requested namespace (or any namespace, when namespace is empty) changes.
+// The caller is responsible for having already authenticated and authorized the
+// request; authorization is evaluated once, at connection time.
+func (a *App) streamWorkspaces(w http.ResponseWriter, r *http.Request, namespace string) {
+	ctx := r.Context()
+
+	// Set Server-Sent Events headers before the first write so downstream
+	// wrappers (e.g. gzip) see the content type and skip buffering/compression.
+	header := w.Header()
+	header.Set("Content-Type", constants.MediaTypeEventStream)
+	header.Set("Cache-Control", "no-cache")
+	header.Set("Connection", "keep-alive")
+	// Hint to reverse proxies (nginx/Envoy) not to buffer the response.
+	header.Set("X-Accel-Buffering", "no")
+
+	rc := http.NewResponseController(w)
+	// Clear the server's WriteTimeout for this connection only; a long-lived
+	// stream must not be torn down by the global deadline.
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		a.logger.Warn("failed to clear write deadline for workspace stream", "error", err)
+	}
+
+	// Subscribe before sending the initial snapshot so no change that occurs
+	// between listing and subscribing is missed.
+	notifyCh, unsubscribe := a.Hub.Subscribe(namespace)
+	defer unsubscribe()
+
+	// Send the initial snapshot immediately.
+	if !a.writeWorkspacesSnapshot(w, rc, r, namespace) {
+		return
+	}
+
+	heartbeat := time.NewTicker(streamHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	// debounce is lazily created on the first notification of a burst; while it
+	// is running, further notifications are absorbed and collapse into one
+	// re-list when it fires.
+	var debounce *time.Timer
+	var debounceCh <-chan time.Time
+	stopDebounce := func() {
+		if debounce != nil {
+			debounce.Stop()
+			debounce = nil
+			debounceCh = nil
+		}
+	}
+	defer stopDebounce()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-notifyCh:
+			if debounce == nil {
+				debounce = time.NewTimer(streamDebounceInterval)
+				debounceCh = debounce.C
+			}
+
+		case <-debounceCh:
+			debounce = nil
+			debounceCh = nil
+			if !a.writeWorkspacesSnapshot(w, rc, r, namespace) {
+				return
+			}
+
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			if err := rc.Flush(); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// writeWorkspacesSnapshot lists the current workspaces (from the same cache-backed
+// client the non-streaming handler uses) and writes them as a single SSE `data:`
+// event. It returns false if the client is gone or an unrecoverable error
+// occurred, signaling the caller to close the stream.
+func (a *App) writeWorkspacesSnapshot(w http.ResponseWriter, rc *http.ResponseController, r *http.Request, namespace string) bool {
+	var workspaces []models.WorkspaceListItem
+	var err error
+	if namespace == "" {
+		workspaces, err = a.repositories.Workspace.GetAllWorkspaces(r.Context())
+	} else {
+		workspaces, err = a.repositories.Workspace.GetWorkspaces(r.Context(), namespace)
+	}
+	if err != nil {
+		a.logger.Error("failed to list workspaces for stream", "namespace", namespace, "error", err)
+		// Best-effort notify the client of the error, then end the stream.
+		_, _ = fmt.Fprint(w, "event: error\ndata: failed to list workspaces\n\n")
+		_ = rc.Flush()
+		return false
+	}
+
+	// json.Marshal produces no raw newlines, so the payload is a single SSE line.
+	payload, err := json.Marshal(&WorkspaceListEnvelope{Data: workspaces})
+	if err != nil {
+		a.logger.Error("failed to marshal workspaces for stream", "error", err)
+		return false
+	}
+
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+		return false
+	}
+	if err := rc.Flush(); err != nil {
+		return false
+	}
+	return true
+}

--- a/workspaces/backend/cmd/main.go
+++ b/workspaces/backend/cmd/main.go
@@ -22,14 +22,19 @@ import (
 	"os"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 
 	application "github.com/kubeflow/notebooks/workspaces/backend/api"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/auth"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/server"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/streaming"
 	"github.com/kubeflow/notebooks/workspaces/backend/openapi"
 )
 
@@ -155,6 +160,28 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Set up the signal-aware root context, used both to register the informer
+	// event handler below and to run the manager.
+	ctx := ctrl.SetupSignalHandler()
+
+	// Create the change broadcaster and wire it to the Workspace informer so
+	// that Server-Sent Events stream handlers are notified whenever a Workspace
+	// is added, updated, or deleted.
+	hub := streaming.NewHub()
+	workspaceInformer, err := mgr.GetCache().GetInformer(ctx, &kubefloworgv1beta1.Workspace{})
+	if err != nil {
+		logger.Error("failed to get Workspace informer", "error", err)
+		os.Exit(1)
+	}
+	if _, err := workspaceInformer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { hub.Publish(objectNamespace(obj)) },
+		UpdateFunc: func(_, obj any) { hub.Publish(objectNamespace(obj)) },
+		DeleteFunc: func(obj any) { hub.Publish(objectNamespace(obj)) },
+	}); err != nil {
+		logger.Error("failed to register Workspace event handler", "error", err)
+		os.Exit(1)
+	}
+
 	clientset, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		logger.Error("failed to create Kubernetes clientset", "error", err)
@@ -193,6 +220,7 @@ func main() {
 		reqAuthN,
 		reqAuthZ,
 		clientset,
+		hub,
 	)
 	if err != nil {
 		logger.Error("failed to create app", "error", err)
@@ -210,10 +238,25 @@ func main() {
 
 	// Start the controller manager
 	logger.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		logger.Error("problem running manager", "error", err)
 		os.Exit(1)
 	}
+}
+
+// objectNamespace extracts the namespace of an informer event object, unwrapping
+// cache tombstones (DeletedFinalStateUnknown) for delete events. It returns an
+// empty string if the namespace cannot be determined, which still notifies
+// all-namespaces subscribers.
+func objectNamespace(obj any) string {
+	if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return ""
+	}
+	return accessor.GetNamespace()
 }
 
 func getEnvAsInt(name string, defaultVal int) int {

--- a/workspaces/backend/internal/streaming/hub.go
+++ b/workspaces/backend/internal/streaming/hub.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package streaming provides an in-process publish/subscribe broadcaster used to
+// notify long-lived HTTP handlers (e.g. Server-Sent Events streams) that a
+// watched resource has changed, so they can re-read and push a fresh snapshot.
+package streaming
+
+import "sync"
+
+// AllNamespaces is the namespace filter that matches change notifications from
+// every namespace. A subscriber using it receives all published events, which is
+// what a cluster-wide (all-namespaces) listing needs.
+const AllNamespaces = ""
+
+// subscriberChanBuffer is the buffer size of each subscriber's notification
+// channel. Notifications are coalescing signals rather than a lossless event
+// log, so a small buffer is enough: if a subscriber is slower than the publish
+// rate, additional notifications are dropped (see Hub.Publish) because a single
+// pending signal already tells the subscriber it must re-read the current state.
+const subscriberChanBuffer = 1
+
+// subscriber is a single registered listener with its namespace filter.
+type subscriber struct {
+	// namespace is the namespace the subscriber cares about, or AllNamespaces to
+	// receive notifications from every namespace.
+	namespace string
+	// ch receives a signal (an empty struct) whenever a matching change is
+	// published. It is buffered and never blocks the publisher.
+	ch chan struct{}
+}
+
+// Hub is a concurrency-safe, in-process fan-out broadcaster. Producers call
+// Publish with the namespace of a changed object; each subscriber whose filter
+// matches receives a coalescing signal on its channel.
+//
+// The zero value is not usable; construct a Hub with NewHub.
+type Hub struct {
+	mu   sync.Mutex
+	subs map[*subscriber]struct{}
+}
+
+// NewHub creates an empty Hub ready for use.
+func NewHub() *Hub {
+	return &Hub{
+		subs: make(map[*subscriber]struct{}),
+	}
+}
+
+// Subscribe registers a listener for changes in the given namespace (or
+// AllNamespaces for every namespace). It returns a receive-only channel that is
+// signaled on each matching change, and an unsubscribe function that removes the
+// subscription and closes the channel. The unsubscribe function is idempotent and
+// must be called (e.g. via defer) when the subscriber is done to avoid leaks.
+func (h *Hub) Subscribe(namespace string) (<-chan struct{}, func()) {
+	sub := &subscriber{
+		namespace: namespace,
+		ch:        make(chan struct{}, subscriberChanBuffer),
+	}
+
+	h.mu.Lock()
+	h.subs[sub] = struct{}{}
+	h.mu.Unlock()
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			h.mu.Lock()
+			delete(h.subs, sub)
+			h.mu.Unlock()
+			close(sub.ch)
+		})
+	}
+
+	return sub.ch, unsubscribe
+}
+
+// Publish notifies every subscriber whose filter matches namespace that a change
+// occurred. A subscriber matches when it registered for AllNamespaces or for this
+// exact namespace. Delivery is non-blocking: if a subscriber's buffer is already
+// full, the signal is dropped, since a pending signal already tells that
+// subscriber to re-read current state.
+func (h *Hub) Publish(namespace string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for sub := range h.subs {
+		if sub.namespace != AllNamespaces && sub.namespace != namespace {
+			continue
+		}
+		select {
+		case sub.ch <- struct{}{}:
+		default:
+			// Buffer full: an unconsumed signal is already pending, which is
+			// sufficient because signals are coalescing.
+		}
+	}
+}

--- a/workspaces/backend/internal/streaming/hub_test.go
+++ b/workspaces/backend/internal/streaming/hub_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"sync"
+	"testing"
+)
+
+// received reports whether a signal is currently pending on ch without blocking.
+func received(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestHub_PublishDeliversToMatchingSubscriber(t *testing.T) {
+	h := NewHub()
+	ch, unsubscribe := h.Subscribe("team-a")
+	defer unsubscribe()
+
+	h.Publish("team-a")
+
+	if !received(ch) {
+		t.Fatal("expected subscriber to receive a signal for its namespace")
+	}
+}
+
+func TestHub_PublishFiltersByNamespace(t *testing.T) {
+	h := NewHub()
+	ch, unsubscribe := h.Subscribe("team-a")
+	defer unsubscribe()
+
+	h.Publish("team-b")
+
+	if received(ch) {
+		t.Fatal("subscriber for team-a should not receive a team-b notification")
+	}
+}
+
+func TestHub_AllNamespacesReceivesEverything(t *testing.T) {
+	h := NewHub()
+	ch, unsubscribe := h.Subscribe(AllNamespaces)
+	defer unsubscribe()
+
+	h.Publish("any-namespace")
+
+	if !received(ch) {
+		t.Fatal("AllNamespaces subscriber should receive notifications from any namespace")
+	}
+}
+
+func TestHub_UnsubscribeStopsDelivery(t *testing.T) {
+	h := NewHub()
+	ch, unsubscribe := h.Subscribe("team-a")
+
+	unsubscribe()
+
+	// Publishing after unsubscribe must not panic (channel is closed) and must
+	// not deliver. A closed channel would yield a zero value from received; the
+	// key assertion is that Publish does not send on it, which it can't since the
+	// subscriber was removed from the hub before the channel was closed.
+	h.Publish("team-a")
+
+	// Draining a closed, empty channel returns immediately with the zero value.
+	if _, ok := <-ch; ok {
+		t.Fatal("expected no buffered signal on the channel after unsubscribe")
+	}
+}
+
+func TestHub_UnsubscribeIsIdempotent(t *testing.T) {
+	h := NewHub()
+	_, unsubscribe := h.Subscribe("team-a")
+
+	unsubscribe()
+	// A second call must be a no-op and must not panic (e.g. double close).
+	unsubscribe()
+}
+
+func TestHub_PublishDoesNotBlockOnFullBuffer(t *testing.T) {
+	h := NewHub()
+	ch, unsubscribe := h.Subscribe("team-a")
+	defer unsubscribe()
+
+	// Publish more times than the buffer holds; coalescing means excess signals
+	// are dropped rather than blocking the publisher.
+	for range 100 {
+		h.Publish("team-a")
+	}
+
+	if !received(ch) {
+		t.Fatal("expected at least one pending signal after repeated publishes")
+	}
+	// After draining the single buffered signal, no more should remain.
+	if received(ch) {
+		t.Fatal("expected coalesced signals to collapse to a single pending signal")
+	}
+}
+
+func TestHub_ConcurrentPublishAndSubscribe(t *testing.T) {
+	h := NewHub()
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			ch, unsubscribe := h.Subscribe("team-a")
+			defer unsubscribe()
+			h.Publish("team-a")
+			_ = received(ch)
+		})
+	}
+	wg.Wait()
+}

--- a/workspaces/frontend/package-lock.json
+++ b/workspaces/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@monaco-editor/react": "^4.7.0",
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-catalog-view-extension": "^6.2.0",
@@ -6492,6 +6493,12 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "license": "MIT"
     },
     "node_modules/@modern-js/node-bundle-require": {

--- a/workspaces/frontend/package.json
+++ b/workspaces/frontend/package.json
@@ -118,6 +118,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@monaco-editor/react": "^4.7.0",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-catalog-view-extension": "^6.2.0",

--- a/workspaces/frontend/src/app/components/LiveStatusIndicator.tsx
+++ b/workspaces/frontend/src/app/components/LiveStatusIndicator.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Content, ContentVariants } from '@patternfly/react-core/dist/esm/components/Content';
+import { Icon } from '@patternfly/react-core/dist/esm/components/Icon';
+import { RedoIcon } from '@patternfly/react-icons/dist/esm/icons/redo-icon';
+import { CircleIcon } from '@patternfly/react-icons/dist/esm/icons/circle-icon';
+import { StreamConnectionStatus } from '~/app/hooks/useWorkspacesLive';
+
+interface LiveStatusIndicatorProps {
+  status: StreamConnectionStatus;
+  onRefresh: () => void;
+}
+
+const STATUS_META: Record<
+  StreamConnectionStatus,
+  { label: string; color: React.ComponentProps<typeof Icon>['status'] }
+> = {
+  connecting: { label: 'Connecting…', color: undefined },
+  live: { label: 'Live', color: 'success' },
+  reconnecting: { label: 'Reconnecting…', color: 'warning' },
+  error: { label: 'Disconnected', color: 'danger' },
+};
+
+// LiveStatusIndicator shows the Server-Sent Events connection state for the
+// workspaces table, plus a manual refresh (reconnect) control. It replaces the
+// countdown-based RefreshCounter when the table is in live-streaming mode.
+export const LiveStatusIndicator: React.FC<LiveStatusIndicatorProps> = ({ status, onRefresh }) => {
+  const { label, color } = STATUS_META[status];
+
+  return (
+    <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>
+        <Button
+          variant="link"
+          onClick={onRefresh}
+          data-testid="workspace-refresh-now"
+          aria-label="Refresh"
+        >
+          <RedoIcon />
+        </Button>
+      </FlexItem>
+      <FlexItem>
+        <Icon size="sm" status={color}>
+          <CircleIcon />
+        </Icon>
+      </FlexItem>
+      <FlexItem>
+        <Content
+          component={ContentVariants.small}
+          style={{
+            fontStyle: 'italic',
+            color: 'var(--pf-t--global--icon--color--subtle)',
+          }}
+          data-testid="workspace-live-status"
+          aria-live="polite"
+        >
+          {label}
+        </Content>
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/workspaces/frontend/src/app/components/WorkspaceTable.tsx
+++ b/workspaces/frontend/src/app/components/WorkspaceTable.tsx
@@ -55,6 +55,8 @@ import {
 import { RedirectIconWithPopover } from '~/app/components/RedirectIconWithPopover';
 import { POLL_INTERVAL } from '~/shared/utilities/const';
 import { RefreshCounter } from '~/app/components/RefreshCounter';
+import { LiveStatusIndicator } from '~/app/components/LiveStatusIndicator';
+import { StreamConnectionStatus } from '~/app/hooks/useWorkspacesLive';
 import ToolbarFilter, {
   FilterConfigMap,
   FilterValue,
@@ -90,6 +92,11 @@ interface WorkspaceTableProps {
   canCreateWorkspaces?: boolean;
   hiddenColumns?: WorkspaceTableColumnKeys[];
   rowActions?: (workspace: WorkspacesWorkspaceListItem) => IActions;
+  /**
+   * When provided, the table is in live-streaming mode and shows a connection
+   * indicator; when omitted, it shows the interval-polling refresh countdown.
+   */
+  connectionStatus?: StreamConnectionStatus;
 }
 
 const filterConfig = {
@@ -157,6 +164,7 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
       canCreateWorkspaces = true,
       hiddenColumns = [],
       rowActions = () => [],
+      connectionStatus,
     },
     ref,
   ) => {
@@ -590,7 +598,11 @@ const WorkspaceTable = React.forwardRef<WorkspaceTableRef, WorkspaceTableProps>(
         </div>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
           <FlexItem>
-            <RefreshCounter interval={POLL_INTERVAL} onRefresh={refreshWorkspaces} />
+            {connectionStatus ? (
+              <LiveStatusIndicator status={connectionStatus} onRefresh={refreshWorkspaces} />
+            ) : (
+              <RefreshCounter interval={POLL_INTERVAL} onRefresh={refreshWorkspaces} />
+            )}
           </FlexItem>
           <FlexItem>
             <Pagination

--- a/workspaces/frontend/src/app/hooks/useWorkspacesLive.ts
+++ b/workspaces/frontend/src/app/hooks/useWorkspacesLive.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchEventSource, EventStreamContentType } from '@microsoft/fetch-event-source';
+import { FetchState } from 'mod-arch-core';
+import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
+import { useNamespaceSelectorWrapper } from '~/app/hooks/useNamespaceSelectorWrapper';
+import { ApiWorkspaceListEnvelope } from '~/generated/data-contracts';
+import { BFF_API_VERSION, DEV_MODE, URL_PREFIX } from '~/shared/utilities/const';
+import { getDevAuthHeaders } from '~/shared/utilities/devAuth';
+
+/**
+ * Connection state of the workspaces live stream, surfaced to the UI so it can
+ * show a "Live"/reconnecting indicator.
+ */
+export type StreamConnectionStatus = 'connecting' | 'live' | 'reconnecting' | 'error';
+
+type WorkspaceList = ApiWorkspaceListEnvelope['data'];
+
+/**
+ * FatalStreamError marks a stream failure that will not be recovered by
+ * reconnecting (e.g. 401/403). Thrown from onopen/onerror to stop
+ * fetch-event-source from retrying.
+ */
+class FatalStreamError extends Error {}
+
+const buildStreamUrl = (namespace: string): string => {
+  const prefix = URL_PREFIX.replace(/\/$/, '');
+  return `${prefix}/api/${BFF_API_VERSION}/workspaces/${namespace}?watch=true`;
+};
+
+/**
+ * useWorkspacesByNamespaceLive streams the workspace list for a namespace over
+ * Server-Sent Events, pushing a fresh full-list snapshot on every backend
+ * change instead of polling. It returns a `FetchState` tuple identical in shape
+ * to {@link useWorkspacesByNamespace} (so it is a drop-in replacement) alongside
+ * the current stream connection status.
+ */
+export const useWorkspacesByNamespaceLive = (
+  namespace: string,
+): { fetchState: FetchState<WorkspaceList>; connectionStatus: StreamConnectionStatus } => {
+  const { apiAvailable } = useNotebookAPI();
+  const { namespacesLoaded, selectedNamespace } = useNamespaceSelectorWrapper();
+
+  const [workspaces, setWorkspaces] = useState<WorkspaceList>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [connectionStatus, setConnectionStatus] = useState<StreamConnectionStatus>('connecting');
+  // Bumped by refresh() to force the effect to tear down and reopen the stream.
+  const [reconnectNonce, setReconnectNonce] = useState(0);
+
+  // Holds the latest workspaces so refresh() can resolve with current data
+  // without needing to be recreated on every snapshot.
+  const workspacesRef = useRef<WorkspaceList>(workspaces);
+  workspacesRef.current = workspaces;
+
+  const ready = apiAvailable && namespacesLoaded && selectedNamespace !== '';
+
+  useEffect(() => {
+    if (!ready) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    setConnectionStatus('connecting');
+
+    fetchEventSource(buildStreamUrl(namespace), {
+      signal: controller.signal,
+      // In dev the userid/groups headers are set client-side (mirrors the axios
+      // interceptor); in prod the gateway injects them, so this is empty.
+      headers: DEV_MODE ? getDevAuthHeaders() : undefined,
+      onopen: async (response) => {
+        const contentType = response.headers.get('content-type') ?? '';
+        if (response.ok && contentType.includes(EventStreamContentType)) {
+          setConnectionStatus('live');
+          setError(undefined);
+          return;
+        }
+        // 4xx (auth/not-found/validation) won't succeed on retry — fail fast.
+        if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+          throw new FatalStreamError(`workspace stream failed with status ${response.status}`);
+        }
+        // 5xx / 429 / unexpected: let the library retry with backoff.
+        throw new Error(`workspace stream failed with status ${response.status}`);
+      },
+      onmessage: (msg) => {
+        if (msg.event === 'error') {
+          setError(new Error(msg.data || 'workspace stream error'));
+          return;
+        }
+        if (!msg.data) {
+          return;
+        }
+        try {
+          const envelope: ApiWorkspaceListEnvelope = JSON.parse(msg.data);
+          setWorkspaces(envelope.data);
+          setLoaded(true);
+          setError(undefined);
+          setConnectionStatus('live');
+        } catch {
+          setError(new Error('failed to parse workspace stream payload'));
+        }
+      },
+      onclose: () => {
+        // Server ended the stream unexpectedly; throw so the library reconnects.
+        throw new Error('workspace stream closed by server');
+      },
+      onerror: (err) => {
+        if (err instanceof FatalStreamError) {
+          setConnectionStatus('error');
+          setError(err);
+          throw err; // stop retrying
+        }
+        setConnectionStatus('reconnecting');
+        return undefined; // retry with the library's default backoff
+      },
+    }).catch(() => {
+      // Reaches here on abort (unmount/refresh) or a fatal error already
+      // reflected in state; nothing further to do.
+    });
+
+    return () => controller.abort();
+  }, [ready, namespace, reconnectNonce]);
+
+  const refresh = useCallback<FetchState<WorkspaceList>[3]>(() => {
+    setReconnectNonce((nonce) => nonce + 1);
+    return Promise.resolve(workspacesRef.current);
+  }, []);
+
+  return { fetchState: [workspaces, loaded, error, refresh], connectionStatus };
+};

--- a/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx
@@ -4,18 +4,39 @@ import { PageSection } from '@patternfly/react-core/dist/esm/components/Page';
 import { Stack, StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack';
 import WorkspaceTable from '~/app/components/WorkspaceTable';
 import { useWorkspacesByNamespace } from '~/app/hooks/useWorkspaces';
+import {
+  StreamConnectionStatus,
+  useWorkspacesByNamespaceLive,
+} from '~/app/hooks/useWorkspacesLive';
 import { useNamespaceSelectorWrapper } from '~/app/hooks/useNamespaceSelectorWrapper';
 import { LoadingSpinner } from '~/app/components/LoadingSpinner';
 import { LoadError } from '~/app/components/LoadError';
 import { useWorkspaceRowActions } from '~/app/hooks/useWorkspaceRowActions';
-import { V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import { ApiWorkspaceListEnvelope, V1Beta1WorkspaceState } from '~/generated/data-contracts';
+import { ENABLE_WORKSPACE_STREAM, MOCK_API_ENABLED } from '~/shared/utilities/const';
 
-export const Workspaces: React.FunctionComponent = () => {
-  const { namespacesLoaded, selectedNamespace } = useNamespaceSelectorWrapper();
+interface WorkspacesContentProps {
+  workspaces: ApiWorkspaceListEnvelope['data'];
+  workspacesLoaded: boolean;
+  workspacesLoadError: Error | undefined;
+  refreshWorkspaces: () => void;
+  selectedNamespace: string;
+  namespacesLoaded: boolean;
+  /** Present only in live (streaming) mode; drives the connection indicator. */
+  connectionStatus?: StreamConnectionStatus;
+}
 
-  const [workspaces, workspacesLoaded, workspacesLoadError, refreshWorkspaces] =
-    useWorkspacesByNamespace(selectedNamespace);
-
+// WorkspacesContent renders the workspaces page from an already-resolved data
+// source, so it can be shared by both the live (SSE) and polling variants.
+const WorkspacesContent: React.FunctionComponent<WorkspacesContentProps> = ({
+  workspaces,
+  workspacesLoaded,
+  workspacesLoadError,
+  refreshWorkspaces,
+  selectedNamespace,
+  namespacesLoaded,
+  connectionStatus,
+}) => {
   const tableRowActions = useWorkspaceRowActions([
     { id: 'viewDetails' },
     { id: 'edit' },
@@ -63,9 +84,58 @@ export const Workspaces: React.FunctionComponent = () => {
             namespace={selectedNamespace}
             hiddenColumns={['namespace', 'gpu', 'idleGpu']}
             refreshWorkspaces={refreshWorkspaces}
+            connectionStatus={connectionStatus}
           />
         </StackItem>
       </Stack>
     </PageSection>
   );
 };
+
+// WorkspacesLive drives the table from the Server-Sent Events stream.
+const WorkspacesLive: React.FunctionComponent = () => {
+  const { namespacesLoaded, selectedNamespace } = useNamespaceSelectorWrapper();
+  const {
+    fetchState: [workspaces, workspacesLoaded, workspacesLoadError, refreshWorkspaces],
+    connectionStatus,
+  } = useWorkspacesByNamespaceLive(selectedNamespace);
+
+  return (
+    <WorkspacesContent
+      workspaces={workspaces}
+      workspacesLoaded={workspacesLoaded}
+      workspacesLoadError={workspacesLoadError}
+      refreshWorkspaces={refreshWorkspaces}
+      selectedNamespace={selectedNamespace}
+      namespacesLoaded={namespacesLoaded}
+      connectionStatus={connectionStatus}
+    />
+  );
+};
+
+// WorkspacesPolling drives the table from the interval-polling fetch hook.
+const WorkspacesPolling: React.FunctionComponent = () => {
+  const { namespacesLoaded, selectedNamespace } = useNamespaceSelectorWrapper();
+  const [workspaces, workspacesLoaded, workspacesLoadError, refreshWorkspaces] =
+    useWorkspacesByNamespace(selectedNamespace);
+
+  return (
+    <WorkspacesContent
+      workspaces={workspaces}
+      workspacesLoaded={workspacesLoaded}
+      workspacesLoadError={workspacesLoadError}
+      refreshWorkspaces={refreshWorkspaces}
+      selectedNamespace={selectedNamespace}
+      namespacesLoaded={namespacesLoaded}
+    />
+  );
+};
+
+// The streaming vs polling choice is a build-time constant, so exactly one
+// branch is rendered for the lifetime of the session — the two variants never
+// swap, which keeps their hooks stable. Streaming is disabled under the mock API
+// since there is no backend to stream from.
+const useLiveStream = ENABLE_WORKSPACE_STREAM && !MOCK_API_ENABLED;
+
+export const Workspaces: React.FunctionComponent = () =>
+  useLiveStream ? <WorkspacesLive /> : <WorkspacesPolling />;

--- a/workspaces/frontend/src/shared/utilities/const.ts
+++ b/workspaces/frontend/src/shared/utilities/const.ts
@@ -8,6 +8,12 @@ export const DEV_MODE = process.env.APP_ENV === 'development';
 export const POLL_INTERVAL = process.env.POLL_INTERVAL
   ? parseInt(process.env.POLL_INTERVAL)
   : 30000;
+/**
+ * When true (the default), the Workspaces table streams live updates via
+ * Server-Sent Events instead of polling every POLL_INTERVAL. Set
+ * ENABLE_WORKSPACE_STREAM=false to fall back to interval polling.
+ */
+export const ENABLE_WORKSPACE_STREAM = process.env.ENABLE_WORKSPACE_STREAM !== 'false';
 export const KUBEFLOW_USERNAME = process.env.KUBEFLOW_USERNAME || 'user@example.com';
 export const IMAGE_DIR = process.env.IMAGE_DIR || 'images';
 export const ROUTES_PREFIX = process.env.ROUTES_PREFIX ?? '';

--- a/workspaces/frontend/src/shared/utilities/devAuth.ts
+++ b/workspaces/frontend/src/shared/utilities/devAuth.ts
@@ -24,19 +24,33 @@ const getDevAuthGroups = (): string => {
   }
 };
 
+// getDevAuthHeaders returns the dev-mode auth headers (kubeflow-userid/groups)
+// as a plain object, for callers that cannot use the axios interceptor — e.g.
+// the Server-Sent Events client, which sets headers on a fetch request directly.
+export const getDevAuthHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  const user = getDevAuthUser().trim();
+  const groups = getDevAuthGroups().trim();
+
+  if (user) {
+    headers[USERID_HEADER] = user;
+  }
+  if (groups) {
+    headers[GROUPS_HEADER] = groups;
+  }
+
+  return headers;
+};
+
 // Reads raw localStorage values written by useBrowserStorage (non-JSON mode)
 // in DebugAuthSection — the two must share the same keys and storage format.
 export const registerDevAuthInterceptor = (axiosInstance: AxiosInstance): void => {
   axiosInstance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-    const user = getDevAuthUser().trim();
-    const groups = getDevAuthGroups().trim();
+    const headers = getDevAuthHeaders();
 
-    if (user) {
-      config.headers.set(USERID_HEADER, user);
-    }
-    if (groups) {
-      config.headers.set(GROUPS_HEADER, groups);
-    }
+    Object.entries(headers).forEach(([key, value]) => {
+      config.headers.set(key, value);
+    });
 
     return config;
   });


### PR DESCRIPTION
> [!NOTE]
>
> The idea of this PR is to be a conversation starter and not intended to be merged in its current state!

---

## What this does

Replace the Workspaces table fixed interval polling with **live updates over Server-Sent Events (SSE)**. The table now reflects backend changes (state transitions, pause/resume, pods coming up, create/delete) almost instantly, without fixed-interval refetching.

https://github.com/user-attachments/assets/a4600b63-9421-4136-8aa4-538e7b6e4e50

## Motivation

Today the frontend keeps the Workspaces table fresh by re-fetching the entire list every 30 s via a countdown (`RefreshCounter` → `POLL_INTERVAL`). This means up to 30 s of staleness after a workspace changes, and a full list re-fetch on every tick regardless of whether anything changed.

The backend already runs a controller-runtime manager with a **shared informer cache on `Workspace`**, and its RBAC already grants `watch`, so the real-time signals already exists but were never surfaced to the frontend.

## How it works

```
Workspace informer -> change hub (pub/sub) -> SSE handler -> browser EventSource -> table
```

- A `watch` query parameter on the existing list routes upgrades the response to an event stream, mirroring the Kubernetes API convention: `GET /api/v1/workspaces/{namespace}?watch=true` (also `watch=1`; cluster-wide `GET /api/v1/workspaces?watch=true`). Same route, **same auth** as the non-streaming list.
- The stream emits an **initial full-list snapshot**, then a fresh snapshot on every change. Bursts are debounced (~250 ms) and idle connections get a heartbeat comment every 20 s.
- Sending full snapshots (rather than deltas) keeps the frontend a drop-in and makes reconnects self-healing — any change during a brief disconnect is captured by the next snapshot.

## Changes

### Backend (`workspaces/backend`)

- **`internal/streaming/hub.go`**: small concurrency-safe pub/sub broadcaster (namespace-filtered, non-blocking, coalescing) with unit tests.
- **`cmd/main.go`**: registers a Workspace informer event handler that publishes changes to the hub.
- **`api/workspaces_stream_handler.go`** + a `watch` branch in the existing list handler: the SSE endpoint. Clears the per-connection `WriteTimeout` via `http.ResponseController` so long-lived streams aren't torn down; gzip is configured to pass `text/event-stream` through untouched so flushing works.

### Frontend (`workspaces/frontend`)

- **`hooks/useWorkspacesLive.ts`**: SSE client (via `@microsoft/fetch-event-source`, so it can set the dev `kubeflow-userid` header the axios layer already uses). Returns a `FetchState` tuple identical to the polling hook, plus a connection status.
- **`components/LiveStatusIndicator.tsx`**: "Live"/"Reconnecting…" indicator that replaces the countdown in live mode (manual refresh preserved).
- **`pages/Workspaces/Workspaces.tsx`**: selects the live or polling variant.

## Testing

<details>
<summary>Click to see test report</summary>


### SSE Live-Update: Test Report

**Feature:** Live Workspace table updates via Server-Sent Events (branch `feat/workspace-live-updates`)
**Date:** 2026-08-28
**Target:** Kubeflow Notebooks v2, Tilt deployment via Istio gateway (`https://localhost:8443`), backend behind `istio-envoy` over HTTP/2.
**Endpoint under test:** `GET /workspaces/api/v1/workspaces/{namespace}?watch=true` (and cluster-wide `/workspaces?watch=true`).

#### Method

Changes were driven through the BFF's own pause/start action
(`POST .../workspaces/{namespace}/{name}/actions/pause`), which exercises the
full **API → controller → informer → hub → SSE** loop end-to-end. Tilt's Kind
cluster was not reachable via `kubectl` from this shell (only a GKE context was
configured), so backend/pod restart was simulated at the network layer (abrupt
client disconnect + reconnect) rather than by killing the pod.

All local pre-checks passed before live testing: backend `go build`/`go vet`/
`gofmt`/`golangci-lint` (clean on changed files) + hub unit tests with `-race`;
frontend `test:type-check`, `test:lint`, and `test:jest` (452 tests).

#### Results summary

| # | Test | Result |
|---|------|--------|
| T1 | Response headers | ✅ `text/event-stream`, `cache-control: no-cache`, `x-accel-buffering: no`; HTTP/2 via istio-envoy |
| T1b | **Served uncompressed with `Accept-Encoding: gzip`** (browser-realistic) | ✅ No `content-encoding: gzip`; body is plaintext `data:` |
| T2 | Missing `Kubeflow-Userid` → 401 | ✅ `401` + error envelope |
| T3 | `watch=false` / absent → normal JSON | ✅ `application/json`, one-shot list |
| T3b | `watch=1` alias | ✅ streams |
| T4 | Initial snapshot immediate on connect | ✅ full list pushed at once |
| T5 | Snapshot payload == non-streaming list | ✅ byte-identical |
| T6 | Namespace scoping (namespaced vs cluster-wide) | ✅ both stream correctly |
| T7 | Nonexistent/empty namespace | ✅ stream opens, `data: {"data":[]}` |
| **R1** | **Self-heal: change during disconnect appears on reconnect** | ✅ **PASS** (paused True→False captured, ~300 ms reconnect) |
| R2 | Live-push latency (change → snapshot) | ✅ **≈271 ms** (debounce-bound) |
| R3 | Concurrent clients fan-out (1 change → N clients) | ✅ both received |
| R4 | 20× rapid reconnect churn → backend health | ✅ list & stream still `200` |
| H | Heartbeat keep-alive | ✅ `: ping` at exactly 20 s idle |

#### Detailed observations

##### Protocol & headers (T1 / T1b)
```
HTTP/2 200
content-type: text/event-stream
cache-control: no-cache
x-accel-buffering: no
vary: Accept-Encoding
server: istio-envoy
```
Critically, even when the client sends `Accept-Encoding: gzip` (which every
browser does), the response is **not** gzip-compressed — the `gzhttp`
`ExceptContentTypes("text/event-stream")` configuration works, so the browser
`EventSource`/parser receives readable `data:` frames.

##### Live push & lifecycle (T4, R2)
A single pause→unpause→pause sequence produced snapshots tracking the real
controller lifecycle, each pushed within ~1 s of the underlying change:
```
00:32:44  test.state = Paused       (paused=true)   ← initial snapshot
00:32:47  test.state = Pending      (paused=false)  ← after unpause POST
00:32:48  test.state = Running      (paused=false)  ← pod up
00:32:50  test.state = Terminating  (paused=true)   ← after re-pause POST
00:32:54  test.state = Paused       (paused=true)   ← settled
```
Precise latency measurement (first snapshot after a change):
```
POST(unpause) t0
   +271 ms  state=Pending   <-- first post-change snapshot
  +1868 ms  state=Running   (controller starting the pod — real work, not our latency)
```
Push latency is **≈271 ms**, essentially the 250 ms debounce interval plus
network overhead.

##### Heartbeat (H)
```
00:33:29  data: {…}     ← initial snapshot
00:33:49  : ping        ← heartbeat, exactly 20 s later
```
Keeps idle connections alive through proxies/gateways.

##### Namespace scoping & edge cases (T5–T7)
- Streamed initial snapshot is byte-identical to the non-streaming list endpoint.
- Cluster-wide (`/workspaces?watch=true`) and namespaced
  (`/workspaces/default?watch=true`) both stream correctly.
- A nonexistent namespace still opens the stream and emits `data: {"data":[]}`.

#### Connection-loss behavior (focus area)

**Frontend runtime path** (`useWorkspacesByNamespaceLive` +
`@microsoft/fetch-event-source`):

1. **Drop detected** → `onerror` runs; non-fatal, so the hook sets
   `connectionStatus = 'reconnecting'` (UI shows "Reconnecting…") and returns
   `undefined`.
2. **Library retries** after a **fixed 1000 ms** (`DefaultRetryInterval`; no
   exponential backoff — confirmed in the library source `fetch.js`).
3. **Reconnect succeeds** → `onopen` re-validates the `text/event-stream`
   content type → `connectionStatus = 'live'`, error cleared → `onmessage`
   delivers a **fresh full snapshot**.
4. Because every connection re-sends the entire list, **any changes that occurred
   during the gap are already present in that first snapshot** — no missed
   updates. Proven empirically by **R1**: the `paused` flag was flipped while no
   stream was connected, and the reconnected stream's initial snapshot already
   reflected the new value (reconnect completed in ~300 ms).
5. **Fatal errors only:** a `4xx` (e.g. 401/403) is treated as non-retryable →
   `connectionStatus = 'error'`, stopping the reconnect loop (no reconnect
   storm on an auth failure).

**Backend robustness:** 20 abrupt connect/disconnect cycles left the backend
fully responsive (both the list endpoint and a fresh stream returned `200`).
Per-connection resources (goroutine, hub subscription, heartbeat ticker) are
released via `defer` on `r.Context().Done()`.

#### Findings & recommendations

1. **Fixed 1 s reconnect, no backoff** (library default). Ideal for brief blips
   (fast recovery), but during a *prolonged* outage every open browser tab
   retries at ~1 req/s against the gateway. Consider adding jittered exponential
   backoff (the hook's `onerror` can return an increasing interval) before a wide
   rollout. Low-effort, non-blocking.
2. **Connect-time authorization only** (by design, matching the existing model):
   a long-lived stream is authorized once at connect and not re-authorized
   mid-connection (SAR result cached ~10 s). Acceptable for now; note it if
   session-revocation latency ever becomes a requirement.
3. **No correctness issues found** — all other behavior matches the design.

#### Verdict

The live-update feature works correctly end-to-end against the live Tilt
deployment, and the connection-loss path is **safe and self-healing**: brief
drops recover within ~1 s with no lost updates, and the backend stays healthy
under reconnect churn.

</details>

### Try it out

```bash
curl -N -sk -H "Kubeflow-Userid: admin" \
  "https://localhost:8443/workspaces/api/v1/workspaces/default?watch=true"
# expect an initial `data:` snapshot, `: ping` heartbeats, and a new snapshot
# whenever a workspace in the namespace changes.
```
