### PR TITLE
feat: add Kind, Image Config, and Pod Config printer columns to Workspace CRD

### DIFF
--- a/workspaces/controller/api/v1beta1/workspace_types.go
+++ b/workspaces/controller/api/v1beta1/workspace_types.go
@@ -378,6 +378,9 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state",description="The current state of the Workspace"
+// +kubebuilder:printcolumn:name="Kind",type="string",JSONPath=".spec.kind",description="The WorkspaceKind of the Workspace"
+// +kubebuilder:printcolumn:name="Image Config",type="string",JSONPath=".spec.podTemplate.options.imageConfig",description="The imageConfig option of the Workspace"
+// +kubebuilder:printcolumn:name="Pod Config",type="string",JSONPath=".spec.podTemplate.options.podConfig",description="The podConfig option of the Workspace"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=ws
 

--- a/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspaces.yaml
+++ b/workspaces/controller/manifests/kustomize/base/crd/kubeflow.org_workspaces.yaml
@@ -21,6 +21,18 @@ spec:
       jsonPath: .status.state
       name: State
       type: string
+    - description: The WorkspaceKind of the Workspace
+      jsonPath: .spec.kind
+      name: Kind
+      type: string
+    - description: The imageConfig option of the Workspace
+      jsonPath: .spec.podTemplate.options.imageConfig
+      name: Image Config
+      type: string
+    - description: The podConfig option of the Workspace
+      jsonPath: .spec.podTemplate.options.podConfig
+      name: Pod Config
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
## What this does

Enriches the `kubectl get workspaces` and k9s output by adding three `additionalPrinterColumns` to the `Workspace` CRD, surfacing the same information the frontend workspace table already shows:

- **Kind**: the `WorkspaceKind` (`.spec.kind`)
- **Image Config**: the selected imageConfig option id (`.spec.podTemplate.options.imageConfig`)
- **Pod Config**: the selected podConfig option id (`.spec.podTemplate.options.podConfig`)

The existing **State** column is kept. All columns show in the default output (no `-o wide` needed).

## Before

```
$ kubectl get workspaces
NAME                   STATE
jupyterlab-workspace   Running
test                   Running
```

## After

```
$ kubectl get workspaces
NAME                   KIND         IMAGE CONFIG                POD CONFIG   STATE
jupyterlab-workspace   jupyterlab   jupyter-scipy:v1.10.0       tiny_cpu     Running
test                   codeserver   codeserver-python:v1.10.0   tiny_cpu     Running
```

## Notes

- The last activity was intentionally omitted: it is stored as epoch milliseconds, which kubectl's `type=date` columns cannot render as a friendly relative time.