### PR TITLE
feat: simulate GPUs in Tilt via the fake-gpu-operator

### DIFF
--- a/developing/DEVELOPMENT_GUIDE.md
+++ b/developing/DEVELOPMENT_GUIDE.md
@@ -116,6 +116,9 @@ ENABLE_PROMETHEUS=true make tilt-up
 
 # OPTION 3: run with metrics-server enabled (kubectl top verification)
 ENABLE_METRICS_SERVER=true make tilt-up
+
+# OPTION 4: run with simulated GPUs enabled (schedule GPU workspaces without hardware)
+ENABLE_FAKE_GPU=true make tilt-up
 ```
 
 What this does:
@@ -239,6 +242,40 @@ Example log entry:
     "upstream": "10.244.1.9:4000"
 }
 ```
+
+### Tilt - Simulating GPUs
+
+The sample WorkspaceKinds ship a `big_gpu` podConfig that requests `nvidia.com/gpu: 1`, but the local Kind cluster advertises no GPU capacity, so GPU workspaces stay `Pending` forever. Setting `ENABLE_FAKE_GPU=true` installs the [fake-gpu-operator](https://github.com/run-ai/fake-gpu-operator) (FGO), which simulates GPUs at the Kubernetes API level — no driver and no hardware:
+
+```bash
+cd developing
+ENABLE_FAKE_GPU=true make tilt-up
+```
+
+This labels the worker node, installs FGO (via Helm) into the `gpu-operator` namespace, and makes the worker advertise one simulated GPU. `helm` must be installed for this path; the default `make tilt-up` does not require it.
+
+The GPU workspace options are already defined on the sample WorkspaceKinds, which Tilt does not apply automatically. Apply them, then create a GPU workspace (`spec.podTemplate.options.podConfig: big_gpu`) via the UI spawner or `kubectl`:
+
+```bash
+kubectl apply -k workspaces/controller/manifests/kustomize/samples
+```
+
+Verify:
+
+```bash
+# 1. The worker advertises GPU capacity
+kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:'.status.capacity.nvidia\.com/gpu'
+
+# 2. FGO's pods are running
+kubectl get pods -n gpu-operator
+
+# 3. A GPU workspace pod schedules (not Pending) and sees a fake GPU
+kubectl exec <workspace-pod> -- nvidia-smi
+```
+
+> [!NOTE]
+>
+> FGO provides a fake `nvidia-smi` and `nvidia.com/gpu` scheduling only — there is no real device. Do not co-install it alongside a real NVIDIA GPU operator or device plugin.
 
 ### Tilt - Clean Up
 

--- a/developing/Makefile
+++ b/developing/Makefile
@@ -27,6 +27,21 @@ check-tilt:
 		exit 1; \
 	fi
 
+# Check if helm is installed (only required for the ENABLE_FAKE_GPU path).
+# Hard-fail when ENABLE_FAKE_GPU=true, otherwise warn and continue so the
+# default `make tilt-up` does not require helm.
+.PHONY: check-helm
+check-helm:
+	@if ! command -v helm >/dev/null 2>&1; then \
+		if [ "$$ENABLE_FAKE_GPU" = "true" ]; then \
+			echo "ERROR: helm is required for ENABLE_FAKE_GPU=true. Please install helm first:"; \
+			echo "  https://helm.sh/docs/intro/install/"; \
+			exit 1; \
+		else \
+			echo "WARNING: helm is not installed; ENABLE_FAKE_GPU will be unavailable."; \
+		fi; \
+	fi
+
 # Ensure kind cluster exists and context is set before running tilt
 .PHONY: setup-kind
 setup-kind:
@@ -60,9 +75,15 @@ setup-metrics-server:
 	@echo "Setting up metrics-server..."
 	@export PATH="$(LOCALBIN):$$PATH" && ./scripts/setup-metrics-server.sh
 
+# Install the fake-gpu-operator to simulate GPUs (optional, gated by ENABLE_FAKE_GPU)
+.PHONY: setup-fake-gpu-operator
+setup-fake-gpu-operator:
+	@echo "Setting up fake-gpu-operator..."
+	@export PATH="$(LOCALBIN):$$PATH" && ./scripts/setup-fake-gpu-operator.sh
+
 # Run tilt up with kind cluster, cert-manager, and Istio setup
 .PHONY: tilt-up
-tilt-up: kustomize check-tilt setup-kind setup-istio setup-prometheus setup-metrics-server
+tilt-up: kustomize check-tilt check-helm setup-kind setup-istio setup-prometheus setup-metrics-server setup-fake-gpu-operator
 	@echo "Starting Tilt..."
 	@tilt up
 

--- a/developing/manifests/fake-gpu-operator/fgo.values.yaml
+++ b/developing/manifests/fake-gpu-operator/fgo.values.yaml
@@ -1,0 +1,26 @@
+# Helm values for the run-ai/fake-gpu-operator (FGO) in the Tilt dev cluster.
+#
+# FGO simulates NVIDIA GPUs at the Kubernetes API level: a device-plugin
+# DaemonSet advertises `nvidia.com/gpu` capacity on labeled nodes and injects a
+# fake `nvidia-smi` into GPU pods. No driver and no hardware are required, so
+# GPU workspaces (e.g. the `big_gpu` podConfig) schedule and run locally.
+#
+# Consumed by developing/scripts/setup-fake-gpu-operator.sh (ENABLE_FAKE_GPU=true).
+
+# A single node pool named "integration", matched to the worker(s) via the
+# `run.ai/simulated-gpu-node-pool=integration` node label the setup script
+# applies. We advertise one A100 so the sample `big_gpu` podConfig
+# (limits: nvidia.com/gpu: 1) can schedule.
+topology:
+  nodePools:
+    integration:
+      gpuProduct: NVIDIA-A100-SXM4-40GB
+      gpuCount: 1
+      gpuMemory: 40960  # MiB
+  nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+
+# builtinProfiles ships the gpu-profile ConfigMaps FGO's fake `nvidia-smi`
+# reads for the products above. Left at its chart default (true); stated here
+# to document that the in-pod tooling relies on it.
+builtinProfiles:
+  enabled: true

--- a/developing/scripts/setup-fake-gpu-operator.sh
+++ b/developing/scripts/setup-fake-gpu-operator.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# Setup script for the run-ai/fake-gpu-operator (FGO).
+# This installs FGO into the Kind cluster so GPU workspaces (e.g. the sample
+# `big_gpu` podConfig) can schedule and run without real GPU hardware: FGO's
+# device-plugin advertises `nvidia.com/gpu` capacity on the labeled worker and
+# injects a fake `nvidia-smi` into GPU pods.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVELOPING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Chart pinned during the validation spike (matches its published topology
+# schema: topology.nodePools.<pool>.{gpuProduct,gpuCount,gpuMemory}).
+FGO_CHART="oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator"
+FGO_VERSION="0.2.0"
+NAMESPACE="gpu-operator"
+
+# Do nothing if ENABLE_FAKE_GPU is not set to true
+if [[ "${ENABLE_FAKE_GPU:-false}" != "true" ]]; then
+  echo ""
+  echo ""
+  echo "INFO: fake-gpu-operator setup is disabled. Set ENABLE_FAKE_GPU=true to enable."
+  echo ""
+  echo ""
+  exit 0
+fi
+
+# helm is only required for the GPU path, so we check for it here rather than
+# as a global prerequisite.
+if ! command -v helm >/dev/null 2>&1; then
+  echo "ERROR: helm is required for ENABLE_FAKE_GPU=true. Please install helm first:"
+  echo "  https://helm.sh/docs/intro/install/"
+  exit 1
+fi
+
+# ================================
+# Sanity checks: refuse to run alongside a real NVIDIA GPU stack
+# ================================
+# FGO simulates GPUs at the API level. Co-installing it with the real NVIDIA
+# GPU Operator or a real device plugin produces conflicting nvidia.com/gpu
+# advertisements, so bail out (before mutating anything) if we detect one.
+
+# 1. The real NVIDIA GPU Operator / device plugin ships these DaemonSets; FGO
+#    never creates them (its own device-plugin DaemonSet is named "device-plugin").
+if kubectl get daemonset --all-namespaces \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+  | grep -Eqx 'nvidia-driver-daemonset|nvidia-device-plugin-daemonset'; then
+  echo "ERROR: a real NVIDIA GPU Operator / device plugin appears to be installed"
+  echo "       (found an 'nvidia-driver-daemonset' or 'nvidia-device-plugin-daemonset')."
+  echo "       Refusing to install the fake-gpu-operator alongside real GPU tooling."
+  exit 1
+fi
+
+# 2. No node should already advertise nvidia.com/gpu capacity, unless it came
+#    from a previous run of this script (i.e. our own FGO release exists). GPU
+#    capacity on a node this script hasn't touched means real hardware or a real
+#    device plugin is present.
+if ! helm status fgo -n "${NAMESPACE}" >/dev/null 2>&1; then
+  # `|| true` keeps `set -e`/`pipefail` from aborting when grep finds no GPU node.
+  GPU_NODES="$(kubectl get nodes \
+    -o jsonpath='{range .items[*]}{.metadata.name}={.status.capacity.nvidia\.com/gpu}{"\n"}{end}' 2>/dev/null \
+    | grep -E '=[1-9][0-9]*$' | cut -d= -f1 | tr '\n' ' ' || true)"
+  if [[ -n "${GPU_NODES// }" ]]; then
+    echo "ERROR: node(s) already advertise nvidia.com/gpu capacity: ${GPU_NODES}"
+    echo "       This script has not installed the fake-gpu-operator here, so real"
+    echo "       GPUs or a real device plugin may be present. Refusing to continue."
+    exit 1
+  fi
+fi
+
+# ================================
+# Namespace + Pod Security Admission
+# ================================
+# FGO's device-plugin runs privileged pods, so the namespace must permit them.
+echo "Ensuring namespace '${NAMESPACE}' exists with privileged Pod Security..."
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "${NAMESPACE}" \
+  pod-security.kubernetes.io/enforce=privileged --overwrite
+
+# ================================
+# Label the worker node(s)
+# ================================
+# FGO assigns nodes to the "integration" pool (see fgo.values.yaml) by this
+# label. Applied at runtime; no node recreate is needed.
+echo "Labeling worker node(s) for the 'integration' GPU node pool..."
+kubectl label node -l '!node-role.kubernetes.io/control-plane' \
+  run.ai/simulated-gpu-node-pool=integration --overwrite
+
+# ================================
+# Install the fake-gpu-operator
+# ================================
+echo "Installing/upgrading fake-gpu-operator (${FGO_VERSION})..."
+helm upgrade -i fgo "${FGO_CHART}" \
+  --namespace "${NAMESPACE}" \
+  --version "${FGO_VERSION}" \
+  -f "${DEVELOPING_DIR}/manifests/fake-gpu-operator/fgo.values.yaml" \
+  --wait
+
+# ================================
+# Wait for GPU capacity to appear
+# ================================
+echo "Waiting for the worker to advertise nvidia.com/gpu capacity..."
+until kubectl get node -l run.ai/simulated-gpu-node-pool=integration \
+  -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}' 2>/dev/null | grep -q '[1-9]'; do
+  echo "... (no GPU capacity yet)"
+  sleep 3
+done
+
+echo "fake-gpu-operator setup complete"
+kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:'.status.capacity.nvidia\.com/gpu'


