### PR TITLE
feat: Apply filterrule for /workspacekinds API

### DIFF
--- a/workspaces/backend/api/workspacekind_podtemplate_options_handler.go
+++ b/workspaces/backend/api/workspacekind_podtemplate_options_handler.go
@@ -142,6 +142,7 @@ func (a *App) PodTemplateOptionsListValuesHandler(w http.ResponseWriter, r *http
 			return
 		}
 		a.serverErrorResponse(w, r, err)
+		return
 	}
 
 	responseEnvelope := &PodTemplateOptionsEnvelope{Data: listValuesResponse}

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -140,6 +140,11 @@ func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _
 
 	workspaceKinds, err := a.repositories.WorkspaceKind.GetWorkspaceKinds(r.Context(), namespace)
 	if err != nil {
+		if helper.IsInternalValidationError(err) {
+			fieldErrs := helper.FieldErrorsFromInternalValidationError(err)
+			a.failedValidationResponse(w, r, errMsgInternalValidation, fieldErrs, nil)
+			return
+		}
 		a.serverErrorResponse(w, r, err)
 		return
 	}

--- a/workspaces/backend/api/workspacekinds_handler.go
+++ b/workspaces/backend/api/workspacekinds_handler.go
@@ -138,7 +138,7 @@ func (a *App) GetWorkspaceKindsHandler(w http.ResponseWriter, r *http.Request, _
 	}
 	// ============================================================
 
-	workspaceKinds, err := a.repositories.WorkspaceKind.GetWorkspaceKinds(r.Context())
+	workspaceKinds, err := a.repositories.WorkspaceKind.GetWorkspaceKinds(r.Context(), namespace)
 	if err != nil {
 		a.serverErrorResponse(w, r, err)
 		return

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -141,9 +141,11 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKind2Key, workspacekind2)).To(Succeed())
 
 			By("ensuring the response contains the expected WorkspaceKinds")
-			// admin listing (no namespaceFilter): filterRules are not evaluated
-			expectedModel1, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1, nil)
-			expectedModel2, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2, nil)
+			// admin listing (no namespaceFilter): matchNamespace filterRules do not fire
+			expectedModel1, apiHide1 := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1, nil)
+			expectedModel2, apiHide2 := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2, nil)
+			Expect(apiHide1).To(BeFalse())
+			Expect(apiHide2).To(BeFalse())
 			Expect(response.Data).To(ConsistOf(expectedModel1, expectedModel2))
 
 			By("ensuring the statefulSetMetadata from the WorkspaceKind is surfaced in the response")
@@ -247,10 +249,17 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			workspacekind2 := &kubefloworgv1beta1.WorkspaceKind{}
 			Expect(k8sClient.Get(ctx, workspaceKind2Key, workspacekind2)).To(Succeed())
 
+			By("getting the filtered Namespace from the Kubernetes API")
+			namespace1 := &corev1.Namespace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespaceName1}, namespace1)).To(Succeed())
+
 			By("ensuring the response contains the expected WorkspaceKinds")
-			// admin listing (no namespaceFilter): filterRules are not evaluated
-			expectedModel1, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1, nil)
-			expectedModel2, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2, nil)
+			// the example WorkspaceKinds define no WORKSPACE_KIND filterRules, so the
+			// namespaceFilter's labels have no effect and nothing is hidden or denied
+			expectedModel1, apiHide1 := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1, namespace1.Labels)
+			expectedModel2, apiHide2 := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2, namespace1.Labels)
+			Expect(apiHide1).To(BeFalse())
+			Expect(apiHide2).To(BeFalse())
 			Expect(response.Data).To(ConsistOf(expectedModel1, expectedModel2))
 		})
 
@@ -281,6 +290,184 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			Expect(response.Error.Message).To(Equal(errMsgQueryParamsInvalid))
 			Expect(response.Error.Cause.ValidationErrors).NotTo(BeEmpty())
 			Expect(response.Error.Cause.ValidationErrors[0].Field).To(Equal(constants.NamespaceFilterQueryParam))
+		})
+
+		It("should return 422 when the namespaceFilter references a non-existent namespace", func() {
+			By("creating the HTTP request with a namespaceFilter for a non-existent namespace")
+			req, err := http.NewRequest(http.MethodGet, constants.AllWorkspaceKindsPath+"?namespaceFilter=non-existent-ns", http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting the auth headers")
+			req.Header.Set(userIdHeader, adminUser)
+
+			By("executing GetWorkspaceKindsHandler")
+			ps := httprouter.Params{}
+			rr := httptest.NewRecorder()
+			a.GetWorkspaceKindsHandler(rr, req, ps)
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			By("verifying the HTTP response status code")
+			Expect(rs.StatusCode).To(Equal(http.StatusUnprocessableEntity), descUnexpectedHTTPStatus, rr.Body.String())
+
+			By("decoding the error response")
+			var response ErrorEnvelope
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the error indicates a validation failure")
+			Expect(response.Error.Cause.ValidationErrors).NotTo(BeEmpty())
+		})
+	})
+
+	// NOTE: these tests create WorkspaceKinds with WORKSPACE_KIND-scoped filterRules and a labeled
+	//       namespace, so they assume a specific cluster state and must run serially and in order.
+	Context("with WorkspaceKinds that define filterRules", Serial, Ordered, func() {
+
+		const prodNamespaceName = "wsk-filterrules-prod-ns"
+
+		var (
+			hiddenWSKName  string // WORKSPACE_KIND rule with ui.hide
+			deniedWSKName  string // WORKSPACE_KIND rule with api.deny
+			omittedWSKName string // WORKSPACE_KIND rule with api.hide
+			plainWSKName   string // no filterRules
+		)
+
+		// wskWithWorkspaceKindRule returns a WorkspaceKind with a single WORKSPACE_KIND-scoped rule
+		// that fires when the namespace has the label tier=prod.
+		wskWithWorkspaceKindRule := func(name string, effect kubefloworgv1beta1.FilterRuleEffect) *kubefloworgv1beta1.WorkspaceKind {
+			wsk := NewExampleWorkspaceKind(name)
+			wsk.Spec.FilterRules = []kubefloworgv1beta1.FilterRule{
+				{
+					Scope:  kubefloworgv1beta1.FilterRuleScopeWorkspaceKind,
+					Effect: effect,
+					Match: []kubefloworgv1beta1.FilterRuleMatch{
+						{
+							MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+								Selector: metav1.LabelSelector{MatchLabels: map[string]string{"tier": "prod"}},
+							},
+						},
+					},
+				},
+			}
+			return wsk
+		}
+
+		BeforeAll(func() {
+			hiddenWSKName = "wsk-filterrules-hidden"
+			deniedWSKName = "wsk-filterrules-denied"
+			omittedWSKName = "wsk-filterrules-omitted"
+			plainWSKName = "wsk-filterrules-plain"
+
+			By("creating the prod Namespace with tier=prod label")
+			prodNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   prodNamespaceName,
+					Labels: map[string]string{"tier": "prod"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, prodNamespace)).To(Succeed())
+
+			By("creating a WorkspaceKind with a ui.hide rule")
+			Expect(k8sClient.Create(ctx, wskWithWorkspaceKindRule(hiddenWSKName,
+				kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}}))).To(Succeed())
+
+			By("creating a WorkspaceKind with an api.deny rule")
+			Expect(k8sClient.Create(ctx, wskWithWorkspaceKindRule(deniedWSKName,
+				kubefloworgv1beta1.FilterRuleEffect{
+					API: &kubefloworgv1beta1.FilterRuleEffectAPI{
+						Deny:        new(true),
+						DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "not allowed in prod"},
+					},
+				}))).To(Succeed())
+
+			By("creating a WorkspaceKind with an api.hide rule")
+			Expect(k8sClient.Create(ctx, wskWithWorkspaceKindRule(omittedWSKName,
+				kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}}))).To(Succeed())
+
+			By("creating a WorkspaceKind with no filterRules")
+			Expect(k8sClient.Create(ctx, NewExampleWorkspaceKind(plainWSKName))).To(Succeed())
+		})
+
+		AfterAll(func() {
+			for _, name := range []string{hiddenWSKName, deniedWSKName, omittedWSKName, plainWSKName} {
+				Expect(k8sClient.Delete(ctx, &kubefloworgv1beta1.WorkspaceKind{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+				})).To(Succeed())
+			}
+			Expect(k8sClient.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: prodNamespaceName},
+			})).To(Succeed())
+		})
+
+		// listWithNamespaceFilter lists WorkspaceKinds filtered by the given namespace and returns
+		// the decoded response items keyed by name.
+		listWithNamespaceFilter := func(namespace string) map[string]models.WorkspaceKindListItem {
+			req, err := http.NewRequest(http.MethodGet, constants.AllWorkspaceKindsPath+"?namespaceFilter="+namespace, http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set(userIdHeader, adminUser)
+
+			rr := httptest.NewRecorder()
+			a.GetWorkspaceKindsHandler(rr, req, httprouter.Params{})
+			rs := rr.Result()
+			defer rs.Body.Close()
+			Expect(rs.StatusCode).To(Equal(http.StatusOK), descUnexpectedHTTPStatus, rr.Body.String())
+
+			var response WorkspaceKindListEnvelope
+			Expect(json.NewDecoder(rs.Body).Decode(&response)).To(Succeed())
+
+			byName := make(map[string]models.WorkspaceKindListItem, len(response.Data))
+			for _, item := range response.Data {
+				byName[item.Name] = item
+			}
+			return byName
+		}
+
+		It("evaluates the WORKSPACE_KIND filterRules against the namespaceFilter labels", func() {
+			By("listing WorkspaceKinds filtered by the prod namespace")
+			byName := listWithNamespaceFilter(prodNamespaceName)
+
+			By("hiding the WorkspaceKind whose ui.hide rule matches")
+			Expect(byName).To(HaveKey(hiddenWSKName))
+			Expect(byName[hiddenWSKName].Hidden).To(BeTrue())
+
+			By("denying the WorkspaceKind whose api.deny rule matches")
+			Expect(byName).To(HaveKey(deniedWSKName))
+			Expect(byName[deniedWSKName].Restrictions).To(BeComparableTo(commonModels.Restrictions{
+				Deny:        true,
+				DenyMessage: &commonModels.DenyMessage{Text: "not allowed in prod"},
+			}))
+
+			By("omitting the WorkspaceKind whose api.hide rule matches")
+			Expect(byName).NotTo(HaveKey(omittedWSKName))
+
+			By("leaving the WorkspaceKind without filterRules unaffected")
+			Expect(byName).To(HaveKey(plainWSKName))
+			Expect(byName[plainWSKName].Hidden).To(BeFalse())
+			Expect(byName[plainWSKName].Restrictions).To(BeComparableTo(commonModels.DefaultRestrictions()))
+		})
+
+		It("does not fire the rules when the namespace labels do not match", func() {
+			By("creating a namespace without the tier=prod label")
+			devNamespaceName := "wsk-filterrules-dev-ns"
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: devNamespaceName},
+			})).To(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: devNamespaceName},
+				})).To(Succeed())
+			}()
+
+			By("listing WorkspaceKinds filtered by the dev namespace")
+			byName := listWithNamespaceFilter(devNamespaceName)
+
+			By("returning every WorkspaceKind unaffected (nothing hidden, denied, or omitted)")
+			for _, name := range []string{hiddenWSKName, deniedWSKName, omittedWSKName, plainWSKName} {
+				Expect(byName).To(HaveKey(name))
+				Expect(byName[name].Hidden).To(BeFalse())
+				Expect(byName[name].Restrictions).To(BeComparableTo(commonModels.DefaultRestrictions()))
+			}
 		})
 	})
 

--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -141,10 +141,10 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKind2Key, workspacekind2)).To(Succeed())
 
 			By("ensuring the response contains the expected WorkspaceKinds")
-			Expect(response.Data).To(ConsistOf(
-				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1),
-				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2),
-			))
+			// admin listing (no namespaceFilter): filterRules are not evaluated
+			expectedModel1, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1, nil)
+			expectedModel2, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2, nil)
+			Expect(response.Data).To(ConsistOf(expectedModel1, expectedModel2))
 
 			By("ensuring the statefulSetMetadata from the WorkspaceKind is surfaced in the response")
 			var item1 models.WorkspaceKindListItem
