### PR TITLE
fix: inherit permissions in reusable workflows

### DIFF
--- a/.github/workflows/ws-build-image.yml
+++ b/.github/workflows/ws-build-image.yml
@@ -1,8 +1,12 @@
 name: Build Image
 
-permissions:
-  contents: read
-  packages: write
+# NOTE: There is no `permissions` key set in this workflow on purpose:
+#
+# A reusable workflow may only request permissions its caller already grants,
+# and the need for `packages: write` depends on the caller. However, setting
+# `packages: write` breaks validation for callers that only grant
+# `contents: read`, and declaring anything here caps the token at those
+# permissions, which would break the publish flow.
 
 on:
   workflow_call:


### PR DESCRIPTION
A reusable workflow may only request permissions its caller already grants, and whether it needs `packages: write` depends on the caller, only `ws-publish.yml` pushes images, and it declares `packages: write` itself.

Fixes #1368

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