### PR DESCRIPTION
The sample WorkspaceKinds ship a `big_gpu` podConfig that requests
`nvidia.com/gpu: 1`, but the local Kind cluster might not even have GPU
resources available, resulting in a degraded experience for some
developers.

Add an opt-in dev integration of `run-ai/fake-gpu-operator`, which
simulates GPUs at the Kubernetes API level: its device-plugin advertises
`nvidia.com/gpu` capacity on the labeled worker and injects a fake
`nvidia-smi` into GPU pods.

---

```
$ kubectl describe node tilt-worker
Capacity:
  cpu:                32
  ephemeral-storage:  3905992Mi
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             131155720Ki
  nvidia.com/gpu:     1
  pods:               110
Allocatable:
  cpu:                32
  ephemeral-storage:  3905992Mi
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             131155720Ki
  nvidia.com/gpu:     1
  pods:               110
```
This way we can simulate a A10 GPU to the notebook:
```
(base) jovyan@ws-test-6sppp-0:~$ nvidia-smi
Mon Sep  7 12:32:56 2026
+------------------------------------------------------------------------------+
| NVIDIA-SMI 470.129.06   Driver Version: 470.129.06   CUDA Version: 11.4      |
+--------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                |                      |               MIG M. |
+--------------------------------+----------------------+----------------------+
|   0  NVIDIA-A10..          Off | 00000001:00:00.0 Off |                  Off |
| N/A   33C    P8    11W /  70W  |  40960MiB / 40960MiB |     100%     Default |
|                                |                      |                  N/A |
+--------------------------------+----------------------+----------------------+

+------------------------------------------------------------------------------+
| Processes:                                                                   |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory  |
|        ID   ID                                                   Usage       |
+------------------------------------------------------------------------------+
|    0   N/A  N/A       150      G   /package/admin/s6/command/s..    40960MiB |
+------------------------------------------------------------------------------+
```

This works even though the KinD cluster is running on an AMD machine:
```
$ inxi -G
Graphics:
  Device-1: Advanced Micro Devices [AMD/ATI] Strix Halo [Radeon Graphics / Radeon 8050S 8060S
    Graphics] driver: amdgpu v: kernel
  Display: unspecified server: X.org v: 1.21.1.24 with: Xwayland v: 24.1.13 driver: X:
    loaded: amdgpu unloaded: modesetting dri: radeonsi gpu: amdgpu tty: 180x48 resolution:
    1: 1920x1080 2: 1920x1080
  API: EGL v: 1.5 drivers: radeonsi,swrast platforms: gbm,wayland,surfaceless,device
  API: OpenGL v: 4.6 vendor: mesa v: 26.2.2-arch1.1 note: console (EGL sourced) renderer: AMD
    Radeon 8060S Graphics (radeonsi strix_halo ACO DRM 3.64 7.3.0-rc1-1-mainline), llvmpipe (LLVM
    22.1.8 256 bits)
  API: Vulkan v: 1.4.357 drivers: radv surfaces: N/A
  Info: Tools: api: clinfo, eglinfo, glxinfo, vulkaninfo de: kscreen-console,kscreen-doctor
    gpu: amd-smi wl: wayland-info x11: xdpyinfo, xprop, xrand
```

# ToDo
- [ ] Explore nvml integration (might be rather simple with `--set integrations.fakeGpuOperator.enabled=true`)
- [ ] Review current changeset (especially around the deploy guards)
- [ ] Explore and document how this setup can be used for more complicated simulation
- [ ] See if we can utilize Kwok (which seems to be part of this implementation to simulate XXX nodes)

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
