### PR TITLE
feat: reject orphan deletes of Workspace resources via webhook

### DIFF
--- a/workspaces/controller/internal/webhook/workspace_webhook.go
+++ b/workspaces/controller/internal/webhook/workspace_webhook.go
@@ -18,22 +18,30 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kubefloworgv1beta1 "github.com/kubeflow/notebooks/workspaces/controller/api/v1beta1"
 )
+
+// orphanDeleteMessage explains why orphan deletion of a Workspace is not permitted.
+const orphanDeleteMessage = "orphan deletion is not permitted for Workspaces, " +
+	"because it would leave the resources owned by the Workspace (StatefulSet, Service, VirtualService) " +
+	"running in the cluster with no parent, use cascading deletion instead"
 
 // WorkspaceValidator validates a Workspace object
 type WorkspaceValidator struct {
@@ -41,7 +49,7 @@ type WorkspaceValidator struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:webhook:path=/validate-kubeflow-org-v1beta1-workspace,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=workspaces,verbs=create;update,versions=v1beta1,name=vworkspace.kb.io,admissionReviewVersions=v1,serviceName=workspaces-webhook-service
+// +kubebuilder:webhook:path=/validate-kubeflow-org-v1beta1-workspace,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=workspaces,verbs=create;update;delete,versions=v1beta1,name=vworkspace.kb.io,admissionReviewVersions=v1,serviceName=workspaces-webhook-service
 
 // SetupWebhookWithManager sets up the webhook with the manager
 func (v *WorkspaceValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -75,6 +83,7 @@ func (v *WorkspaceValidator) ValidateCreate(ctx context.Context, workspace *kube
 	// validate the Workspace
 	// NOTE: we do this after fetching the WorkspaceKind as there will be multiple types in the future,
 	//       and we need to know which one the Workspace is using to validate it correctly.
+	allErrs = append(allErrs, v.validateNoOrphanFinalizer(workspace)...)
 	allErrs = append(allErrs, v.validatePodTemplatePodMetadata(workspace)...)
 	allErrs = append(allErrs, v.validateImageConfig(workspace, workspaceKind)...)
 	allErrs = append(allErrs, v.validatePodConfig(workspace, workspaceKind)...)
@@ -98,6 +107,13 @@ func (v *WorkspaceValidator) ValidateUpdate(ctx context.Context, oldWorkspace, n
 	log.V(1).Info("validating Workspace update")
 
 	var allErrs field.ErrorList
+
+	// don't allow the "orphan" finalizer to be added to an existing Workspace
+	// NOTE: we only reject updates that ADD the finalizer, so a Workspace which somehow already has it
+	//       can still be updated (e.g. to remove the finalizer)
+	if !controllerutil.ContainsFinalizer(oldWorkspace, metav1.FinalizerOrphanDependents) {
+		allErrs = append(allErrs, v.validateNoOrphanFinalizer(newWorkspace)...)
+	}
 
 	// check if workspace kind related fields have changed
 	var workspaceKindChange = false
@@ -163,9 +179,89 @@ func (v *WorkspaceValidator) ValidateUpdate(ctx context.Context, oldWorkspace, n
 // The optional warnings will be added to the response as warning messages.
 // Return an error if the object is invalid.
 func (v *WorkspaceValidator) ValidateDelete(ctx context.Context, workspace *kubefloworgv1beta1.Workspace) (admission.Warnings, error) {
-	// no validation needed for deletion
-	// NOTE: add "delete" to the webhook configuration (+kubebuilder:webhook) if you want to enable deletion validation
-	return nil, nil
+	log := log.FromContext(ctx)
+	log.V(1).Info("validating Workspace delete")
+
+	var allErrs field.ErrorList //nolint:prealloc
+
+	// don't allow the Workspace to be deleted with `propagationPolicy=Orphan`
+	fieldErrs, err := v.validateNoOrphanPropagationPolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+	allErrs = append(allErrs, fieldErrs...)
+
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(
+		schema.GroupKind{Group: kubefloworgv1beta1.GroupVersion.Group, Kind: "Workspace"},
+		workspace.Name,
+		allErrs,
+	)
+}
+
+// validateNoOrphanFinalizer validates that a Workspace does not have the "orphan" finalizer,
+// which would cause its owned resources to be left running in the cluster once it is deleted.
+func (v *WorkspaceValidator) validateNoOrphanFinalizer(workspace *kubefloworgv1beta1.Workspace) []*field.Error {
+	var errs []*field.Error
+
+	finalizersPath := field.NewPath("metadata", "finalizers")
+
+	if controllerutil.ContainsFinalizer(workspace, metav1.FinalizerOrphanDependents) {
+		errs = append(errs, field.Invalid(
+			finalizersPath,
+			metav1.FinalizerOrphanDependents,
+			orphanDeleteMessage,
+		))
+	}
+
+	return errs
+}
+
+// validateNoOrphanPropagationPolicy validates that the in-flight delete request did not request orphan
+// deletion, either with `propagationPolicy=Orphan` or the deprecated `orphanDependents=true` option.
+func (v *WorkspaceValidator) validateNoOrphanPropagationPolicy(ctx context.Context) ([]*field.Error, error) {
+	var errs []*field.Error
+
+	propagationPolicyPath := field.NewPath("propagationPolicy")
+	orphanDependentsPath := field.NewPath("orphanDependents")
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		// the admission request is always present for real delete requests, so treat its absence as an error
+		return nil, fmt.Errorf("unable to read admission request to determine deletion propagation policy: %w", err)
+	}
+
+	// if there are no delete options, the default (non-orphan) propagation policy is used
+	if len(req.Options.Raw) == 0 {
+		return nil, nil
+	}
+
+	deleteOptions := &metav1.DeleteOptions{}
+	if err := json.Unmarshal(req.Options.Raw, deleteOptions); err != nil {
+		return nil, fmt.Errorf("unable to decode delete options: %w", err)
+	}
+
+	if deleteOptions.PropagationPolicy != nil && *deleteOptions.PropagationPolicy == metav1.DeletePropagationOrphan {
+		errs = append(errs, field.Invalid(
+			propagationPolicyPath,
+			*deleteOptions.PropagationPolicy,
+			orphanDeleteMessage,
+		))
+	}
+
+	// `orphanDependents` is deprecated, but the API server still honors it
+	if deleteOptions.OrphanDependents != nil && *deleteOptions.OrphanDependents { //nolint:staticcheck
+		errs = append(errs, field.Invalid(
+			orphanDependentsPath,
+			*deleteOptions.OrphanDependents, //nolint:staticcheck
+			orphanDeleteMessage,
+		))
+	}
+
+	return errs, nil
 }
 
 // validateWorkspaceKind fetches the WorkspaceKind for a Workspace and returns an error if it does not exist

--- a/workspaces/controller/internal/webhook/workspace_webhook_test.go
+++ b/workspaces/controller/internal/webhook/workspace_webhook_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -297,6 +299,153 @@ var _ = Describe("Workspace Webhook", func() {
 			newWorkspace = workspace.DeepCopy()
 			newWorkspace.Spec.PodTemplate.Options.PodConfig = validPodConfig
 			Expect(k8sClient.Patch(ctx, newWorkspace, patch)).To(Succeed())
+		})
+	})
+
+	Context("When orphan-deleting a Workspace", Ordered, func() {
+		var (
+			workspaceName     string
+			workspaceKindName string
+			workspaceKey      types.NamespacedName
+		)
+
+		BeforeAll(func() {
+			uniqueName := "ws-webhook-orphan-test"
+			workspaceName = fmt.Sprintf("workspace-%s", uniqueName)
+			workspaceKindName = fmt.Sprintf("workspacekind-%s", uniqueName)
+			workspaceKey = types.NamespacedName{Name: workspaceName, Namespace: namespaceName}
+
+			By("creating the WorkspaceKind")
+			workspaceKind := NewExampleWorkspaceKind(workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspaceKind)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: workspaceKindName}, &kubefloworgv1beta1.WorkspaceKind{})
+			}, time.Second*5, time.Millisecond*100).Should(Succeed())
+
+			By("creating the Workspace")
+			workspace := NewExampleWorkspace(workspaceName, namespaceName, workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			By("deleting the Workspace")
+			workspace := &kubefloworgv1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workspaceName,
+					Namespace: namespaceName,
+				},
+			}
+			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())
+
+			By("deleting the WorkspaceKind")
+			workspaceKind := &kubefloworgv1beta1.WorkspaceKind{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workspaceKindName,
+				},
+			}
+			Expect(k8sClient.Delete(ctx, workspaceKind)).To(Succeed())
+		})
+
+		It("should reject creating a Workspace with the `orphan` finalizer", func() {
+			By("creating the Workspace")
+			workspace := NewExampleWorkspace(fmt.Sprintf("%s-create", workspaceName), namespaceName, workspaceKindName)
+			workspace.Finalizers = []string{metav1.FinalizerOrphanDependents}
+			err := k8sClient.Create(ctx, workspace)
+			Expect(err).NotTo(Succeed())
+			Expect(err.Error()).To(ContainSubstring("orphan deletion is not permitted for Workspaces"))
+		})
+
+		It("should reject an update which adds the `orphan` finalizer", func() {
+			By("getting the Workspace")
+			workspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey, workspace)).To(Succeed())
+			patch := client.MergeFrom(workspace.DeepCopy())
+
+			By("failing to add the `orphan` finalizer")
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Finalizers = append(newWorkspace.Finalizers, metav1.FinalizerOrphanDependents)
+			err := k8sClient.Patch(ctx, newWorkspace, patch)
+			Expect(err).NotTo(Succeed())
+			Expect(err.Error()).To(ContainSubstring("orphan deletion is not permitted for Workspaces"))
+		})
+
+		It("should allow an update which adds a non-`orphan` finalizer", func() {
+			By("getting the Workspace")
+			workspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey, workspace)).To(Succeed())
+			patch := client.MergeFrom(workspace.DeepCopy())
+
+			By("adding the finalizer")
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Finalizers = append(newWorkspace.Finalizers, "notebooks.kubeflow.org/test-finalizer")
+			Expect(k8sClient.Patch(ctx, newWorkspace, patch)).To(Succeed())
+
+			By("removing the finalizer")
+			Expect(k8sClient.Get(ctx, workspaceKey, workspace)).To(Succeed())
+			patch = client.MergeFrom(workspace.DeepCopy())
+			newWorkspace = workspace.DeepCopy()
+			newWorkspace.Finalizers = nil
+			Expect(k8sClient.Patch(ctx, newWorkspace, patch)).To(Succeed())
+		})
+
+		It("should reject a delete with `propagationPolicy=Orphan`", func() {
+			By("getting the Workspace")
+			workspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey, workspace)).To(Succeed())
+
+			By("failing to delete the Workspace")
+			err := k8sClient.Delete(ctx, workspace, client.PropagationPolicy(metav1.DeletePropagationOrphan))
+			Expect(err).NotTo(Succeed())
+			Expect(err.Error()).To(ContainSubstring("orphan deletion is not permitted for Workspaces"))
+
+			By("verifying the Workspace was not deleted")
+			Expect(k8sClient.Get(ctx, workspaceKey, workspace)).To(Succeed())
+			Expect(workspace.DeletionTimestamp).To(BeNil())
+		})
+
+		It("should reject a delete with the deprecated `orphanDependents=true`", func() {
+			By("creating the dynamic client")
+			// NOTE: the typed client has no option for the deprecated `orphanDependents` field
+			dynamicClient, err := dynamic.NewForConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			workspaceGVR := schema.GroupVersionResource{
+				Group:    kubefloworgv1beta1.GroupVersion.Group,
+				Version:  kubefloworgv1beta1.GroupVersion.Version,
+				Resource: "workspaces",
+			}
+
+			By("failing to delete the Workspace")
+			err = dynamicClient.Resource(workspaceGVR).Namespace(namespaceName).Delete(ctx, workspaceName, metav1.DeleteOptions{
+				OrphanDependents: new(true),
+			})
+			Expect(err).NotTo(Succeed())
+			Expect(err.Error()).To(ContainSubstring("orphan deletion is not permitted for Workspaces"))
+
+			By("verifying the Workspace was not deleted")
+			workspace := &kubefloworgv1beta1.Workspace{}
+			Expect(k8sClient.Get(ctx, workspaceKey, workspace)).To(Succeed())
+			Expect(workspace.DeletionTimestamp).To(BeNil())
+		})
+
+		It("should allow a delete with `propagationPolicy=Background`", func() {
+			By("creating the Workspace")
+			cascadeName := fmt.Sprintf("%s-cascade", workspaceName)
+			workspace := NewExampleWorkspace(cascadeName, namespaceName, workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+
+			By("deleting the Workspace")
+			Expect(k8sClient.Delete(ctx, workspace, client.PropagationPolicy(metav1.DeletePropagationBackground))).To(Succeed())
+		})
+
+		It("should allow a delete with no propagationPolicy", func() {
+			By("creating the Workspace")
+			defaultName := fmt.Sprintf("%s-default", workspaceName)
+			workspace := NewExampleWorkspace(defaultName, namespaceName, workspaceKindName)
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+
+			By("deleting the Workspace")
+			Expect(k8sClient.Delete(ctx, workspace)).To(Succeed())
 		})
 	})
 })

