### PR TITLE
chore: increased OWNERS responsibility for thaorell

### DIFF
--- a/workspaces/frontend/OWNERS
+++ b/workspaces/frontend/OWNERS
@@ -3,6 +3,6 @@ labels:
 approvers:
   - ederign
   - paulovmr
-reviewers:
   - thaorell
+reviewers:
   - caponetto


### PR DESCRIPTION
Charles has continued to demonstrate excellent judgment and dedication as a reviewer and been the main driving force advancing frontend code- LETS LEVEL HIM UP!

Promoting him to approver on `workspaces/frontend/` :100:
