### PR TITLE
fix: deduplicate workspace kind fetches

### DIFF
--- a/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
+++ b/workspaces/frontend/src/app/hooks/__tests__/useWorkspaceFormData.spec.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from '~/__tests__/unit/testUtils/hooks';
 import useWorkspaceFormData, { EMPTY_FORM_DATA } from '~/app/hooks/useWorkspaceFormData';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
-import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { NotebookApis } from '~/shared/api/notebookApi';
 import {
   buildMockWorkspace,
@@ -13,15 +12,11 @@ jest.mock('~/app/hooks/useNotebookAPI', () => ({
   useNotebookAPI: jest.fn(),
 }));
 
-jest.mock('~/app/hooks/useWorkspaceKinds', () => jest.fn());
-
 const mockUseNotebookAPI = useNotebookAPI as jest.MockedFunction<typeof useNotebookAPI>;
-const mockUseWorkspaceKinds = useWorkspaceKinds as jest.MockedFunction<typeof useWorkspaceKinds>;
 
 describe('useWorkspaceFormData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseWorkspaceKinds.mockReturnValue([[], false, undefined, jest.fn()]);
   });
 
   it('returns empty form data when missing namespace or name', async () => {
@@ -35,6 +30,9 @@ describe('useWorkspaceFormData', () => {
         namespace: undefined,
         workspaceName: undefined,
         workspaceKindName: undefined,
+        workspaceKinds: [],
+        workspaceKindsLoaded: false,
+        workspaceKindsError: undefined,
       }),
     );
     await waitForNextUpdate();
@@ -51,13 +49,15 @@ describe('useWorkspaceFormData', () => {
     });
 
     const kindsError = new Error('Failed to fetch workspace kinds');
-    mockUseWorkspaceKinds.mockReturnValue([[], false, kindsError, jest.fn()]);
 
     const { result, waitForNextUpdate } = renderHook(() =>
       useWorkspaceFormData({
         namespace: 'ns',
         workspaceName: 'my-workspace',
         workspaceKindName: 'jupyterlab',
+        workspaceKinds: [],
+        workspaceKindsLoaded: false,
+        workspaceKindsError: kindsError,
       }),
     );
     await waitForNextUpdate();
@@ -87,13 +87,14 @@ describe('useWorkspaceFormData', () => {
       refreshAllAPI: jest.fn(),
     });
 
-    mockUseWorkspaceKinds.mockReturnValue([[mockWorkspaceKind], true, undefined, jest.fn()]);
-
     const { result, waitForNextUpdate } = renderHook(() =>
       useWorkspaceFormData({
         namespace: 'ns',
         workspaceName: 'my-first-jupyter-notebook',
         workspaceKindName: mockWorkspaceKind.name,
+        workspaceKinds: [mockWorkspaceKind],
+        workspaceKindsLoaded: true,
+        workspaceKindsError: undefined,
       }),
     );
     await waitForNextUpdate();
@@ -126,7 +127,5 @@ describe('useWorkspaceFormData', () => {
       },
       revision: mockWorkspaceUpdate.revision,
     });
-
-    expect(mockUseWorkspaceKinds).toHaveBeenCalledWith('ns');
   });
 });

--- a/workspaces/frontend/src/app/hooks/useWorkspaceFormData.ts
+++ b/workspaces/frontend/src/app/hooks/useWorkspaceFormData.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import { FetchState, FetchStateCallbackPromise, useFetchState, NotReadyError } from 'mod-arch-core';
 import { useNotebookAPI } from '~/app/hooks/useNotebookAPI';
