### PR TITLE
ci: harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -2,7 +2,6 @@ name: Approve Workflow Runs
 
 permissions:
   actions: write
-  contents: read
 
 on:
   pull_request_target:

--- a/.github/workflows/semantic-prs.yaml
+++ b/.github/workflows/semantic-prs.yaml
@@ -1,5 +1,8 @@
 name: Semantic PRs
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/ws-build-image.yml
+++ b/.github/workflows/ws-build-image.yml
@@ -1,5 +1,9 @@
 name: Build Image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

* Harden GitHub Actions workflows by explicitly declaring the minimum required `GITHUB_TOKEN` permissions.
* Restrict Semantic PR validation to `pull-requests: read`.
* Restrict workflow-run approval to `actions: write`.
* Retain `contents: read` for workflows that require repository contents.
* Retain `packages: write` for the reusable image workflow used to publish images to GHCR.
* Correct the `permissions` configuration in the affected workflows.

## Security impact

This change follows the principle of least privilege by limiting each workflow's `GITHUB_TOKEN` permissions to the capabilities required by the workflow.

This reduces the potential blast radius of a compromised workflow or third-party action.

## Validation

* Reviewed the GitHub API operations performed by the affected workflows.
* Confirmed workflow-run approval requires `actions: write`.
* Confirmed Semantic PR validation uses `pull-requests: read`.
* Confirmed image publishing requires `packages: write`.
* Confirmed CI workflows only require read access to repository contents.