### PR TITLE
fix: compare waiting container reason to PodInitializing

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -133,7 +133,7 @@ def get_status_from_container_state(notebook):
 
     # If the Notebook is initializing, the status will be waiting
     waiting_state = container_state["waiting"]
-    if ["reason"] == 'PodInitializing':
+    if waiting_state.get("reason") == 'PodInitializing':
         status_phase = status.STATUS_PHASE.WAITING
         status_message = waiting_state.get("reason", "Undetermined reason.")
         return status_phase, status_message

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -34,7 +34,7 @@ class TestStatusFromContainerState(unittest.TestCase):
             (None, None)
         )
 
-    def test_no_message_container_state(self):
+    def test_pod_initializing_container_state(self):
         container_state = {
             "status": {
                 "containerState": {
@@ -47,6 +47,39 @@ class TestStatusFromContainerState(unittest.TestCase):
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
+            ("waiting", "PodInitializing")
+        )
+
+    def test_no_message_container_state(self):
+        container_state = {
+            "status": {
+                "containerState": {
+                    "waiting": {
+                        "reason": "ImagePullBackOff",
+                    }
+                }
+            }
+        }
+
+        self.assertEqual(
+            status.get_status_from_container_state(container_state),
             ("warning",
-             "PodInitializing: No available message for container state.")
+             "ImagePullBackOff: No available message for container state.")
+        )
+
+    def test_waiting_container_state_with_message(self):
+        container_state = {
+            "status": {
+                "containerState": {
+                    "waiting": {
+                        "reason": "ImagePullBackOff",
+                        "message": "Back-off pulling image",
+                    }
+                }
+            }
+        }
+
+        self.assertEqual(
+            status.get_status_from_container_state(container_state),
+            ("warning", "ImagePullBackOff: Back-off pulling image")
         )


### PR DESCRIPTION
`get_status_from_container_state` compares a list literal to a string:

```python
waiting_state = container_state["waiting"]
if ["reason"] == 'PodInitializing':
```

`["reason"]` has no receiver, so Python parses it as a one-element list literal rather than a subscript. The comparison is therefore always `False`, the `WAITING` branch is dead code, and every waiting container falls through to `WARNING`. A notebook that is just starting up shows a warning reading `PodInitializing: No available message for container state.` instead of a waiting spinner reading `PodInitializing`.

Introduced in kubeflow/kubeflow#7585, which extracted `container_state["waiting"]` into `waiting_state`. The other lines in that hunk picked up the new local; this one lost its old receiver without gaining it. flake8 sees valid syntax, so linting never flagged it.

Present on `notebooks-v1`, `v1.11-branch` and the `v1.11.0` tag. The v2 backend has no equivalent code path.

## Fix

Compare `waiting_state.get("reason")`. `.get` rather than `["reason"]` because `status.containerState` is a `corev1.ContainerState` (`notebook-controller/api/v1beta1/notebook_types.go:43`) and `ContainerStateWaiting.Reason` is `+optional` with `omitempty`, so the key can be absent — the pre-#7585 subscript could raise `KeyError` on a valid Notebook.

## Tests

`test_no_message_container_state` asserted the buggy output, so it was holding the defect in place. It now uses `ImagePullBackOff`, which keeps its original missing-message coverage.

Added `test_pod_initializing_container_state`, which fails against the unfixed source, and `test_waiting_container_state_with_message` for the warning path with both fields set, which had no coverage.

`make unittest` passes (12 tests) and flake8 is clean on both files.

## Not fixed here

kubelet uses `ContainerCreating` for this same placeholder state when a pod has no init containers, and `PodInitializing` when it has them — see `defaultWaitingState` in `pkg/kubelet/kubelet_pods.go`. Notebooks without init containers will still show a warning while starting. That predates #7585, which had the same single-reason check, so I have left it out to keep this change focused. Glad to widen the predicate to both reasons here if you would rather have it in one PR.

---

Discovered by Claude while consuming this status output; patch and analysis also by Claude Code.