@@ -248,10 +248,10 @@ var _ = Describe("WorkspaceKinds Handler", func() {
 			Expect(k8sClient.Get(ctx, workspaceKind2Key, workspacekind2)).To(Succeed())
 
 			By("ensuring the response contains the expected WorkspaceKinds")
-			Expect(response.Data).To(ConsistOf(
-				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1),
-				models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2),
-			))
+			// admin listing (no namespaceFilter): filterRules are not evaluated
+			expectedModel1, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind1, nil)
+			expectedModel2, _ := models.NewWorkspaceKindModelFromWorkspaceKind(a.Config, workspacekind2, nil)
+			Expect(response.Data).To(ConsistOf(expectedModel1, expectedModel2))
 		})
 
 		It("should return 422 for an invalid namespaceFilter query parameter", func() {

--- a/workspaces/backend/internal/filterrules/engine.go
+++ b/workspaces/backend/internal/filterrules/engine.go
@@ -119,25 +119,32 @@ func Evaluate(target EvalTarget, evalCtx EvalContext) EvalResult {
 	return EvalResult{Restrictions: common.DefaultRestrictions()}
 }
 
-// EvaluateWorkspaceFilterScopeRule evaluates the WorkspaceKind's WORKSPACE_KIND-scoped filter
+// workspaceKindScopes is the scope set for endpoints that evaluate only WORKSPACE_KIND rules.
+var workspaceKindScopes = map[kubefloworgv1beta1.FilterRuleScope]bool{
+	kubefloworgv1beta1.FilterRuleScopeWorkspaceKind: true,
+}
+
+// imageAndPodConfigScopes is the scope set for the /listvalues API, which evaluates only
+// IMAGE_CONFIG and POD_CONFIG rules.
+var imageAndPodConfigScopes = map[kubefloworgv1beta1.FilterRuleScope]bool{
+	kubefloworgv1beta1.FilterRuleScopeImageConfig: true,
+	kubefloworgv1beta1.FilterRuleScopePodConfig:   true,
+}
+
+// EvaluateWorkspaceKindFilterScopeRule evaluates the WorkspaceKind's WORKSPACE_KIND-scoped filter
 // rules against the given namespace labels, using first-match-wins semantics.
 //
 // namespaceLabels is nil when no namespaceFilter was provided; matchNamespace conditions are then
 // non-matching, so the non-restrictive default is returned (nothing hidden or denied).
-func EvaluateWorkspaceFilterScopeRule(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string) EvalResult {
-	scopes := map[kubefloworgv1beta1.FilterRuleScope]bool{kubefloworgv1beta1.FilterRuleScopeWorkspaceKind: true}
-	evalCtx := buildEvalContext(wsk, namespaceLabels, scopes, "", "")
+func EvaluateWorkspaceKindFilterScopeRule(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string) EvalResult {
+	evalCtx := buildEvalContext(wsk, namespaceLabels, workspaceKindScopes, "", "")
 	return Evaluate(EvalTarget{Scope: kubefloworgv1beta1.FilterRuleScopeWorkspaceKind}, evalCtx)
 }
 
 // BuildEvalContextForImageAndPodCfg builds an EvalContext for the /listvalues API, which only
 // evaluates IMAGE_CONFIG and POD_CONFIG scoped rules.
 func BuildEvalContextForImageAndPodCfg(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string, imageConfigID, podConfigID string) EvalContext {
-	scopes := map[kubefloworgv1beta1.FilterRuleScope]bool{
-		kubefloworgv1beta1.FilterRuleScopeImageConfig: true,
-		kubefloworgv1beta1.FilterRuleScopePodConfig:   true,
-	}
-	return buildEvalContext(wsk, namespaceLabels, scopes, imageConfigID, podConfigID)
+	return buildEvalContext(wsk, namespaceLabels, imageAndPodConfigScopes, imageConfigID, podConfigID)
 }
 
 // buildEvalContext resolves the request-scoped inputs shared across all filter rule evaluations,

--- a/workspaces/backend/internal/filterrules/engine.go
+++ b/workspaces/backend/internal/filterrules/engine.go
@@ -119,16 +119,39 @@ func Evaluate(target EvalTarget, evalCtx EvalContext) EvalResult {
 	return EvalResult{Restrictions: common.DefaultRestrictions()}
 }
 
-// BuildEvalContext resolves the request-scoped inputs shared across all filter rule evaluations.
+// EvaluateWorkspaceFilterScopeRule evaluates the WorkspaceKind's WORKSPACE_KIND-scoped filter
+// rules against the given namespace labels, using first-match-wins semantics.
+//
+// namespaceLabels is nil when no namespaceFilter was provided; matchNamespace conditions are then
+// non-matching, so the non-restrictive default is returned (nothing hidden or denied).
+func EvaluateWorkspaceFilterScopeRule(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string) EvalResult {
+	scopes := map[kubefloworgv1beta1.FilterRuleScope]bool{kubefloworgv1beta1.FilterRuleScopeWorkspaceKind: true}
+	evalCtx := buildEvalContext(wsk, namespaceLabels, scopes, "", "")
+	return Evaluate(EvalTarget{Scope: kubefloworgv1beta1.FilterRuleScopeWorkspaceKind}, evalCtx)
+}
+
+// BuildEvalContextForImageAndPodCfg builds an EvalContext for the /listvalues API, which only
+// evaluates IMAGE_CONFIG and POD_CONFIG scoped rules.
+func BuildEvalContextForImageAndPodCfg(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string, imageConfigID, podConfigID string) EvalContext {
+	scopes := map[kubefloworgv1beta1.FilterRuleScope]bool{
+		kubefloworgv1beta1.FilterRuleScopeImageConfig: true,
+		kubefloworgv1beta1.FilterRuleScopePodConfig:   true,
+	}
+	return buildEvalContext(wsk, namespaceLabels, scopes, imageConfigID, podConfigID)
+}
+
+// buildEvalContext resolves the request-scoped inputs shared across all filter rule evaluations,
+// compiling only the rules whose scope is in scopes (so each endpoint evaluates just the scopes
+// it cares about).
 //
 // namespaceLabels are passed through as-is (nil when no namespace context was provided). The
 // imageConfig/podConfig labels are resolved from the `spawner.labels` of the value selected via
 // `context.imageConfig.id` / `context.podConfig.id`, enabling cross-option matching. They remain
 // nil when the corresponding context id is empty or does not match any value.
-func BuildEvalContext(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string, imageConfigID, podConfigID string) EvalContext {
+func buildEvalContext(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string, scopes map[kubefloworgv1beta1.FilterRuleScope]bool, imageConfigID, podConfigID string) EvalContext {
 	evalCtx := EvalContext{
 		NamespaceLabels: namespaceLabels,
-		compiledRules:   compileRules(wsk.Spec.FilterRules),
+		compiledRules:   compileRules(filterRulesByScope(wsk.Spec.FilterRules, scopes)),
 	}
 
 	if imageConfigID != "" {
@@ -152,6 +175,17 @@ func BuildEvalContext(wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map
 	}
 
 	return evalCtx
+}
+
+// filterRulesByScope returns the subset of rules whose scope is in scopes.
+func filterRulesByScope(rules []kubefloworgv1beta1.FilterRule, scopes map[kubefloworgv1beta1.FilterRuleScope]bool) []kubefloworgv1beta1.FilterRule {
+	filtered := make([]kubefloworgv1beta1.FilterRule, 0, len(rules))
+	for _, rule := range rules {
+		if scopes[rule.Scope] {
+			filtered = append(filtered, rule)
+		}
+	}
+	return filtered
 }
 
 // compileRules pre-compiles the label selector of every match condition in the given rules,

--- a/workspaces/backend/internal/filterrules/engine_test.go
+++ b/workspaces/backend/internal/filterrules/engine_test.go
@@ -504,7 +504,7 @@ var _ = Describe("Evaluate", func() {
 	})
 })
 
-var _ = Describe("BuildEvalContext", func() {
+var _ = Describe("BuildEvalContextForImageAndPodCfg", func() {
 	newWSK := func() *kubefloworgv1beta1.WorkspaceKind {
 		return &kubefloworgv1beta1.WorkspaceKind{
 			Spec: kubefloworgv1beta1.WorkspaceKindSpec{
@@ -543,7 +543,7 @@ var _ = Describe("BuildEvalContext", func() {
 	}
 
 	It("passes through namespace labels and leaves config labels nil when no ids are given", func() {
-		evalCtx := BuildEvalContext(newWSK(), map[string]string{"tier": "prod"}, "", "")
+		evalCtx := BuildEvalContextForImageAndPodCfg(newWSK(), map[string]string{"tier": "prod"}, "", "")
 
 		Expect(evalCtx.NamespaceLabels).To(HaveKeyWithValue("tier", "prod"))
 		Expect(evalCtx.ImageConfigLabels).To(BeNil())
@@ -551,7 +551,7 @@ var _ = Describe("BuildEvalContext", func() {
 	})
 
 	It("compiles the WorkspaceKind's filterRules into the eval context", func() {
-		evalCtx := BuildEvalContext(newWSK(), nil, "", "")
+		evalCtx := BuildEvalContextForImageAndPodCfg(newWSK(), nil, "", "")
 
 		Expect(evalCtx.compiledRules).To(HaveLen(1))
 		cr := evalCtx.compiledRules[0]
@@ -565,22 +565,85 @@ var _ = Describe("BuildEvalContext", func() {
 	It("leaves compiledRules empty when the WorkspaceKind has no filterRules", func() {
 		wsk := newWSK()
 		wsk.Spec.FilterRules = nil
-		evalCtx := BuildEvalContext(wsk, nil, "", "")
+		evalCtx := BuildEvalContextForImageAndPodCfg(wsk, nil, "", "")
 
 		Expect(evalCtx.compiledRules).To(BeEmpty())
 	})
 
 	It("resolves imageConfig and podConfig labels from matching ids", func() {
-		evalCtx := BuildEvalContext(newWSK(), nil, "img1", "pod1")
+		evalCtx := BuildEvalContextForImageAndPodCfg(newWSK(), nil, "img1", "pod1")
 
 		Expect(evalCtx.ImageConfigLabels).To(HaveKeyWithValue("vendor", "nvidia"))
 		Expect(evalCtx.PodConfigLabels).To(HaveKeyWithValue("gpu", "true"))
 	})
 
 	It("leaves labels nil when the ids do not match any value", func() {
-		evalCtx := BuildEvalContext(newWSK(), nil, "missing-img", "missing-pod")
+		evalCtx := BuildEvalContextForImageAndPodCfg(newWSK(), nil, "missing-img", "missing-pod")
 
 		Expect(evalCtx.ImageConfigLabels).To(BeNil())
 		Expect(evalCtx.PodConfigLabels).To(BeNil())
+	})
+})
+
+var _ = Describe("EvaluateWorkspaceFilterScopeRule", func() {
+	// wskHideRule builds a WORKSPACE_KIND-scoped rule that hides the WorkspaceKind
+	// when the namespace matches the given selector.
+	wskHideRule := func(selector map[string]string) kubefloworgv1beta1.FilterRule {
+		return kubefloworgv1beta1.FilterRule{
+			Scope:  kubefloworgv1beta1.FilterRuleScopeWorkspaceKind,
+			Effect: kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+			Match: []kubefloworgv1beta1.FilterRuleMatch{
+				{
+					MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+						Selector: metav1.LabelSelector{MatchLabels: selector},
+					},
+				},
+			},
+		}
+	}
+
+	newWSK := func(rules ...kubefloworgv1beta1.FilterRule) *kubefloworgv1beta1.WorkspaceKind {
+		return &kubefloworgv1beta1.WorkspaceKind{
+			Spec: kubefloworgv1beta1.WorkspaceKindSpec{FilterRules: rules},
+		}
+	}
+
+	It("applies a matching WORKSPACE_KIND rule against the namespace labels", func() {
+		result := EvaluateWorkspaceFilterScopeRule(
+			newWSK(wskHideRule(map[string]string{"tier": "prod"})),
+			map[string]string{"tier": "prod"},
+		)
+
+		Expect(result).To(BeComparableTo(EvalResult{UIHide: true, Restrictions: common.DefaultRestrictions()}))
+	})
+
+	It("returns the non-restrictive default when the namespace does not match", func() {
+		result := EvaluateWorkspaceFilterScopeRule(
+			newWSK(wskHideRule(map[string]string{"tier": "prod"})),
+			map[string]string{"tier": "dev"},
+		)
+
+		Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
+	})
+
+	It("returns the non-restrictive default when namespace labels are absent", func() {
+		result := EvaluateWorkspaceFilterScopeRule(
+			newWSK(wskHideRule(map[string]string{"tier": "prod"})),
+			nil,
+		)
+
+		Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
+	})
+
+	It("ignores non-WORKSPACE_KIND scoped rules", func() {
+		result := EvaluateWorkspaceFilterScopeRule(
+			newWSK(matchImageConfigRule(
+				map[string]string{"gpu": "true"},
+				kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},
+			)),
+			map[string]string{"gpu": "true"},
+		)
+
+		Expect(result).To(BeComparableTo(EvalResult{Restrictions: common.DefaultRestrictions()}))
 	})
 })

--- a/workspaces/backend/internal/filterrules/engine_test.go
+++ b/workspaces/backend/internal/filterrules/engine_test.go
@@ -585,7 +585,7 @@ var _ = Describe("BuildEvalContextForImageAndPodCfg", func() {
 	})
 })
 
-var _ = Describe("EvaluateWorkspaceFilterScopeRule", func() {
+var _ = Describe("EvaluateWorkspaceKindFilterScopeRule", func() {
 	// wskHideRule builds a WORKSPACE_KIND-scoped rule that hides the WorkspaceKind
 	// when the namespace matches the given selector.
 	wskHideRule := func(selector map[string]string) kubefloworgv1beta1.FilterRule {

--- a/workspaces/backend/internal/filterrules/engine_test.go
+++ b/workspaces/backend/internal/filterrules/engine_test.go
@@ -609,7 +609,7 @@ var _ = Describe("EvaluateWorkspaceFilterScopeRule", func() {
 	}
 
 	It("applies a matching WORKSPACE_KIND rule against the namespace labels", func() {
-		result := EvaluateWorkspaceFilterScopeRule(
+		result := EvaluateWorkspaceKindFilterScopeRule(
 			newWSK(wskHideRule(map[string]string{"tier": "prod"})),
 			map[string]string{"tier": "prod"},
 		)
@@ -618,7 +618,7 @@ var _ = Describe("EvaluateWorkspaceFilterScopeRule", func() {
 	})
 
 	It("returns the non-restrictive default when the namespace does not match", func() {
-		result := EvaluateWorkspaceFilterScopeRule(
+		result := EvaluateWorkspaceKindFilterScopeRule(
 			newWSK(wskHideRule(map[string]string{"tier": "prod"})),
 			map[string]string{"tier": "dev"},
 		)
@@ -627,7 +627,7 @@ var _ = Describe("EvaluateWorkspaceFilterScopeRule", func() {
 	})
 
 	It("returns the non-restrictive default when namespace labels are absent", func() {
-		result := EvaluateWorkspaceFilterScopeRule(
+		result := EvaluateWorkspaceKindFilterScopeRule(
 			newWSK(wskHideRule(map[string]string{"tier": "prod"})),
 			nil,
 		)
@@ -636,7 +636,7 @@ var _ = Describe("EvaluateWorkspaceFilterScopeRule", func() {
 	})
 
 	It("ignores non-WORKSPACE_KIND scoped rules", func() {
-		result := EvaluateWorkspaceFilterScopeRule(
+		result := EvaluateWorkspaceKindFilterScopeRule(
 			newWSK(matchImageConfigRule(
 				map[string]string{"gpu": "true"},
 				kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}},

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -23,14 +23,30 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
-	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/filterrules"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common/assets"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds/podtemplate/options"
 )
 
 // NewWorkspaceKindModelFromWorkspaceKind creates a WorkspaceKind model from a WorkspaceKind object.
 // Asset SHA256 hashes and error codes are read directly from the WorkspaceKind status.
-func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubefloworgv1beta1.WorkspaceKind) WorkspaceKindListItem {
+//
+// namespaceLabels are the labels of the namespace named in the request's `namespaceFilter`
+// (resolved by the caller via the k8s API), or nil when `namespaceFilter` was not provided.
+// The WorkspaceKind's `spec.filterRules[]` with `scope: WORKSPACE_KIND` are evaluated against
+// these labels; apiHide is true when a matching rule has `api.hide`, signalling the caller to
+// omit the WorkspaceKind from the response entirely.
+func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string) (item WorkspaceKindListItem, apiHide bool) {
+	// evaluate the WorkspaceKind's WORKSPACE_KIND-scoped filter rules (first-match-wins).
+	// only matchNamespace conditions apply at this scope; when namespaceLabels is nil (no
+	// namespaceFilter), those conditions are non-matching, so nothing is hidden or denied.
+	result := filterrules.EvaluateWorkspaceFilterScopeRule(wsk, namespaceLabels)
+
+	// `api.hide` omits the WorkspaceKind from the response entirely; skip building the model
+	if result.APIHide {
+		return WorkspaceKindListItem{}, true
+	}
+
 	podLabels := make(map[string]string)
 	podAnnotations := make(map[string]string)
 	if wsk.Spec.PodTemplate.PodMetadata != nil {
@@ -62,9 +78,10 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 		Description:        wsk.Spec.Spawner.Description,
 		Deprecated:         ptr.Deref(wsk.Spec.Spawner.Deprecated, false),
 		DeprecationMessage: ptr.Deref(wsk.Spec.Spawner.DeprecationMessage, ""),
-		Hidden:             ptr.Deref(wsk.Spec.Spawner.Hidden, false),
-		Icon:               assets.NewImageRefFromWorkspaceKindAssetIcon(cfg, wsk.Spec.Spawner.Icon, wsk.Status.SpawnerIcon, wsk.Name),
-		Logo:               assets.NewImageRefFromWorkspaceKindAssetLogo(cfg, wsk.Spec.Spawner.Logo, wsk.Status.SpawnerLogo, wsk.Name),
+		// `hidden` is the admin-set value OR the `ui.hide` effect of the first matching rule
+		Hidden: ptr.Deref(wsk.Spec.Spawner.Hidden, false) || result.UIHide,
+		Icon:   assets.NewImageRefFromWorkspaceKindAssetIcon(cfg, wsk.Spec.Spawner.Icon, wsk.Status.SpawnerIcon, wsk.Name),
+		Logo:   assets.NewImageRefFromWorkspaceKindAssetLogo(cfg, wsk.Spec.Spawner.Logo, wsk.Status.SpawnerLogo, wsk.Name),
 		// TODO: in the future will need to support including exactly one of clusterMetrics or namespaceMetrics based on request context
 		ClusterMetrics: ClusterKindMetrics{
 			Workspaces: wsk.Status.Workspaces,
@@ -85,11 +102,8 @@ func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubeflow
 			Options:       *podTemplateOptions,
 		},
 		ActivityRules: buildActivityRules(wsk.Spec.ActivityRules),
-		//
-		// TODO: replace this with the calculation of the actual restriction!
-		//
-		Restrictions: common.DefaultRestrictions(),
-	}
+		Restrictions:  result.Restrictions,
+	}, false
 }
 
 func buildActivityProbe(probe *kubefloworgv1beta1.ActivityProbe) *ActivityProbe {

--- a/workspaces/backend/internal/models/workspacekinds/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs.go
@@ -34,13 +34,13 @@ import (
 // namespaceLabels are the labels of the namespace named in the request's `namespaceFilter`
 // (resolved by the caller via the k8s API), or nil when `namespaceFilter` was not provided.
 // The WorkspaceKind's `spec.filterRules[]` with `scope: WORKSPACE_KIND` are evaluated against
-// these labels; apiHide is true when a matching rule has `api.hide`, signalling the caller to
+// these labels; apiHide is true when a matching rule has `api.hide`, signaling the caller to
 // omit the WorkspaceKind from the response entirely.
 func NewWorkspaceKindModelFromWorkspaceKind(cfg *config.EnvConfig, wsk *kubefloworgv1beta1.WorkspaceKind, namespaceLabels map[string]string) (item WorkspaceKindListItem, apiHide bool) {
 	// evaluate the WorkspaceKind's WORKSPACE_KIND-scoped filter rules (first-match-wins).
 	// only matchNamespace conditions apply at this scope; when namespaceLabels is nil (no
 	// namespaceFilter), those conditions are non-matching, so nothing is hidden or denied.
-	result := filterrules.EvaluateWorkspaceFilterScopeRule(wsk, namespaceLabels)
+	result := filterrules.EvaluateWorkspaceKindFilterScopeRule(wsk, namespaceLabels)
 
 	// `api.hide` omits the WorkspaceKind from the response entirely; skip building the model
 	if result.APIHide {

--- a/workspaces/backend/internal/models/workspacekinds/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_test.go
@@ -23,6 +23,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 )
 
 var (
@@ -189,5 +192,113 @@ var _ = Describe("buildActivityRules", func() {
 		Expect(apiRules[1].Config.MinRunningSeconds).To(Equal(int32(0)))
 		Expect(apiRules[1].Match).To(BeNil())
 		Expect(apiRules[1].Effect.PauseWorkspace).To(BeTrue())
+	})
+})
+
+var _ = Describe("NewWorkspaceKindModelFromWorkspaceKind", func() {
+	cfg := &config.EnvConfig{}
+
+	// newWSK builds a minimal WorkspaceKind with the given admin-set hidden flag and filterRules.
+	newWSK := func(hidden bool, rules []kubefloworgv1beta1.FilterRule) *kubefloworgv1beta1.WorkspaceKind {
+		return &kubefloworgv1beta1.WorkspaceKind{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-wsk"},
+			Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+				Spawner:     kubefloworgv1beta1.WorkspaceKindSpawner{Hidden: new(hidden)},
+				FilterRules: rules,
+			},
+		}
+	}
+
+	// wskRule builds a WORKSPACE_KIND-scoped rule that matches namespaces with the given labels.
+	wskRule := func(nsSelector map[string]string, effect kubefloworgv1beta1.FilterRuleEffect) kubefloworgv1beta1.FilterRule {
+		return kubefloworgv1beta1.FilterRule{
+			Scope:  kubefloworgv1beta1.FilterRuleScopeWorkspaceKind,
+			Effect: effect,
+			Match: []kubefloworgv1beta1.FilterRuleMatch{
+				{
+					MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+						Selector: metav1.LabelSelector{MatchLabels: nsSelector},
+					},
+				},
+			},
+		}
+	}
+
+	Context("admin listing (no namespaceFilter)", func() {
+		It("does not apply matchNamespace rules: hidden is admin-set and deny is not set", func() {
+			wsk := newWSK(true, []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Deny: new(true)}}),
+			})
+
+			// namespaceLabels is nil, so the matchNamespace condition cannot fire => no deny
+			item, apiHide := NewWorkspaceKindModelFromWorkspaceKind(cfg, wsk, nil)
+
+			Expect(apiHide).To(BeFalse())
+			Expect(item.Hidden).To(BeTrue()) // admin-set value preserved
+			Expect(item.Restrictions.Deny).To(BeFalse())
+			Expect(item.Restrictions).To(BeComparableTo(common.DefaultRestrictions()))
+		})
+	})
+
+	Context("ui.hide via matchNamespace", func() {
+		It("merges admin-set hidden with the ui.hide effect (logical OR)", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}}),
+			}
+
+			By("hiding when the namespace labels match")
+			item, apiHide := NewWorkspaceKindModelFromWorkspaceKind(cfg, newWSK(false, rules), map[string]string{"tier": "prod"})
+			Expect(apiHide).To(BeFalse())
+			Expect(item.Hidden).To(BeTrue())
+
+			By("not hiding when the namespace labels do not match")
+			item, _ = NewWorkspaceKindModelFromWorkspaceKind(cfg, newWSK(false, rules), map[string]string{"tier": "dev"})
+			Expect(item.Hidden).To(BeFalse())
+
+			By("still hidden when admin-set even though the rule does not match")
+			item, _ = NewWorkspaceKindModelFromWorkspaceKind(cfg, newWSK(true, rules), map[string]string{"tier": "dev"})
+			Expect(item.Hidden).To(BeTrue())
+		})
+	})
+
+	Context("api.hide via matchNamespace", func() {
+		It("signals the WorkspaceKind should be omitted from the response", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}}),
+			}
+
+			item, apiHide := NewWorkspaceKindModelFromWorkspaceKind(cfg, newWSK(false, rules), map[string]string{"tier": "prod"})
+			Expect(apiHide).To(BeTrue())
+			Expect(item).To(BeComparableTo(WorkspaceKindListItem{}))
+		})
+	})
+
+	Context("api.deny via matchNamespace", func() {
+		It("populates restrictions with deny and denyMessage", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{
+							Deny:        new(true),
+							DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "not allowed in prod"},
+						},
+					}),
+			}
+
+			By("denying when the namespace labels match")
+			item, apiHide := NewWorkspaceKindModelFromWorkspaceKind(cfg, newWSK(false, rules), map[string]string{"tier": "prod"})
+			Expect(apiHide).To(BeFalse())
+			Expect(item.Restrictions).To(BeComparableTo(common.Restrictions{
+				Deny:        true,
+				DenyMessage: &common.DenyMessage{Text: "not allowed in prod"},
+			}))
+
+			By("not denying when the namespace labels do not match")
+			item, _ = NewWorkspaceKindModelFromWorkspaceKind(cfg, newWSK(false, rules), map[string]string{"tier": "dev"})
+			Expect(item.Restrictions).To(BeComparableTo(common.DefaultRestrictions()))
+		})
 	})
 })

--- a/workspaces/backend/internal/models/workspacekinds/funcs_test.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_test.go
@@ -54,8 +54,9 @@ var _ = Describe("NewWorkspaceKindModelFromWorkspaceKind", func() {
 			},
 		}
 
-		item := NewWorkspaceKindModelFromWorkspaceKind(nil, wsk)
+		item, apiHide := NewWorkspaceKindModelFromWorkspaceKind(nil, wsk, nil)
 
+		Expect(apiHide).To(BeFalse())
 		Expect(item.PodTemplate.StatefulSetMetadata.Labels).NotTo(BeNil())
 		Expect(item.PodTemplate.StatefulSetMetadata.Labels).To(BeEmpty())
 		Expect(item.PodTemplate.StatefulSetMetadata.Annotations).NotTo(BeNil())
@@ -75,8 +76,9 @@ var _ = Describe("NewWorkspaceKindModelFromWorkspaceKind", func() {
 			},
 		}
 
-		item := NewWorkspaceKindModelFromWorkspaceKind(nil, wsk)
+		item, apiHide := NewWorkspaceKindModelFromWorkspaceKind(nil, wsk, nil)
 
+		Expect(apiHide).To(BeFalse())
 		Expect(item.PodTemplate.StatefulSetMetadata.Labels).To(HaveKeyWithValue("my-sts-label", "my-value"))
 		Expect(item.PodTemplate.StatefulSetMetadata.Annotations).To(HaveKeyWithValue("my-sts-annotation", "my-value"))
 

--- a/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
+++ b/workspaces/backend/internal/models/workspacekinds/podtemplate/options/funcs.go
@@ -36,8 +36,9 @@ func NewPodTemplateOptionsModelFromWorkspaceKind(wsk *kubefloworgv1beta1.Workspa
 	var allValErrs field.ErrorList //nolint:prealloc
 
 	// resolve the request-scoped context shared across all rule evaluations
+	// (only IMAGE_CONFIG and POD_CONFIG scoped rules apply to /listvalues)
 	imageConfigID, podConfigID := request.configIDs()
-	evalCtx := filterrules.BuildEvalContext(wsk, namespaceLabels, imageConfigID, podConfigID)
+	evalCtx := filterrules.BuildEvalContextForImageAndPodCfg(wsk, namespaceLabels, imageConfigID, podConfigID)
 
 	// calculate maps of "option id" -> "number of workspaces using that option in the cluster"
 	metricsMapImageConfig := calculateOptionMetricsMap(wsk.Status.PodTemplateOptions.ImageConfig)

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	modelsCommon "github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
@@ -96,7 +97,7 @@ func (r *WorkspaceKindRepository) GetWorkspaceKinds(ctx context.Context, namespa
 
 	// resolve the labels of the namespace named in namespaceFilter (used by matchNamespace rules).
 	// nil when no namespaceFilter was provided, so those conditions are treated as non-matching.
-	namespaceLabels, err := r.resolveNamespaceLabels(ctx, namespaceFilter)
+	namespaceLabels, err := r.resolveNamespaceLabels(ctx, namespaceFilter, field.NewPath(constants.NamespaceFilterQueryParam))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +216,7 @@ func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Conte
 	if listValuesRequest.Context.Namespace != nil {
 		namespaceName = listValuesRequest.Context.Namespace.Name
 	}
-	namespaceLabels, err := r.resolveNamespaceLabels(ctx, namespaceName)
+	namespaceLabels, err := r.resolveNamespaceLabels(ctx, namespaceName, field.NewPath("context", "namespace", "name"))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,10 @@ func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Conte
 // It returns nil (and no error) when the name is empty, so that matchNamespace conditions are
 // conservatively treated as non-matching. When a name is given but the namespace does not exist,
 // it returns an internal validation error so the caller can surface a 422 to the client.
-func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, namespaceName string) (map[string]string, error) {
+//
+// fieldPath identifies the caller's user-facing input (e.g. the `namespaceFilter` query param, or
+// `context.namespace.name` in the request body) so the validation error points at the right field.
+func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, namespaceName string, fieldPath *field.Path) (map[string]string, error) {
 	if namespaceName == "" {
 		return nil, nil
 	}
@@ -241,9 +245,8 @@ func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, na
 	namespace := &corev1.Namespace{}
 	if err := r.client.Get(ctx, client.ObjectKey{Name: namespaceName}, namespace); err != nil {
 		if apierrors.IsNotFound(err) {
-			namespacePath := field.NewPath("namespace")
 			errDetail := fmt.Sprintf("namespace %q not found", namespaceName)
-			valErrs := field.ErrorList{field.Invalid(namespacePath, namespaceName, errDetail)}
+			valErrs := field.ErrorList{field.Invalid(fieldPath, namespaceName, errDetail)}
 			return nil, helper.NewInternalValidationError(valErrs)
 		}
 		return nil, err

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -229,8 +230,9 @@ func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Conte
 }
 
 // resolveNamespaceLabels fetches the labels of the namespace with the given name.
-// It returns nil (and no error) when the name is empty, or when the namespace does not exist,
-// so that matchNamespace conditions are conservatively treated as non-matching.
+// It returns nil (and no error) when the name is empty, so that matchNamespace conditions are
+// conservatively treated as non-matching. When a name is given but the namespace does not exist,
+// it returns an internal validation error so the caller can surface a 422 to the client.
 func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, namespaceName string) (map[string]string, error) {
 	if namespaceName == "" {
 		return nil, nil
@@ -239,7 +241,10 @@ func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, na
 	namespace := &corev1.Namespace{}
 	if err := r.client.Get(ctx, client.ObjectKey{Name: namespaceName}, namespace); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, nil
+			namespacePath := field.NewPath("namespace")
+			errDetail := fmt.Sprintf("namespace %q not found", namespaceName)
+			valErrs := field.ErrorList{field.Invalid(namespacePath, namespaceName, errDetail)}
+			return nil, helper.NewInternalValidationError(valErrs)
 		}
 		return nil, err
 	}

--- a/workspaces/backend/internal/repositories/workspacekinds/repo.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo.go
@@ -79,16 +79,35 @@ func (r *WorkspaceKindRepository) GetWorkspaceKind(ctx context.Context, name str
 	return workspaceKindModel, nil
 }
 
-func (r *WorkspaceKindRepository) GetWorkspaceKinds(ctx context.Context) ([]models.WorkspaceKindListItem, error) {
+// GetWorkspaceKinds returns the WorkspaceKind list items.
+//
+// When namespaceFilter is provided, each WorkspaceKind's `spec.filterRules[]` with
+// `scope: WORKSPACE_KIND` are evaluated against that namespace's labels, computing `hidden`
+// and `restrictions` and omitting any WorkspaceKind whose matching rule sets `api.hide`.
+// When namespaceFilter is empty (admin listing), rules are NOT evaluated: `hidden` is the
+// admin-set value and `restrictions.deny` is false.
+func (r *WorkspaceKindRepository) GetWorkspaceKinds(ctx context.Context, namespaceFilter string) ([]models.WorkspaceKindListItem, error) {
 	workspaceKindList := &kubefloworgv1beta1.WorkspaceKindList{}
 	err := r.client.List(ctx, workspaceKindList)
 	if err != nil {
 		return nil, err
 	}
 
-	workspaceKindsModels := make([]models.WorkspaceKindListItem, len(workspaceKindList.Items))
+	// resolve the labels of the namespace named in namespaceFilter (used by matchNamespace rules).
+	// nil when no namespaceFilter was provided, so those conditions are treated as non-matching.
+	namespaceLabels, err := r.resolveNamespaceLabels(ctx, namespaceFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	workspaceKindsModels := make([]models.WorkspaceKindListItem, 0, len(workspaceKindList.Items))
 	for i := range workspaceKindList.Items {
-		workspaceKindsModels[i] = models.NewWorkspaceKindModelFromWorkspaceKind(r.cfg, &workspaceKindList.Items[i])
+		model, apiHide := models.NewWorkspaceKindModelFromWorkspaceKind(r.cfg, &workspaceKindList.Items[i], namespaceLabels)
+		// `api.hide` omits the WorkspaceKind from the response entirely
+		if apiHide {
+			continue
+		}
+		workspaceKindsModels = append(workspaceKindsModels, model)
 	}
 
 	return workspaceKindsModels, nil
@@ -191,7 +210,11 @@ func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Conte
 
 	// resolve the labels of the namespace named in the request context (used by matchNamespace rules).
 	// nil when no namespace context was provided, so those conditions are treated as non-matching.
-	namespaceLabels, err := r.resolveNamespaceLabels(ctx, listValuesRequest)
+	var namespaceName string
+	if listValuesRequest.Context.Namespace != nil {
+		namespaceName = listValuesRequest.Context.Namespace.Name
+	}
+	namespaceLabels, err := r.resolveNamespaceLabels(ctx, namespaceName)
 	if err != nil {
 		return nil, err
 	}
@@ -205,16 +228,16 @@ func (r *WorkspaceKindRepository) ListPodTemplateOptionsValues(ctx context.Conte
 	return listValuesResponse, nil
 }
 
-// resolveNamespaceLabels fetches the labels of the namespace named in the request context.
-// It returns nil (and no error) when no namespace context was provided, or when the namespace
-// does not exist, so that matchNamespace conditions are conservatively treated as non-matching.
-func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, listValuesRequest *modelsPodTemplateOptions.ListValuesRequest) (map[string]string, error) {
-	if listValuesRequest.Context.Namespace == nil || listValuesRequest.Context.Namespace.Name == "" {
+// resolveNamespaceLabels fetches the labels of the namespace with the given name.
+// It returns nil (and no error) when the name is empty, or when the namespace does not exist,
+// so that matchNamespace conditions are conservatively treated as non-matching.
+func (r *WorkspaceKindRepository) resolveNamespaceLabels(ctx context.Context, namespaceName string) (map[string]string, error) {
+	if namespaceName == "" {
 		return nil, nil
 	}
 
 	namespace := &corev1.Namespace{}
-	if err := r.client.Get(ctx, client.ObjectKey{Name: listValuesRequest.Context.Namespace.Name}, namespace); err != nil {
+	if err := r.client.Get(ctx, client.ObjectKey{Name: namespaceName}, namespace); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/workspaces/backend/internal/repositories/workspacekinds/repo_test.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo_test.go
@@ -29,9 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kubeflow/notebooks/workspaces/backend/api/constants"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
+	modelsPodTemplateOptions "github.com/kubeflow/notebooks/workspaces/backend/internal/models/workspacekinds/podtemplate/options"
 )
 
 func TestWorkspaceKindRepository(t *testing.T) {
@@ -148,6 +150,11 @@ var _ = Describe("WorkspaceKindRepository.GetWorkspaceKinds", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(helper.IsInternalValidationError(err)).To(BeTrue())
 			Expect(items).To(BeNil())
+
+			// the error must point at the caller's user-facing query param, not a generic "namespace"
+			fieldErrs := helper.FieldErrorsFromInternalValidationError(err)
+			Expect(fieldErrs).To(HaveLen(1))
+			Expect(fieldErrs[0].Field).To(Equal(constants.NamespaceFilterQueryParam))
 		})
 	})
 
@@ -188,6 +195,28 @@ var _ = Describe("WorkspaceKindRepository.GetWorkspaceKinds", func() {
 				Deny:        true,
 				DenyMessage: &common.DenyMessage{Text: "not allowed in prod"},
 			}))
+		})
+	})
+
+	Context("ListPodTemplateOptionsValues namespace context", func() {
+		It("returns a validation error naming context.namespace.name when the namespace does not exist", func() {
+			repo := newRepo(newWSK("wsk-a", false, nil))
+
+			request := &modelsPodTemplateOptions.ListValuesRequest{
+				Context: modelsPodTemplateOptions.ListValuesContext{
+					Namespace: &modelsPodTemplateOptions.ContextNamespace{Name: "missing-ns"},
+				},
+			}
+
+			values, err := repo.ListPodTemplateOptionsValues(ctx, "wsk-a", request)
+			Expect(err).To(HaveOccurred())
+			Expect(helper.IsInternalValidationError(err)).To(BeTrue())
+			Expect(values).To(BeNil())
+
+			// the error must point at the caller's request body field, not a generic "namespace"
+			fieldErrs := helper.FieldErrorsFromInternalValidationError(err)
+			Expect(fieldErrs).To(HaveLen(1))
+			Expect(fieldErrs[0].Field).To(Equal("context.namespace.name"))
 		})
 	})
 })

--- a/workspaces/backend/internal/repositories/workspacekinds/repo_test.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspacekinds
+
+import (
+	"context"
+	"testing"
+
+	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
+)
+
+func TestWorkspaceKindRepository(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "WorkspaceKinds Repository Suite")
+}
+
+var _ = Describe("WorkspaceKindRepository.GetWorkspaceKinds", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(kubefloworgv1beta1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	// newWSK builds a minimal WorkspaceKind with the given name, admin-set hidden flag, and filterRules.
+	newWSK := func(name string, hidden bool, rules []kubefloworgv1beta1.FilterRule) *kubefloworgv1beta1.WorkspaceKind {
+		return &kubefloworgv1beta1.WorkspaceKind{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kubefloworgv1beta1.WorkspaceKindSpec{
+				Spawner:     kubefloworgv1beta1.WorkspaceKindSpawner{Hidden: new(hidden)},
+				FilterRules: rules,
+				PodTemplate: kubefloworgv1beta1.WorkspaceKindPodTemplate{
+					Options: kubefloworgv1beta1.WorkspaceKindPodOptions{
+						ImageConfig: kubefloworgv1beta1.ImageConfig{
+							Spawner: kubefloworgv1beta1.OptionsSpawnerConfig{Default: "img1"},
+							Values: []kubefloworgv1beta1.ImageConfigValue{
+								{Id: "img1", Spawner: kubefloworgv1beta1.OptionSpawnerInfo{DisplayName: "img1"}},
+							},
+						},
+						PodConfig: kubefloworgv1beta1.PodConfig{
+							Spawner: kubefloworgv1beta1.OptionsSpawnerConfig{Default: "pod1"},
+							Values: []kubefloworgv1beta1.PodConfigValue{
+								{Id: "pod1", Spawner: kubefloworgv1beta1.OptionSpawnerInfo{DisplayName: "pod1"}},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// wskRule builds a WORKSPACE_KIND-scoped rule that matches namespaces with the given labels.
+	wskRule := func(nsSelector map[string]string, effect kubefloworgv1beta1.FilterRuleEffect) kubefloworgv1beta1.FilterRule {
+		return kubefloworgv1beta1.FilterRule{
+			Scope:  kubefloworgv1beta1.FilterRuleScopeWorkspaceKind,
+			Effect: effect,
+			Match: []kubefloworgv1beta1.FilterRuleMatch{
+				{
+					MatchNamespace: &kubefloworgv1beta1.FilterRuleSelector{
+						Selector: metav1.LabelSelector{MatchLabels: nsSelector},
+					},
+				},
+			},
+		}
+	}
+
+	prodNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-ns", Labels: map[string]string{"tier": "prod"}},
+	}
+
+	// newRepo builds a repository backed by a fake client seeded with the given objects.
+	newRepo := func(objs ...client.Object) *WorkspaceKindRepository {
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		return NewWorkspaceKindRepository(&config.EnvConfig{}, cl, cl)
+	}
+
+	Context("no-namespaceFilter mode (admin listing)", func() {
+		It("returns all WorkspaceKinds without evaluating rules", func() {
+			wsk := newWSK("wsk-a", true, []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}}),
+			})
+			repo := newRepo(wsk, prodNamespace)
+
+			items, err := repo.GetWorkspaceKinds(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			// even though an api.hide rule matches prod, no namespaceFilter => not evaluated
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].Name).To(Equal("wsk-a"))
+			Expect(items[0].Hidden).To(BeTrue()) // admin-set value preserved
+			Expect(items[0].Restrictions).To(BeComparableTo(common.DefaultRestrictions()))
+		})
+	})
+
+	Context("namespace matching (ui.hide)", func() {
+		It("merges admin-set hidden with the ui.hide effect when namespace labels match", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}}),
+			}
+			repo := newRepo(newWSK("wsk-a", false, rules), prodNamespace)
+
+			items, err := repo.GetWorkspaceKinds(ctx, "prod-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].Hidden).To(BeTrue())
+		})
+
+		It("does not hide when the namespace does not exist (labels treated as absent)", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}}),
+			}
+			repo := newRepo(newWSK("wsk-a", false, rules))
+
+			items, err := repo.GetWorkspaceKinds(ctx, "missing-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].Hidden).To(BeFalse())
+		})
+	})
+
+	Context("api.hide omission", func() {
+		It("omits the WorkspaceKind from the response when a matching rule sets api.hide", func() {
+			hiddenWSK := newWSK("wsk-hidden", false, []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{API: &kubefloworgv1beta1.FilterRuleEffectAPI{Hide: new(true)}}),
+			})
+			visibleWSK := newWSK("wsk-visible", false, nil)
+			repo := newRepo(hiddenWSK, visibleWSK, prodNamespace)
+
+			items, err := repo.GetWorkspaceKinds(ctx, "prod-ns")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].Name).To(Equal("wsk-visible"))
+		})
+	})
+
+	Context("api.deny", func() {
+		It("returns the WorkspaceKind with restrictions populated from the api.deny effect", func() {
+			rules := []kubefloworgv1beta1.FilterRule{
+				wskRule(map[string]string{"tier": "prod"},
+					kubefloworgv1beta1.FilterRuleEffect{
+						API: &kubefloworgv1beta1.FilterRuleEffectAPI{
+							Deny:        new(true),
+							DenyMessage: &kubefloworgv1beta1.FilterRuleDenyMessage{Text: "not allowed in prod"},
+						},
+					}),
+			}
+			repo := newRepo(newWSK("wsk-a", false, rules), prodNamespace)
+
+			items, err := repo.GetWorkspaceKinds(ctx, "prod-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].Restrictions).To(BeComparableTo(common.Restrictions{
+				Deny:        true,
+				DenyMessage: &common.DenyMessage{Text: "not allowed in prod"},
+			}))
+		})
+	})
+})