--- a/workspaces/controller/manifests/kustomize/base/webhook/manifests.yaml
+++ b/workspaces/controller/manifests/kustomize/base/webhook/manifests.yaml
@@ -21,6 +21,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - workspaces
   sideEffects: None


### PR DESCRIPTION
Closes #1197
Part of #1196

## Motivation

A `Workspace` owns a `StatefulSet`, a `Service`, and (when Istio is enabled) a
`VirtualService`. These are cleaned up by Kubernetes garbage collection via
`metadata.ownerReferences` when the Workspace is deleted.

An **orphan delete** deliberately skips that cascade, removing the Workspace but
leaving its owned resources running with no parent. This wastes cluster
resources indefinitely and causes collisions if a new Workspace is later created
with the same name, since the controller expects to own resources at those
names. Nothing currently prevents this.

## Changes

Kubernetes exposes orphan deletion through three request shapes. All three are
now rejected:

| Mechanism | Admission op | Validator |
|---|---|---|
| `metadata.finalizers` contains `orphan` | CREATE / UPDATE | `validateNoOrphanFinalizer` |
| `propagationPolicy: Orphan` | DELETE | `validateNoOrphanPropagationPolicy` |
| `orphanDependents: true` (deprecated) | DELETE | `validateNoOrphanPropagationPolicy` |

