### PR TITLE
fix: expose WorkspaceKind filterRules in backend API

### DIFF
--- a/workspaces/backend/api/workspacekinds_handler_test.go
+++ b/workspaces/backend/api/workspacekinds_handler_test.go
@@ -1077,6 +1077,24 @@ metadata:
 
 		var wskName string
 
+		newFilterRule := func(hide bool) kubefloworgv1beta1.FilterRule {
+			return kubefloworgv1beta1.FilterRule{
+				Scope: kubefloworgv1beta1.FilterRuleScopeImageConfig,
+				Effect: kubefloworgv1beta1.FilterRuleEffect{
+					UI: &kubefloworgv1beta1.FilterRuleEffectUI{Hide: hide},
+				},
+				Match: []kubefloworgv1beta1.FilterRuleMatch{
+					{
+						MatchImageConfig: &kubefloworgv1beta1.FilterRuleSelector{
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"gpu": "true"},
+							},
+						},
+					},
+				},
+			}
+		}
+
 		getWorkspaceKindData := func(name string) *models.WorkspaceKindUpdate {
 			getReq, err := http.NewRequest(http.MethodGet, strings.Replace(constants.WorkspaceKindsByNamePath, ":"+constants.ResourceNamePathParam, name, 1), http.NoBody)
 			Expect(err).NotTo(HaveOccurred())
@@ -1111,6 +1129,9 @@ metadata:
 
 			By("creating the WorkspaceKind")
 			wsk := NewExampleWorkspaceKind(wskName)
+			wsk.Spec.FilterRules = []kubefloworgv1beta1.FilterRule{
+				newFilterRule(true),
+			}
 			Expect(k8sClient.Create(ctx, wsk)).To(Succeed())
 
 			By("getting the revision via GET")
@@ -1383,6 +1404,93 @@ metadata:
 			wsk := &kubefloworgv1beta1.WorkspaceKind{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wskName}, wsk)).To(Succeed())
 			Expect(wsk.Spec.ActivityRules).To(BeEmpty())
+		})
+
+		It("should include filterRules in the WorkspaceKind GET response", func() {
+			By("getting the WorkspaceKind through the API")
+			getData := getWorkspaceKindData(wskName)
+
+			By("verifying filterRules are included in the response")
+			Expect(getData.FilterRules).To(BeComparableTo(
+				[]kubefloworgv1beta1.FilterRule{newFilterRule(true)},
+			))
+		})
+
+		It("should edit existing filterRules and persist the change", func() {
+			By("getting current data")
+			getData := getWorkspaceKindData(wskName)
+			Expect(getData.FilterRules).To(BeComparableTo(
+				[]kubefloworgv1beta1.FilterRule{newFilterRule(true)},
+			))
+
+			By("modifying the existing filter rule")
+			getData.FilterRules[0].Effect.UI.Hide = false
+
+			dataJSON, err := json.Marshal(getData)
+			Expect(err).NotTo(HaveOccurred())
+			updateBody := fmt.Sprintf(`{"data": %s}`, string(dataJSON))
+
+			By("executing update")
+			rr := doUpdate(wskName, updateBody)
+			Expect(rr.Result().StatusCode).To(
+				Equal(http.StatusOK),
+				descUnexpectedHTTPStatus,
+				rr.Body.String(),
+			)
+
+			By("verifying the change persists via GET")
+			updatedData := getWorkspaceKindData(wskName)
+			Expect(updatedData.FilterRules).To(BeComparableTo(
+				[]kubefloworgv1beta1.FilterRule{newFilterRule(false)},
+			))
+
+			By("verifying the CRD was updated in Kubernetes")
+			wsk := &kubefloworgv1beta1.WorkspaceKind{}
+			Expect(k8sClient.Get(
+				ctx,
+				types.NamespacedName{Name: wskName},
+				wsk,
+			)).To(Succeed())
+
+			Expect(wsk.Spec.FilterRules).To(BeComparableTo(
+				[]kubefloworgv1beta1.FilterRule{newFilterRule(false)},
+			))
+		})
+
+		It("should clear filterRules when omitted from update", func() {
+			By("getting current data")
+			getData := getWorkspaceKindData(wskName)
+			Expect(getData.FilterRules).To(BeComparableTo(
+				[]kubefloworgv1beta1.FilterRule{newFilterRule(false)},
+			))
+
+			By("setting filterRules to nil to simulate omission")
+			getData.FilterRules = nil
+
+			dataJSON, err := json.Marshal(getData)
+			Expect(err).NotTo(HaveOccurred())
+			updateBody := fmt.Sprintf(`{"data": %s}`, string(dataJSON))
+
+			By("executing update")
+			rr := doUpdate(wskName, updateBody)
+			Expect(rr.Result().StatusCode).To(
+				Equal(http.StatusOK),
+				descUnexpectedHTTPStatus,
+				rr.Body.String(),
+			)
+
+			By("verifying filterRules are cleared via GET")
+			updatedData := getWorkspaceKindData(wskName)
+			Expect(updatedData.FilterRules).To(BeEmpty())
+
+			By("verifying the CRD was updated in Kubernetes")
+			wsk := &kubefloworgv1beta1.WorkspaceKind{}
+			Expect(k8sClient.Get(
+				ctx,
+				types.NamespacedName{Name: wskName},
+				wsk,
+			)).To(Succeed())
+			Expect(wsk.Spec.FilterRules).To(BeEmpty())
 		})
 
 		It("should return 404 for a non-existent WorkspaceKind", func() {

--- a/workspaces/backend/internal/models/workspacekinds/funcs_write.go
+++ b/workspaces/backend/internal/models/workspacekinds/funcs_write.go
@@ -40,6 +40,7 @@ func NewWorkspaceKindUpdateModelFromWorkspaceKind(wsk *kubefloworgv1beta1.Worksp
 		Spawner:       wsk.Spec.Spawner,
 		PodTemplate:   wsk.Spec.PodTemplate,
 		ActivityRules: wsk.Spec.ActivityRules,
+		FilterRules:   wsk.Spec.FilterRules,
 	}
 }
 
@@ -49,4 +50,5 @@ func ApplyWorkspaceKindUpdateModelToWorkspaceKind(update *WorkspaceKindUpdate, w
 	wsk.Spec.Spawner = update.Spawner
 	wsk.Spec.PodTemplate = update.PodTemplate
 	wsk.Spec.ActivityRules = update.ActivityRules
+	wsk.Spec.FilterRules = update.FilterRules
 }

--- a/workspaces/backend/internal/models/workspacekinds/types_write.go
+++ b/workspaces/backend/internal/models/workspacekinds/types_write.go
@@ -42,6 +42,7 @@ type WorkspaceKindUpdate struct {
 	Spawner       kubefloworgv1beta1.WorkspaceKindSpawner     `json:"spawner"`
 	PodTemplate   kubefloworgv1beta1.WorkspaceKindPodTemplate `json:"podTemplate"`
 	ActivityRules []kubefloworgv1beta1.ActivityRule           `json:"activityRules,omitempty"`
+	FilterRules   []kubefloworgv1beta1.FilterRule             `json:"filterRules,omitempty"`
 }
 
 // Validate performs validation on the WorkspaceKindUpdate struct

--- a/workspaces/backend/openapi/docs.go
+++ b/workspaces/backend/openapi/docs.go
@@ -6684,6 +6684,163 @@ const docTemplate = `{
                 }
             }
         },
+        "v1beta1.FilterRule": {
+            "type": "object",
+            "required": [
+                "effect",
+                "match",
+                "scope"
+            ],
+            "properties": {
+                "effect": {
+                    "description": "the effect to apply to matched items when all ` + "`" + `match` + "`" + ` conditions are satisfied",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleEffect"
+                        }
+                    ]
+                },
+                "match": {
+                    "description": "the conditions which must ALL be satisfied for the rule to apply\n+kubebuilder:validation:MinItems:=1\n+listType:=\"atomic\"",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1beta1.FilterRuleMatch"
+                    }
+                },
+                "scope": {
+                    "description": "the type of resource whose visibility this rule controls",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleScope"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.FilterRuleDenyMessage": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "description": "the text of the message to show when the item is denied\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=1024",
+                    "type": "string"
+                }
+            }
+        },
+        "v1beta1.FilterRuleEffect": {
+            "type": "object",
+            "properties": {
+                "api": {
+                    "description": "server-enforced behavior evaluated by the backend API server\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleEffectAPI"
+                        }
+                    ]
+                },
+                "ui": {
+                    "description": "rendering hints for the frontend (the item is still returned by the API)\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleEffectUI"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.FilterRuleEffectAPI": {
+            "type": "object",
+            "properties": {
+                "deny": {
+                    "description": "return the matched item but reject any workspace create/update which selects it\n+kubebuilder:validation:Optional",
+                    "type": "boolean"
+                },
+                "denyMessage": {
+                    "description": "a message explaining why the matched item is denied\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleDenyMessage"
+                        }
+                    ]
+                },
+                "hide": {
+                    "description": "omit the matched item from the API response entirely\n+kubebuilder:validation:Optional",
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1beta1.FilterRuleEffectUI": {
+            "type": "object",
+            "required": [
+                "hide"
+            ],
+            "properties": {
+                "hide": {
+                    "description": "suggest the UI hide the matched item",
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1beta1.FilterRuleMatch": {
+            "type": "object",
+            "properties": {
+                "matchImageConfig": {
+                    "description": "match against the ` + "`" + `spawner.labels` + "`" + ` of an imageConfig value\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleSelector"
+                        }
+                    ]
+                },
+                "matchNamespace": {
+                    "description": "match against the labels of the namespace the workspace would be created in\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleSelector"
+                        }
+                    ]
+                },
+                "matchPodConfig": {
+                    "description": "match against the ` + "`" + `spawner.labels` + "`" + ` of a podConfig value\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleSelector"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.FilterRuleScope": {
+            "type": "string",
+            "enum": [
+                "WORKSPACE_KIND",
+                "POD_CONFIG",
+                "IMAGE_CONFIG"
+            ],
+            "x-enum-varnames": [
+                "FilterRuleScopeWorkspaceKind",
+                "FilterRuleScopePodConfig",
+                "FilterRuleScopeImageConfig"
+            ]
+        },
+        "v1beta1.FilterRuleSelector": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "description": "a standard Kubernetes label selector",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.LabelSelector"
+                        }
+                    ]
+                }
+            }
+        },
         "v1beta1.HTTPProxy": {
             "type": "object",
             "properties": {
@@ -7796,6 +7953,12 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/v1beta1.ActivityRule"
+                    }
+                },
+                "filterRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1beta1.FilterRule"
                     }
                 },
                 "podTemplate": {

--- a/workspaces/backend/openapi/swagger.json
+++ b/workspaces/backend/openapi/swagger.json
@@ -6682,6 +6682,163 @@
                 }
             }
         },
+        "v1beta1.FilterRule": {
+            "type": "object",
+            "required": [
+                "effect",
+                "match",
+                "scope"
+            ],
+            "properties": {
+                "effect": {
+                    "description": "the effect to apply to matched items when all `match` conditions are satisfied",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleEffect"
+                        }
+                    ]
+                },
+                "match": {
+                    "description": "the conditions which must ALL be satisfied for the rule to apply\n+kubebuilder:validation:MinItems:=1\n+listType:=\"atomic\"",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1beta1.FilterRuleMatch"
+                    }
+                },
+                "scope": {
+                    "description": "the type of resource whose visibility this rule controls",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleScope"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.FilterRuleDenyMessage": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "description": "the text of the message to show when the item is denied\n+kubebuilder:validation:MinLength:=2\n+kubebuilder:validation:MaxLength:=1024",
+                    "type": "string"
+                }
+            }
+        },
+        "v1beta1.FilterRuleEffect": {
+            "type": "object",
+            "properties": {
+                "api": {
+                    "description": "server-enforced behavior evaluated by the backend API server\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleEffectAPI"
+                        }
+                    ]
+                },
+                "ui": {
+                    "description": "rendering hints for the frontend (the item is still returned by the API)\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleEffectUI"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.FilterRuleEffectAPI": {
+            "type": "object",
+            "properties": {
+                "deny": {
+                    "description": "return the matched item but reject any workspace create/update which selects it\n+kubebuilder:validation:Optional",
+                    "type": "boolean"
+                },
+                "denyMessage": {
+                    "description": "a message explaining why the matched item is denied\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleDenyMessage"
+                        }
+                    ]
+                },
+                "hide": {
+                    "description": "omit the matched item from the API response entirely\n+kubebuilder:validation:Optional",
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1beta1.FilterRuleEffectUI": {
+            "type": "object",
+            "required": [
+                "hide"
+            ],
+            "properties": {
+                "hide": {
+                    "description": "suggest the UI hide the matched item",
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1beta1.FilterRuleMatch": {
+            "type": "object",
+            "properties": {
+                "matchImageConfig": {
+                    "description": "match against the `spawner.labels` of an imageConfig value\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleSelector"
+                        }
+                    ]
+                },
+                "matchNamespace": {
+                    "description": "match against the labels of the namespace the workspace would be created in\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleSelector"
+                        }
+                    ]
+                },
+                "matchPodConfig": {
+                    "description": "match against the `spawner.labels` of a podConfig value\n+kubebuilder:validation:Optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1beta1.FilterRuleSelector"
+                        }
+                    ]
+                }
+            }
+        },
+        "v1beta1.FilterRuleScope": {
+            "type": "string",
+            "enum": [
+                "WORKSPACE_KIND",
+                "POD_CONFIG",
+                "IMAGE_CONFIG"
+            ],
+            "x-enum-varnames": [
+                "FilterRuleScopeWorkspaceKind",
+                "FilterRuleScopePodConfig",
+                "FilterRuleScopeImageConfig"
+            ]
+        },
+        "v1beta1.FilterRuleSelector": {
+            "type": "object",
+            "required": [
+                "selector"
+            ],
+            "properties": {
+                "selector": {
+                    "description": "a standard Kubernetes label selector",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/v1.LabelSelector"
+                        }
+                    ]
+                }
+            }
+        },
         "v1beta1.HTTPProxy": {
             "type": "object",
             "properties": {
@@ -7794,6 +7951,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/v1beta1.ActivityRule"
+                    }
+                },
+                "filterRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v1beta1.FilterRule"
                     }
                 },
                 "podTemplate": {


### PR DESCRIPTION
## What changed

Expose `filterRules` through the WorkspaceKind GET/PUT API.

The backend now:

- returns `filterRules` from GET
- persists changes through PUT
- supports clearing existing rules

Regression tests cover reading, editing, and clearing `filterRules`.

## Why

This follows up on the `filterRules` issue found while validating #1365.

The field existed in the WorkspaceKind CR, but the backend update model did not expose it, so it was missing from the WorkspaceKind Edit YAML.

Related discussion: https://github.com/kubeflow/notebooks/pull/1365#issuecomment-5496385595

## Frontend follow-up

This PR only contains the backend API change.

After this is merged, the frontend API client can be regenerated against the merged backend SHA, followed by the small frontend change in a separate PR.

Related: #1372