### PR TITLE
fix: handle contextual pod config defaults

### DIFF
--- a/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
+++ b/workspaces/frontend/src/__tests__/cypress/cypress/tests/mocked/workspaces/createWorkspace.cy.ts
@@ -1630,6 +1630,75 @@ describe('Create workspace', () => {
       createWorkspace.findPodConfigCard(bigGpuPod.id).should('be.visible');
     });
 
+    it('should not select a pod config default hidden by image context', () => {
+      const hiddenSmallCpuPod: OptionsPodConfigValue = {
+        ...smallCpuPod,
+        hidden: true,
+      };
+
+      const kind = buildMockWorkspaceKind({
+        podTemplate: {
+          ...mockWorkspaceKind.podTemplate,
+          options: {
+            imageConfig: {
+              default: cpuImage.id,
+              values: [cpuImage, cudaImage],
+            },
+            podConfig: {
+              default: smallCpuPod.id,
+              values: [smallCpuPod, bigGpuPod],
+            },
+          },
+        },
+      });
+
+      cy.interceptApi(
+        'GET /api/:apiVersion/workspacekinds',
+        { path: { apiVersion: NOTEBOOKS_API_VERSION } },
+        mockModArchResponse([kind]),
+      ).as('getWorkspaceKindsListValues');
+
+      cy.intercept(
+        'POST',
+        `**/workspacekinds/${kind.name}/podtemplate/options/listvalues`,
+        (req) => {
+          const imageId = req.body?.data?.context?.imageConfig?.id;
+          const isCudaContext = imageId === cudaImage.id;
+
+          req.reply({
+            data: {
+              imageConfig: {
+                default: cpuImage.id,
+                values: imageId
+                  ? [cpuImage, cudaImage].filter((image) => image.id === imageId)
+                  : [cpuImage, cudaImage],
+              },
+              podConfig: {
+                default: smallCpuPod.id,
+                values: isCudaContext ? [hiddenSmallCpuPod, bigGpuPod] : [smallCpuPod, bigGpuPod],
+              },
+            },
+          });
+        },
+      );
+
+      createWorkspace.visit();
+      cy.wait('@getWorkspaceKindsListValues');
+
+      createWorkspace.selectKind(kind.name);
+      createWorkspace.clickNext();
+
+      createWorkspace.selectImage(cudaImage.id);
+      createWorkspace.clickNext();
+
+      createWorkspace.assertExtraFilterNotChecked('showHidden');
+      createWorkspace.findPodConfigCard(smallCpuPod.id).should('not.exist');
+      createWorkspace.findPodConfigCard(bigGpuPod.id).should('be.visible');
+
+      // The contextually hidden default must not remain selected.
+      cy.findByTestId('next-button').should('be.disabled');
+    });
+
     it('should show only CPU pod configs when listValues returns no GPU options', () => {
       const kind = buildMockWorkspaceKind({
         podTemplate: {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -50,6 +50,7 @@ import { submitFormData } from '~/app/pages/Workspaces/Form/submitHelper';
 import { WorkspaceFormSummaryPanel } from '~/app/pages/Workspaces/Form/WorkspaceFormSummaryPanel';
 import { WorkspaceFormRedirectConfirmModal } from '~/app/pages/Workspaces/Form/WorkspaceFormRedirectConfirmModal';
 import { validateName } from './helpers';
+import { resolveContextualDefaultId } from './utils/filterDefaults';
 
 enum WorkspaceFormSteps {
   KindSelection,
@@ -104,6 +105,24 @@ const WorkspaceForm: React.FC = () => {
       imageId: data.imageConfig,
     });
 
+  const effectivePodConfigDefaultId = useMemo(() => {
+    if (
+      !data.imageConfig ||
+      !allValuesLoaded ||
+      !filteredValuesLoaded ||
+      !allValuesData ||
+      !filteredValuesData
+    ) {
+      return undefined;
+    }
+
+    return resolveContextualDefaultId(
+      allValuesData.podConfig.values ?? [],
+      filteredValuesData.podConfig.values ?? [],
+      allValuesData.podConfig.default,
+    );
+  }, [data.imageConfig, allValuesLoaded, filteredValuesLoaded, allValuesData, filteredValuesData]);
+
   // Store original values for edit mode diff view
   const [originalData, setOriginalData] = useState<WorkspaceFormData | undefined>(undefined);
 
@@ -111,6 +130,7 @@ const WorkspaceForm: React.FC = () => {
   // Refs for filter control
   const imageFilterControlRef = useRef<ImageSelectionFilterHandle>(null);
   const podConfigFilterControlRef = useRef<PodConfigSelectionFilterHandle>(null);
+  const autoSelectedPodConfigRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!initialFormDataLoaded || mode === 'create') {
       return;
@@ -120,31 +140,65 @@ const WorkspaceForm: React.FC = () => {
     setOriginalData(initialFormData);
   }, [initialFormData, initialFormDataLoaded, mode, replaceData]);
 
-  // Apply default imageConfig and podConfig from listValues when a kind is first selected.
-  // Only sets defaults when the values are unset (undefined), so user selections are never overwritten.
+  // Apply the configured image default when a kind is first selected.
   useEffect(() => {
     if (!allValuesData || !allValuesLoaded || !data.kind) {
       return;
     }
+
     if (!data.imageConfig && allValuesData.imageConfig.default) {
       setData('imageConfig', allValuesData.imageConfig.default);
     }
-    if (!data.podConfig && allValuesData.podConfig.default) {
-      setData('podConfig', allValuesData.podConfig.default);
-    }
-  }, [allValuesData, allValuesLoaded, data.kind, data.imageConfig, data.podConfig, setData]);
+  }, [allValuesData, allValuesLoaded, data.kind, data.imageConfig, setData]);
 
-  // Clear podConfig when filtered values reload and the current selection is no longer compatible
+  // Apply the PodConfig default only after it has been evaluated
+  // against the selected image context.
+  useEffect(() => {
+    if (
+      !data.kind ||
+      !data.imageConfig ||
+      !filteredValuesLoaded ||
+      data.podConfig ||
+      !effectivePodConfigDefaultId
+    ) {
+      return;
+    }
+
+    autoSelectedPodConfigRef.current = effectivePodConfigDefaultId;
+    setData('podConfig', effectivePodConfigDefaultId);
+  }, [
+    data.kind,
+    data.imageConfig,
+    data.podConfig,
+    filteredValuesLoaded,
+    effectivePodConfigDefaultId,
+    setData,
+  ]);
+
+  // Clear incompatible PodConfig selections and auto-selected defaults
+  // that are no longer valid in the selected image context.
   useEffect(() => {
     if (!filteredValuesLoaded || !filteredValuesData || !data.podConfig) {
       return;
     }
+
     const podConfigOptions = filteredValuesData.podConfig.values ?? [];
     const isStillValid = podConfigOptions.some((pc) => pc.id === data.podConfig);
-    if (!isStillValid) {
+
+    const isAutoSelectedDefault = autoSelectedPodConfigRef.current === data.podConfig;
+    const isEffectiveDefault = effectivePodConfigDefaultId === data.podConfig;
+
+    if (!isStillValid || (isAutoSelectedDefault && !isEffectiveDefault)) {
+      autoSelectedPodConfigRef.current = undefined;
       setData('podConfig', undefined);
     }
-  }, [filteredValuesData, filteredValuesLoaded, data.podConfig, setData]);
+  }, [
+    filteredValuesData,
+    filteredValuesLoaded,
+    data.podConfig,
+    effectivePodConfigDefaultId,
+    setData,
+  ]);
 
   const onDisplayNameChange = useCallback(
     (value: string) => {
@@ -236,6 +290,7 @@ const WorkspaceForm: React.FC = () => {
         return;
       }
       if (mode === 'create') {
+        autoSelectedPodConfigRef.current = undefined;
         resetData();
         setData('kind', kind);
       }
@@ -259,6 +314,7 @@ const WorkspaceForm: React.FC = () => {
 
   const handlePodConfigSelect = useCallback(
     (podConfig: OptionsPodConfigValue | undefined) => {
+      autoSelectedPodConfigRef.current = undefined;
       if (podConfig) {
         if (podConfig.hidden || podConfig.redirect !== undefined) {
           podConfigFilterControlRef.current?.adaptFiltersForPodConfig(podConfig);
@@ -527,16 +583,14 @@ const WorkspaceForm: React.FC = () => {
                           title="Failed to load pod config options"
                           error={(filteredValuesError ?? allValuesError)!}
                         />
-                      ) : !(filteredValuesLoaded || allValuesLoaded) ? (
+                      ) : !filteredValuesLoaded ? (
                         <LoadingSpinner />
                       ) : (
                         <WorkspaceFormPodConfigSelection
                           selectedPodConfig={selectedPodConfig}
                           onSelect={handlePodConfigSelect}
-                          podConfigs={(filteredValuesData ?? allValuesData)?.podConfig.values ?? []}
-                          defaultPodConfigId={
-                            (filteredValuesData ?? allValuesData)?.podConfig.default
-                          }
+                          podConfigs={filteredValuesData?.podConfig.values ?? []}
+                          defaultPodConfigId={effectivePodConfigDefaultId}
                           filterControlRef={podConfigFilterControlRef}
                         />
                       ))}

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/filterDefaults.spec.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/__tests__/filterDefaults.spec.ts
@@ -1,4 +1,7 @@
-import { computeDefaultFilterValues } from '~/app/pages/Workspaces/Form/utils/filterDefaults';
+import {
+  computeDefaultFilterValues,
+  resolveContextualDefaultId,
+} from '~/app/pages/Workspaces/Form/utils/filterDefaults';
 
 describe('computeDefaultFilterValues', () => {
   it('should return false for both filters when no defaultId provided', () => {
@@ -130,5 +133,71 @@ describe('computeDefaultFilterValues', () => {
       showHidden: false,
       showRedirected: false,
     });
+  });
+});
+
+describe('resolveContextualDefaultId', () => {
+  const visibleDefault = {
+    id: 'tiny_cpu',
+    hidden: false,
+  };
+
+  const hiddenDefault = {
+    id: 'tiny_cpu',
+    hidden: true,
+  };
+
+  const visibleAlternative = {
+    id: 'big_gpu',
+    hidden: false,
+  };
+
+  it('should preserve a visible default that remains visible in the current context', () => {
+    const result = resolveContextualDefaultId(
+      [visibleDefault, visibleAlternative],
+      [visibleDefault, visibleAlternative],
+      'tiny_cpu',
+    );
+
+    expect(result).toBe('tiny_cpu');
+  });
+
+  it('should preserve a statically hidden default that remains hidden in the current context', () => {
+    const result = resolveContextualDefaultId(
+      [hiddenDefault, visibleAlternative],
+      [hiddenDefault, visibleAlternative],
+      'tiny_cpu',
+    );
+
+    expect(result).toBe('tiny_cpu');
+  });
+
+  it('should reject a visible default that becomes hidden in the current context', () => {
+    const result = resolveContextualDefaultId(
+      [visibleDefault, visibleAlternative],
+      [hiddenDefault, visibleAlternative],
+      'tiny_cpu',
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should reject a default that is removed from the current context', () => {
+    const result = resolveContextualDefaultId(
+      [visibleDefault, visibleAlternative],
+      [visibleAlternative],
+      'tiny_cpu',
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when no configured default is provided', () => {
+    const result = resolveContextualDefaultId(
+      [visibleDefault, visibleAlternative],
+      [visibleDefault, visibleAlternative],
+    );
+
+    expect(result).toBeUndefined();
   });
 });

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/utils/filterDefaults.ts
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/utils/filterDefaults.ts
@@ -23,3 +23,38 @@ export const computeDefaultFilterValues = <T extends OptionWithHiddenAndRedirect
     showRedirected: defaultOption.redirect !== undefined,
   };
 };
+
+type OptionWithHidden = {
+  id: string;
+  hidden: boolean;
+};
+
+/**
+ * Resolves whether the configured default remains valid in the current context.
+ *
+ * Preserves defaults that are already hidden in the unfiltered configuration,
+ * but rejects defaults that become hidden or are removed by contextual filtering.
+ */
+export const resolveContextualDefaultId = <T extends OptionWithHidden>(
+  allOptions: T[],
+  contextualOptions: T[],
+  defaultId?: string,
+): string | undefined => {
+  if (!defaultId) {
+    return undefined;
+  }
+
+  const configuredDefault = allOptions.find((option) => option.id === defaultId);
+  const contextualDefault = contextualOptions.find((option) => option.id === defaultId);
+
+  if (!configuredDefault || !contextualDefault) {
+    return undefined;
+  }
+
+  // It was visible in the unfiltered configuration, but became hidden in the current context.
+  if (!configuredDefault.hidden && contextualDefault.hidden) {
+    return undefined;
+  }
+
+  return defaultId;
+};


### PR DESCRIPTION
Fixes #1353

# What changed

PodConfig defaults are now evaluated against the selected image context before being automatically selected.

This prevents a configured default from remaining selected when dynamic filter rules make it hidden or remove it from the contextual `listValues` response.

The form now:

- resolves the effective PodConfig default using both unfiltered and image-contextual values
- preserves statically hidden defaults and their existing `Show hidden` behavior
- clears an auto-selected default when it becomes invalid for the selected image
- preserves explicit user selections separately from auto-selected defaults
- waits for contextual PodConfig values before rendering the PodConfig selection step

# Root cause

The form previously applied the PodConfig default from the unfiltered `listValues` response before image-context filtering was available.

With dynamic filter rules, the configured default could later become hidden or be removed while still remaining selected.

With `ui.hide`, this caused hidden PodConfigs to be revealed automatically.

With `ui.hide + api.hide`, the form could repeatedly apply and clear the default, resulting in flickering and a `Maximum update depth exceeded` error.

# Testing

## Manually reproduced both cases from #1353 before the fix

- `ui.hide`: hidden CPU PodConfigs were automatically revealed
<img width="1366" height="768" alt="1345_5_show_hidden" src="https://github.com/user-attachments/assets/260d1e5d-fcaa-447d-b01e-ffb4b234caaa" />

- `ui.hide + api.hide`: reproduced flickering and `Maximum update depth exceeded`

## Verified after the fix

- dynamically hidden defaults are no longer auto-selected
- `Show hidden` remains off for image-context-hidden defaults

- API-hidden defaults no longer cause the select/clear loop
- no flickering or maximum update-depth error
<img width="1366" height="768" alt="Screenshot from 2026-08-29 22-31-07" src="https://github.com/user-attachments/assets/dba1bf5c-b165-47c0-b01f-4a6351cf5426" />
<img width="1366" height="768" alt="Screenshot from 2026-08-29 22-33-16" src="https://github.com/user-attachments/assets/ebe03510-310e-4c68-af1e-bf09830e2e9e" />

- compatible GPU PodConfig remains selectable
- switching from CUDA back to the default SciPy image restores the valid default
- statically hidden and redirected default behavior remains unchanged

## Automated validation

- Jest: 457 tests passing
- targeted Cypress suites: 87 tests passing
- added regression coverage for an image-context-hidden PodConfig default
- TypeScript checks passing
- ESLint passing
- Prettier passing
- `git diff --check` clean

# Related implementation history

While tracing this issue, I found a few earlier changes that are closely related to the behavior fixed here:

- #948 / #957 introduced the hidden and redirected option UX for workspace image and PodConfig selection.
- #691 / #972 introduced the backend `listValues` API used to return image and PodConfig options for compatibility filtering.
- #861 / #1098 integrated `listValues` into `WorkspaceForm` using separate unfiltered (`allValuesData`) and image-contextual (`filteredValuesData`) responses. It also documented a previous default/deselect loop, which is closely related to the failure mode in #1353.
- #1144 / #1254 extended the workspace form's hidden/redirect handling and PodConfig revalidation when image context changes.