- **`workspace_webhook.go`** — added the two validators above, following the
  existing `[]*field.Error` convention of the other Workspace validators.
  Rejections are returned via `apierrors.NewInvalid`, consistent with
  `ValidateCreate`/`ValidateUpdate`.
- **`+kubebuilder:webhook` marker** — added `delete` to the verbs, so
  `ValidateDelete` is actually invoked (see the note below on why this is
  required).
- **`manifests.yaml`** — regenerated via `make manifests`; adds `DELETE` to the
  `vworkspace.kb.io` rule.

On UPDATE, the finalizer check only fires when the finalizer is *newly added*,
so a Workspace that somehow already carries it can still be patched to remove
it. Existing legitimate finalizers, including the WorkspaceKind protection
finalizer, are unaffected.

## DELETE coverage

The issue suggested rejecting updates that add an `orphan` finalizer. On its own
this is **not sufficient**.

When a client issues `DELETE ?propagationPolicy=Orphan`, it never writes to
`metadata.finalizers` — the API server's garbage collector adds the `orphan`
finalizer *itself*, internally, as part of processing the delete. No UPDATE
admission request carrying that finalizer is ever generated, so a webhook that
only inspects `metadata.finalizers` on CREATE/UPDATE sees nothing to reject and
the orphan delete succeeds.

This was confirmed against a real API server in `envtest`: at DELETE admission
time the object's finalizer list is empty (`[]string(nil)`), and the `orphan`
finalizer only appears afterwards, written by the API server.

### Why the deprecated `orphanDependents` field is also needed

`orphanDependents` is the pre-1.7 way of requesting orphan deletion. It is
deprecated in favour of `propagationPolicy`, but the API server **still honors
it**, and it is **not** normalized into `propagationPolicy` — it arrives at the
webhook as its own distinct field.

Modern `kubectl` does not expose this field, so it takes a raw API call to
reach — but any client using the dynamic client, raw REST, or an older client
library can set it.

### Commands that trigger an orphan delete

All of the following are now rejected:

```bash
# propagationPolicy=Orphan (single object)
kubectl delete workspace <name> -n <namespace> --cascade=orphan

# propagationPolicy=Orphan (deletecollection)
kubectl delete workspaces --all -n <namespace> --cascade=orphan

# deprecated orphanDependents=true (needs the raw API)
kubectl proxy --port=8001 &
curl -X DELETE \
  -H 'Content-Type: application/json' \
  -d '{"apiVersion":"meta.k8s.io/v1","kind":"DeleteOptions","orphanDependents":true}' \
  'http://127.0.0.1:8001/apis/kubeflow.org/v1beta1/namespaces/<namespace>/workspaces/<name>'
```

`deletecollection` was specifically checked because it was not obvious whether
admission fires per object there; it does, so it is covered by the same
validator.

Normal cascading deletes are unaffected:

```bash
kubectl delete workspace <name> -n <namespace>                        # allowed
kubectl delete workspace <name> -n <namespace> --cascade=background   # allowed
kubectl delete workspace <name> -n <namespace> --cascade=foreground   # allowed
```

## Testing

### Unit / envtest

Verified in `envtest` against a real API server:

| Scenario | Expected |
|---|---|
| CREATE with `orphan` finalizer | rejected |
| UPDATE adding `orphan` finalizer | rejected |
| UPDATE adding a non-`orphan` finalizer | allowed |
| DELETE with `propagationPolicy=Orphan` | rejected, object still present |
| DELETE with deprecated `orphanDependents=true` | rejected, object still present |
| DELETE with `propagationPolicy=Background` | allowed |
| DELETE with no propagationPolicy | allowed |

```
Ran 7 of 111 Specs -- 7 Passed | 0 Failed
```

Full controller unit suite passes; `golangci-lint` reports 0 issues.

### Manual verification on GKE

Built and deployed the controller to a GKE cluster and exercised every path by
hand. All 11 checks behaved as expected.

Webhook configuration after deploy:

```console
$ kubectl get validatingwebhookconfiguration workspaces-validating-webhook-configuration \
    -o jsonpath='{range .webhooks[?(@.name=="vworkspace.kb.io")]}{.rules[*].operations}{end}'
["CREATE","UPDATE","DELETE"]
```

**1. Create a valid Workspace, and confirm the owned resources exist**

```console
$ kubectl apply -f workspace.yaml
workspace.kubeflow.org/orphan-demo created

$ kubectl get statefulset,service -n orphan-test
NAME                                    READY   AGE
statefulset.apps/ws-orphan-demo-dmbrw   0/1     15s

NAME                           TYPE        CLUSTER-IP      PORT(S)    AGE
service/ws-orphan-demo-8qxg2   ClusterIP   34.118.226.93   8888/TCP   15s

$ kubectl get statefulset -n orphan-test -o jsonpath='{.items[0].metadata.ownerReferences}'
[{"apiVersion":"kubeflow.org/v1beta1","blockOwnerDeletion":true,"controller":true,
  "kind":"Workspace","name":"orphan-demo","uid":"9b530823-..."}]
```

These are the resources an orphan delete would strand.

**2. CREATE with the `orphan` finalizer — rejected**

```console
$ kubectl apply -f workspace-with-orphan-finalizer.yaml
The Workspace "orphan-finalizer-create" is invalid: metadata.finalizers: Invalid
value: "orphan": orphan deletion is not permitted for Workspaces, because it would
leave the resources owned by the Workspace (StatefulSet, Service, VirtualService)
running in the cluster with no parent, use cascading deletion instead
```

**3. UPDATE adding the `orphan` finalizer — rejected**

```console
$ kubectl patch workspace orphan-demo -n orphan-test --type=merge \
    -p '{"metadata":{"finalizers":["orphan"]}}'
The Workspace "orphan-demo" is invalid: metadata.finalizers: Invalid value:
"orphan": orphan deletion is not permitted for Workspaces, ...
```

**4-5. UPDATE with a legitimate finalizer, and a normal spec change — allowed**

```console
$ kubectl patch workspace orphan-demo -n orphan-test --type=merge \
    -p '{"metadata":{"finalizers":["notebooks.kubeflow.org/test-finalizer"]}}'
workspace.kubeflow.org/orphan-demo patched

$ kubectl patch workspace orphan-demo -n orphan-test --type=merge -p '{"spec":{"paused":true}}'
workspace.kubeflow.org/orphan-demo patched
```