-import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { WorkspaceFormData } from '~/app/types';
+import { WorkspacekindsWorkspaceKindListItem } from '~/generated/data-contracts';
 
 export const EMPTY_FORM_DATA: WorkspaceFormData = {
   revision: '',
@@ -21,10 +21,19 @@ const useWorkspaceFormData = (args: {
   namespace: string | undefined;
   workspaceName: string | undefined;
   workspaceKindName: string | undefined;
+  workspaceKinds: WorkspacekindsWorkspaceKindListItem[];
+  workspaceKindsLoaded: boolean;
+  workspaceKindsError: Error | undefined;
 }): FetchState<WorkspaceFormData> => {
-  const { namespace, workspaceName, workspaceKindName } = args;
+  const {
+    namespace,
+    workspaceName,
+    workspaceKindName,
+    workspaceKinds,
+    workspaceKindsLoaded,
+    workspaceKindsError,
+  } = args;
   const { api, apiAvailable } = useNotebookAPI();
-  const [workspaceKinds, workspaceKindsLoaded, workspaceKindsError] = useWorkspaceKinds(namespace);
 
   const call = useCallback<FetchStateCallbackPromise<WorkspaceFormData>>(async () => {
     if (!apiAvailable) {

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx
@@ -33,6 +33,7 @@ import { WorkspaceFormPropertiesSelection } from '~/app/pages/Workspaces/Form/pr
 import { WorkspaceFormData } from '~/app/types';
 import usePodTemplateOptionsListValues from '~/app/hooks/usePodTemplateOptionsListValues';
 import useWorkspaceFormData from '~/app/hooks/useWorkspaceFormData';
+import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { useRedirectConfirmation } from '~/app/hooks/useRedirectConfirmation';
 import { useTypedNavigate } from '~/app/routerHelper';
 import {
@@ -77,10 +78,14 @@ const WorkspaceForm: React.FC = () => {
   const { api } = useNotebookAPI();
 
   const { mode, namespace, workspaceName, workspaceKindName } = useWorkspaceFormLocationData();
+  const [workspaceKinds, workspaceKindsLoaded, workspaceKindsError] = useWorkspaceKinds(namespace);
   const [initialFormData, initialFormDataLoaded, initialFormDataError] = useWorkspaceFormData({
     namespace,
     workspaceName,
     workspaceKindName,
+    workspaceKinds,
+    workspaceKindsLoaded,
+    workspaceKindsError,
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -502,7 +507,9 @@ const WorkspaceForm: React.FC = () => {
                     {currentStep === WorkspaceFormSteps.KindSelection && (
                       <WorkspaceFormKindSelection
                         mode={mode}
-                        namespace={namespace}
+                        workspaceKinds={workspaceKinds}
+                        workspaceKindsLoaded={workspaceKindsLoaded}
+                        workspaceKindsError={workspaceKindsError}
                         selectedKind={data.kind}
                         onSelect={handleKindSelect}
                       />

--- a/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Form/kind/WorkspaceFormKindSelection.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Content } from '@patternfly/react-core/dist/esm/components/Content';
-import useWorkspaceKinds from '~/app/hooks/useWorkspaceKinds';
 import { WorkspaceFormKindList } from '~/app/pages/Workspaces/Form/kind/WorkspaceFormKindList';
 import { WorkspacekindsWorkspaceKindListItem } from '~/generated/data-contracts';
 import { LoadingSpinner } from '~/app/components/LoadingSpinner';
@@ -9,24 +8,26 @@ import { WorkspaceFormMode } from '~/app/types';
 
 interface WorkspaceFormKindSelectionProps {
   mode: WorkspaceFormMode;
-  namespace?: string;
+  workspaceKinds: WorkspacekindsWorkspaceKindListItem[];
+  workspaceKindsLoaded: boolean;
+  workspaceKindsError: Error | undefined;
   selectedKind: WorkspacekindsWorkspaceKindListItem | undefined;
   onSelect: (kind: WorkspacekindsWorkspaceKindListItem | undefined) => void;
 }
 
 const WorkspaceFormKindSelection: React.FunctionComponent<WorkspaceFormKindSelectionProps> = ({
   mode,
-  namespace,
+  workspaceKinds,
+  workspaceKindsLoaded,
+  workspaceKindsError,
   selectedKind,
   onSelect,
 }) => {
-  const [workspaceKinds, loaded, error] = useWorkspaceKinds(namespace);
-
-  if (error) {
-    return <LoadError title="Failed to load workspace kinds" error={error} />;
+  if (workspaceKindsError) {
+    return <LoadError title="Failed to load workspace kinds" error={workspaceKindsError} />;
   }
 
-  if (!loaded) {
+  if (!workspaceKindsLoaded) {
     return <LoadingSpinner />;
   }
 


### PR DESCRIPTION
Fixes #1112

## What changed

`WorkspaceForm` now fetches WorkspaceKinds once and shares the result with:

- `useWorkspaceFormData`
- `WorkspaceFormKindSelection`

Previously, both called `useWorkspaceKinds` separately, causing duplicate `listWorkspaceKinds` requests.

## Validation

- reduced WorkspaceKind fetches from 2 logical calls to 1
- with React StrictMode enabled, network requests reduced from 4 to 2
- existing unit tests pass
- TypeScript, Prettier, and ESLint checks pass
- Cypress tests pass
- manually verified the Create Workspace flow

### Manual verification

With React StrictMode enabled, the Create Workspace form now makes 2 `workspacekinds` requests instead of 4.

#### Before

<img width="1366" height="768" alt="1367_Before" src="https://github.com/user-attachments/assets/063d30c3-9bee-4428-b52b-7b0f1e34fe91" />

#### After

<img width="1366" height="768" alt="1367_after" src="https://github.com/user-attachments/assets/55fe7f5e-a5f7-4b98-bf9a-24005d50330c" />
