### PR TITLE
fix: block stored XSS via WorkspaceKind SVG assets

### DIFF
--- a/workspaces/backend/api/helpers.go
+++ b/workspaces/backend/api/helpers.go
@@ -58,10 +58,28 @@ func (a *App) WriteJSON(w http.ResponseWriter, status int, data any, headers htt
 }
 
 // WriteSVG writes an SVG response with the given status code, content, and headers.
+//
+// SVG is a scriptable document format: when a browser performs a top-level
+// navigation to an "image/svg+xml" response, any <script> inside the SVG
+// executes on this origin. Since the asset bytes come from a user-controlled
+// ConfigMap and are served unsanitized, we set defensive headers so a malicious
+// SVG cannot run as a same-origin document (stored XSS):
+//   - Content-Security-Policy denies everything: no scripts and no external
+//     resource loads (which also closes CSS-based exfiltration). The sandbox
+//     directive additionally forces a unique, script-disabled origin if the SVG
+//     is ever rendered as a document.
+//   - X-Content-Type-Options prevents MIME sniffing to a scriptable type.
+//   - Content-Disposition forces a download instead of inline rendering on
+//     direct navigation. The frontend fetch()es the bytes and renders them via
+//     a data URL, and fetch() ignores Content-Disposition, so in-app display is
+//     unaffected.
 func (a *App) WriteSVG(w http.ResponseWriter, status int, content []byte, headers http.Header) error {
 	maps.Copy(w.Header(), headers)
 
 	w.Header().Set("Content-Type", constants.MediaTypeSVG)
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'none'; sandbox")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="workspacekind-asset.svg"`)
 	w.WriteHeader(status)
 	_, err := w.Write(content)
 	if err != nil {

--- a/workspaces/backend/api/workspacekind_assets_handler_test.go
+++ b/workspaces/backend/api/workspacekind_assets_handler_test.go
@@ -115,6 +115,15 @@ func assertAssetResponse(handler httprouter.Handle, tc *assetTestCase) {
 		Expect(gotContentType).To(Equal(tc.expectedContentType), descUnexpectedHTTPHeaderContentType, tc.expectedContentType, gotContentType)
 	}
 
+	// A served SVG must carry the defensive headers that prevent it from
+	// executing as a same-origin document (stored XSS, see WriteSVG).
+	if gotContentType == constants.MediaTypeSVG {
+		By("verifying the SVG response carries XSS-protective headers")
+		Expect(rs.Header.Get("Content-Security-Policy")).To(Equal("default-src 'none'; script-src 'none'; sandbox"))
+		Expect(rs.Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
+		Expect(rs.Header.Get("Content-Disposition")).To(HavePrefix("attachment"))
+	}
+
 	By("reading the HTTP response body")
 	body, err := io.ReadAll(rs.Body)
 	Expect(err).NotTo(HaveOccurred())

--- a/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx
+++ b/workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx
@@ -67,9 +67,7 @@ export const WorkspaceKindDetailsOverview: React.FunctionComponent<
       </DescriptionListDescription>
       <DescriptionListTerm style={{ alignSelf: 'center' }}>Source Type</DescriptionListTerm>
       <DescriptionListDescription>
-        <a href={workspaceKind.icon.url} target="_blank" rel="noreferrer">
-          {workspaceKind.icon.url}
-        </a>
+        <span title={workspaceKind.icon.url}>{workspaceKind.icon.url}</span>
       </DescriptionListDescription>
     </DescriptionListGroup>
     <Divider />
@@ -94,9 +92,7 @@ export const WorkspaceKindDetailsOverview: React.FunctionComponent<
       </DescriptionListDescription>
       <DescriptionListTerm style={{ alignSelf: 'center' }}>Source Type</DescriptionListTerm>
       <DescriptionListDescription>
-        <a href={workspaceKind.logo.url} target="_blank" rel="noreferrer">
-          {workspaceKind.logo.url}
-        </a>
+        <span title={workspaceKind.logo.url}>{workspaceKind.logo.url}</span>
       </DescriptionListDescription>
     </DescriptionListGroup>
   </DescriptionList>


### PR DESCRIPTION
## Summary

The backend served WorkspaceKind icon/logo SVG assets from a ConfigMap with only a `Content-Type: image/svg+xml` header and no related `Content-Security-Policy`, no `X-Content-Type-Options` or no `Content-Disposition`. The WorkspaceKind details drawer additionally rendered the raw asset URL as a clickable `<a href={...} target="_blank">` link.

Because the asset endpoint is **same-origin** with the dashboard, clicking that link performed a top-level navigation to an `image/svg+xml` document, and any `<script>` embedded in the SVG executed on the dashboard origin **as the victim user**, which results in a stored XSS.

This PR tries to adress this issue at both layers:

- it hardens the backend response headers (the authoritative fix at the source)
- it removes the clickable link that provided the user-interaction vector

## Changes

`workspaces/backend/api/helpers.go` (`WriteSVG`)

Sets three headers on all served SVG assets:

- **`Content-Security-Policy: default-src 'none'; script-src 'none'; sandbox`**: blocks `<script>` execution and external resource loads inside the SVG document, while still allowing it to render as an image.
- **`X-Content-Type-Options: nosniff`**: prevents MIME sniffing to a scriptable type.
- **`Content-Disposition: attachment`**: a direct top-level navigation now downloads the file instead of rendering it as a document (the airtight kill for the click vector).

This does **not** break in-app icon/logo display: the frontend `fetch()`es the bytes and renders them via a data URL, and `fetch()` ignores `Content-Disposition`.

`workspaces/frontend/src/app/pages/WorkspaceKinds/details/WorkspaceKindDetailsOverview.tsx`

Replace both `<a href={...url} target="_blank" rel="noreferrer">` links (icon + logo) with plain `<span title={...url}>` text.

Beyond removing the click prerequisite for the ConfigMap case, this closes a class the backend headers **cannot** cover: the `url` field on a WorkspaceKind asset is returned verbatim and has no scheme validation, so the anchor could render an arbitrary `javascript:` or remote URL that the backend never serves, so `javascript:` in an `href` would execute on the dashboard origin regardless of any response header.

`workspaces/backend/api/workspacekind_assets_handler_test.go`

`assertAssetResponse` now asserts the three protective headers on every
successful SVG response, so both the icon and logo handler test tables verify
them.

## Security impact

- **Class:** Stored Cross-Site Scripting (SVG served as a same-origin document)
- **Preconditions:** attacker needs `workspacekinds` create/update (admin) plus `configmaps` create/update for a labeled ConfigMap; victim must be a workspaces admin and click the link.
- **Effect of fix:** the served SVG can no longer execute script or render as a top-level document, and the clickable link (including the unvalidated-URL path) is removed.

A more nuanced version (given that the preconditions above already grant arbitrary code execution via the used image reference) would only require configmap update access to then use this as part of a privilege escalation strategy to obtain admin credentials.