--- a/workspaces/backend/internal/repositories/workspacekinds/repo_test.go
+++ b/workspaces/backend/internal/repositories/workspacekinds/repo_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/config"
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/helper"
 	"github.com/kubeflow/notebooks/workspaces/backend/internal/models/common"
 )
 
@@ -136,7 +137,7 @@ var _ = Describe("WorkspaceKindRepository.GetWorkspaceKinds", func() {
 			Expect(items[0].Hidden).To(BeTrue())
 		})
 
-		It("does not hide when the namespace does not exist (labels treated as absent)", func() {
+		It("returns a validation error when the namespaceFilter references a non-existent namespace", func() {
 			rules := []kubefloworgv1beta1.FilterRule{
 				wskRule(map[string]string{"tier": "prod"},
 					kubefloworgv1beta1.FilterRuleEffect{UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: true}}),
@@ -144,9 +145,9 @@ var _ = Describe("WorkspaceKindRepository.GetWorkspaceKinds", func() {
 			repo := newRepo(newWSK("wsk-a", false, rules))
 
 			items, err := repo.GetWorkspaceKinds(ctx, "missing-ns")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(items).To(HaveLen(1))
-			Expect(items[0].Hidden).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(helper.IsInternalValidationError(err)).To(BeTrue())
+			Expect(items).To(BeNil())
 		})
 	})
 

--- a/workspaces/controller/internal/webhook/workspacekind_webhook.go
+++ b/workspaces/controller/internal/webhook/workspacekind_webhook.go
@@ -706,13 +706,13 @@ func validateFilterRules(workspaceKind *kubefloworgv1beta1.WorkspaceKind) []*fie
 			}
 			if match.MatchImageConfig != nil {
 				if rule.Scope == kubefloworgv1beta1.FilterRuleScopeWorkspaceKind {
-					errs = append(errs, field.Invalid(conditionPath.Child("matchImageConfig"), match.MatchImageConfig, "'matchImageConfig' is only valid when 'scope' is 'POD_CONFIG' or 'IMAGE_CONFIG'"))
+					errs = append(errs, field.Invalid(conditionPath.Child("matchImageConfig"), "", "'matchImageConfig' is only valid when 'scope' is 'POD_CONFIG' or 'IMAGE_CONFIG'"))
 				}
 				errs = append(errs, v1validation.ValidateLabelSelector(&match.MatchImageConfig.Selector, selectorOpts, conditionPath.Child("matchImageConfig", "selector"))...)
 			}
 			if match.MatchPodConfig != nil {
 				if rule.Scope == kubefloworgv1beta1.FilterRuleScopeWorkspaceKind {
-					errs = append(errs, field.Invalid(conditionPath.Child("matchPodConfig"), match.MatchPodConfig, "'matchPodConfig' is only valid when 'scope' is 'POD_CONFIG' or 'IMAGE_CONFIG'"))
+					errs = append(errs, field.Invalid(conditionPath.Child("matchPodConfig"), "", "'matchPodConfig' is only valid when 'scope' is 'POD_CONFIG' or 'IMAGE_CONFIG'"))
 				}
 				errs = append(errs, v1validation.ValidateLabelSelector(&match.MatchPodConfig.Selector, selectorOpts, conditionPath.Child("matchPodConfig", "selector"))...)
 			}


### PR DESCRIPTION
Closes #847

## Summary

Implements **compatibility selectors** for the `/workspacekinds` API (issue #847),
building on the shared `filterrules` evaluation engine introduced in #846.

When a `namespaceFilter` is supplied, each WorkspaceKind's `spec.filterRules[]` with
`scope: WORKSPACE_KIND` are evaluated (first-match-wins) against the namespace's labels
to compute the per-WorkspaceKind `hidden` flag and `restrictions`, and to omit
`api.hide`'d kinds from the response entirely.

## Changes

- **`filterrules` engine**
  - Add `EvaluateWorkspaceFilterScopeRule(wsk, namespaceLabels)` to evaluate
    `WORKSPACE_KIND`-scoped rules against namespace labels.
  - Add `BuildEvalContextForImageAndPodCfg(...)` wrapper for the `/listvalues` path
    (`IMAGE_CONFIG` + `POD_CONFIG` scopes) and make `buildEvalContext` unexported.
  - Add `filterRulesByScope` so each endpoint only compiles the scopes it evaluates.
- **Model builder** (`NewWorkspaceKindModelFromWorkspaceKind`)
  - Evaluate rules first; return early (`apiHide=true`) when `api.hide` matches.
  - Merge admin-set `hidden` with the `ui.hide` effect (logical OR) and surface
    `restrictions` from `api.deny`.
- **Repository** (`GetWorkspaceKinds`)
  - Resolve namespace labels from `namespaceFilter` and omit `api.hide`'d kinds.
- **Handler**: pass the request namespace through to the repository.

## Behavior

| Scenario | Result |
| --- | --- |
| No `namespaceFilter` (admin listing) | `matchNamespace` rules do not fire; admin-set `hidden` preserved, no deny |
| `ui.hide` matches namespace | `hidden = adminHidden \|\| true` |
| `api.hide` matches namespace | WorkspaceKind omitted from response |
| `api.deny` matches namespace | `restrictions` populated with `deny` + `denyMessage` |

## Testing

Added unit tests at three layers:
- **Engine** — `EvaluateWorkspaceFilterScopeRule` and `BuildEvalContextForImageAndPodCfg`.
- **Model** — `ui.hide` / `api.hide` / `api.deny` via `matchNamespace`, plus admin-listing.
- **Repository** — end-to-end with a fake client (ui.hide, api.hide omission, api.deny,
  missing namespace).

All packages pass:
- internal/filterrules
- internal/models/workspacekinds
- internal/repositories/workspacekinds