**6. DELETE with `--cascade=orphan` — rejected, nothing removed**

```console
$ kubectl delete workspace orphan-demo -n orphan-test --cascade=orphan
The Workspace "orphan-demo" is invalid: propagationPolicy: Invalid value: "Orphan":
orphan deletion is not permitted for Workspaces, ...

$ kubectl get workspace orphan-demo -n orphan-test \
    -o jsonpath='{.metadata.name} deletionTimestamp={.metadata.deletionTimestamp}'
orphan-demo deletionTimestamp=

$ kubectl get statefulset,service -n orphan-test --no-headers
statefulset.apps/ws-orphan-demo-dmbrw   0/1   54s
service/ws-orphan-demo-8qxg2   ClusterIP   34.118.226.93   8888/TCP   54s
```

No `deletionTimestamp`, and both owned resources survived.

**7. DELETE with the deprecated `orphanDependents=true` — rejected**

```console
$ kubectl proxy --port=8001 &
$ curl -s -X DELETE -H 'Content-Type: application/json' \
    -d '{"apiVersion":"meta.k8s.io/v1","kind":"DeleteOptions","orphanDependents":true}' \
    'http://127.0.0.1:8001/apis/kubeflow.org/v1beta1/namespaces/orphan-test/workspaces/orphan-demo'
{
  "kind": "Status",
  "status": "Failure",
  "message": "admission webhook \"vworkspace.kb.io\" denied the request:
    Workspace.kubeflow.org \"orphan-demo\" is invalid: orphanDependents: Invalid
    value: true: orphan deletion is not permitted for Workspaces, ...",
  "reason": "Invalid"
}
```

**8. `deletecollection` with `--cascade=orphan` — rejected**

```console
$ kubectl delete workspaces --all -n orphan-test --cascade=orphan
The Workspace "orphan-demo" is invalid: propagationPolicy: Invalid value: "Orphan":
orphan deletion is not permitted for Workspaces, ...
```

**9. DELETE with `--cascade=background` — allowed, children garbage-collected**

```console
$ kubectl delete workspace orphan-demo -n orphan-test --cascade=background
workspace.kubeflow.org "orphan-demo" deleted from orphan-test namespace

$ kubectl get statefulset,service -n orphan-test --no-headers
No resources found in orphan-test namespace.
```

This is the key non-regression check: normal cascading deletion still works and
the owned resources are cleaned up.

**10-11. DELETE with no flag, and with `--cascade=foreground` — allowed**

```console
$ kubectl delete workspace orphan-demo2 -n orphan-test
workspace.kubeflow.org "orphan-demo2" deleted from orphan-test namespace

$ kubectl delete workspace orphan-demo3 -n orphan-test --cascade=foreground
workspace.kubeflow.org "orphan-demo3" deleted from orphan-test namespace
```

> Note: after a rejected delete the `kubectl get workspace` STATUS column may read
> `Terminating`. That column is `.status.state` (the workspace **pod's** state),
> not Kubernetes deletion — `deletionTimestamp` and `finalizers` were both empty
> in every rejected case above.

## Limitations

- **Webhook availability now gates Workspace deletion.** The webhook uses
  `failurePolicy: Fail`, so extending it to DELETE means Workspaces cannot be
  deleted while the webhook is unreachable. This matches the existing
  `vworkspacekind.kb.io` behavior, which already covers DELETE under the same
  policy — but it is a **new** failure mode for Workspaces specifically.
  Operators recovering a broken cluster may need to remove the webhook
  configuration first. **Flagging this for explicit reviewer sign-off.**
- **Cluster-admin bypass remains possible.** Anyone able to edit or remove the
  `ValidatingWebhookConfiguration`, or write directly to etcd, can bypass this.
  Admission control is a guardrail against accidental misuse, not a security
  boundary.
- **Pre-existing orphans are not remediated.** This change is preventative only.
  Adoption of already-orphaned resources is the scope of #1198.
- **Deletion ordering of owned resources is still non-deterministic**, as the
  Workspace has no finalizer of its own. Raised separately on #1196; not
  addressed here.
