### PR TITLE
chore: increased OWNERS responsibility for christian-heusel

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -2,5 +2,4 @@ labels:
   - area/ci
 approvers:
   - andyatmiami
-reviewers:
   - christian-heusel

--- a/developing/OWNERS
+++ b/developing/OWNERS
@@ -3,5 +3,4 @@ labels:
   - area/v2
 approvers:
   - andyatmiami
-reviewers:
   - christian-heusel

--- a/workspaces/backend/OWNERS
+++ b/workspaces/backend/OWNERS
@@ -2,3 +2,5 @@ labels:
   - area/backend
 approvers:
   - andyatmiami
+reviewers:
+  - christian-heusel


### PR DESCRIPTION
Christian has continued to demonstrate excellent judgment and dedication as a reviewer - LETS LEVEL HIM UP!

Promoting him to approver on `.github/workflows/` and `developing/`, and welcoming him as a reviewer on `workspaces/backend/` to get him more (formally) involved in the `workspaces/` directories :100:
